### PR TITLE
chore: add src20 deploy img url to balance output

### DIFF
--- a/lib/database/src20Class.ts
+++ b/lib/database/src20Class.ts
@@ -7,6 +7,7 @@ import {
 } from "constants";
 import { handleSqlQueryWithCache } from "utils/cache.ts";
 import { BigFloat } from "bigfloat/mod.ts";
+import { conf } from "../../lib/utils/config.ts";
 
 // NOTE: To compare tick use this ones below:
 //  tick COLLATE utf8mb4_0900_as_ci = '${tick}'
@@ -68,7 +69,20 @@ export class Src20Class {
       client,
       `
         SELECT 
-            src20.*,
+            src20.tx_hash,
+            src20.tx_index,
+            src20.block_index,
+            src20.p,
+            src20.op,
+            src20.tick,
+            src20.creator,
+            src20.amt,
+            src20.deci,
+            src20.lim,
+            src20.max,
+            src20.destination,
+            src20.block_time,
+            src20.status,
             creator_info.creator as creator_name,
             destination_info.creator as destination_name
         FROM 
@@ -97,7 +111,20 @@ export class Src20Class {
       client,
       `
         SELECT 
-            src20.*,
+            src20.tx_hash,
+            src20.tx_index,
+            src20.block_index,
+            src20.p,
+            src20.op,
+            src20.tick,
+            src20.creator,
+            src20.amt,
+            src20.deci,
+            src20.lim,
+            src20.max,
+            src20.destination,
+            src20.block_time,
+            src20.status,
             creator_info.creator as creator_name,
             destination_info.creator as destination_name
         FROM
@@ -128,7 +155,20 @@ export class Src20Class {
       client,
       `
         SELECT 
-            src20.*,
+            src20.tx_hash,
+            src20.tx_index,
+            src20.block_index,
+            src20.p,
+            src20.op,
+            src20.tick,
+            src20.creator,
+            src20.amt,
+            src20.deci,
+            src20.lim,
+            src20.max,
+            src20.destination,
+            src20.block_time,
+            src20.status,
             creator_info.creator as creator_name,
             destination_info.creator as destination_name
         FROM
@@ -167,7 +207,7 @@ export class Src20Class {
   static async get_total_valid_src20_tx_by_tick_with_op_with_client(
     client: Client,
     tick: string,
-    op = "DEPLOY",
+    op: string,
   ) {
     return await handleSqlQueryWithCache(
       client,
@@ -185,8 +225,8 @@ export class Src20Class {
   static async get_valid_src20_tx_by_tick_with_op_with_client(
     client: Client,
     tick: string,
-    op = "DEPLOY",
-    limit = SMALL_LIMIT,
+    op: string,
+    limit = BIG_LIMIT,
     page = 0,
     order = "ASC",
   ) {
@@ -195,7 +235,20 @@ export class Src20Class {
       client,
       `
         SELECT
-            src20.*,
+            src20.tx_hash,
+            src20.tx_index,
+            src20.block_index,
+            src20.p,
+            src20.op,
+            src20.tick,
+            src20.creator,
+            src20.amt,
+            src20.deci,
+            src20.lim,
+            src20.max,
+            src20.destination,
+            src20.block_time,
+            src20.status,
             creator_info.creator as creator_name,
             destination_info.creator as destination_name
         FROM 
@@ -227,7 +280,20 @@ export class Src20Class {
       client,
       `
         SELECT 
-            src20.*,
+            src20.tx_hash,
+            src20.tx_index,
+            src20.block_index,
+            src20.p,
+            src20.op,
+            src20.tick,
+            src20.creator,
+            src20.amt,
+            src20.deci,
+            src20.lim,
+            src20.max,
+            src20.destination,
+            src20.block_time,
+            src20.status,
             creator_info.creator as creator_name,
             destination_info.creator as destination_name
         FROM 
@@ -248,7 +314,7 @@ export class Src20Class {
 
   static async get_total_valid_src20_tx_by_op_with_client(
     client: Client,
-    op = "DEPLOY",
+    op: string,
     limit = SMALL_LIMIT,
     page = 0,
   ) {
@@ -269,7 +335,7 @@ export class Src20Class {
 
   static async get_valid_src20_tx_by_op_with_client(
     client: Client,
-    op = "DEPLOY",
+    op: string,
     limit = SMALL_LIMIT,
     page = 0,
   ) {
@@ -279,7 +345,20 @@ export class Src20Class {
       `
         SELECT 
             (@row_number:=@row_number + 1) AS row_num,
-            src20.*,
+            src20.tx_hash,
+            src20.tx_index,
+            src20.block_index,
+            src20.p,
+            src20.op,
+            src20.tick,
+            src20.creator,
+            src20.amt,
+            src20.deci,
+            src20.lim,
+            src20.max,
+            src20.destination,
+            src20.block_time,
+            src20.status,
             creator_info.creator as creator_name,
             destination_info.creator as destination_name
         FROM 
@@ -303,25 +382,39 @@ export class Src20Class {
 
   static async get_valid_src20_deploy_by_tick_with_client(
     client: Client,
-    tick: string,
+    ticks: string[],
   ) {
+    const tickPlaceholders = ticks.map(() => "?").join(",");
     return await handleSqlQueryWithCache(
       client,
       `
-        SELECT 
-            src20.*,
-            creator_info.creator as creator_name,
-            destination_info.creator as destination_name
-        FROM 
-            ${SRC20_TABLE} src20
-        LEFT JOIN 
-            creator creator_info ON src20.creator = creator_info.address
-        LEFT JOIN 
-            creator destination_info ON src20.destination = destination_info.address
-        WHERE src20.op = 'DEPLOY'
-        AND src20.tick COLLATE utf8mb4_0900_as_ci = '${tick}'
-        `,
-      [tick],
+            SELECT 
+                src20.tx_hash,
+                src20.tx_index,
+                src20.block_index,
+                src20.p,
+                src20.op,
+                src20.tick,
+                src20.creator,
+                src20.amt,
+                src20.deci,
+                src20.lim,
+                src20.max,
+                src20.destination,
+                src20.block_time,
+                src20.status,
+                creator_info.creator as creator_name,
+                destination_info.creator as destination_name
+            FROM 
+                ${SRC20_TABLE} src20
+            LEFT JOIN 
+                creator creator_info ON src20.creator = creator_info.address
+            LEFT JOIN 
+                creator destination_info ON src20.destination = destination_info.address
+            WHERE src20.op = 'DEPLOY'
+            AND src20.tick COLLATE utf8mb4_0900_as_ci IN (${tickPlaceholders})
+            `,
+      ticks,
       1000 * 60 * 2,
     );
   }
@@ -334,7 +427,20 @@ export class Src20Class {
       client,
       `
         SELECT
-            src20.*,
+            src20.tx_hash,
+            src20.tx_index,
+            src20.block_index,
+            src20.p,
+            src20.op,
+            src20.tick,
+            src20.creator,
+            src20.amt,
+            src20.deci,
+            src20.lim,
+            src20.max,
+            src20.destination,
+            src20.block_time,
+            src20.status,
             creator_info.creator as creator_name,
             destination_info.creator as destination_name
         FROM
@@ -377,7 +483,20 @@ export class Src20Class {
       client,
       `
         SELECT 
-            src20.*,
+            src20.tx_hash,
+            src20.tx_index,
+            src20.block_index,
+            src20.p,
+            src20.op,
+            src20.tick,
+            src20.creator,
+            src20.amt,
+            src20.deci,
+            src20.lim,
+            src20.max,
+            src20.destination,
+            src20.block_time,
+            src20.status,
             creator_info.creator as creator_name,
             destination_info.creator as destination_name
         FROM 
@@ -427,7 +546,20 @@ export class Src20Class {
       client,
       `
         SELECT 
-            src20.*,
+            src20.tx_hash,
+            src20.tx_index,
+            src20.block_index,
+            src20.p,
+            src20.op,
+            src20.tick,
+            src20.creator,
+            src20.amt,
+            src20.deci,
+            src20.lim,
+            src20.max,
+            src20.destination,
+            src20.block_time,
+            src20.status,
             creator_info.creator as creator_name,
             destination_info.creator as destination_name
         FROM 
@@ -455,17 +587,36 @@ export class Src20Class {
     page = 0,
   ) {
     const offset = limit && page ? Number(limit) * (Number(page) - 1) : 0;
-    return await handleSqlQueryWithCache(
+    const results = await handleSqlQueryWithCache(
       client,
       `
-        SELECT id,address,p,tick,amt,block_time,last_update
-        FROM ${SRC20_BALANCE_TABLE}
-        WHERE address = '${address}' AND amt > 0
-        ${limit ? `LIMIT ${limit} OFFSET ${offset}` : ""};
+            SELECT address,p,tick,amt,block_time,last_update
+            FROM ${SRC20_BALANCE_TABLE}
+            WHERE address = '${address}' AND amt > 0
+            ${limit ? `LIMIT ${limit} OFFSET ${offset}` : ""};
         `,
       [address, limit, offset],
       1000 * 60 * 2,
     );
+
+    const ticks = results.rows ? results.rows.map((result) => result.tick) : [];
+    console.log(ticks);
+    const tx_hashes_response = await Src20Class
+      .get_valid_src20_deploy_by_tick_with_client(client, ticks);
+    const tx_hashes = tx_hashes_response.rows.map((row) => row.tx_hash);
+    console.log(tx_hashes);
+    // Pair each result with its corresponding tx_hash
+    const resultsAndHashes = results.rows.map((result, index) => ({
+      result,
+      tx_hash: tx_hashes[index],
+    }));
+
+    const resultsWithStampUrl = resultsAndHashes.map(({ result, tx_hash }) => {
+      const stampUrl = `${conf.IMAGES_SRC_PATH}/${tx_hash}.svg`;
+      return { ...result, stampUrl };
+    });
+    console.log(resultsWithStampUrl);
+    return { rows: resultsWithStampUrl };
   }
 
   static async get_src20_balance_by_address_and_tick_with_client(

--- a/routes/api/v2/src20/balance/snapshot/[tick].tsx
+++ b/routes/api/v2/src20/balance/snapshot/[tick].tsx
@@ -59,6 +59,7 @@ export const handler = async (
   const params = url.searchParams;
   const limit = Number(params.get("limit")) || BIG_LIMIT;
   const page = Number(params.get("page")) || 1;
+  const amt = Number(params.get("amt"));
   try {
     const client = await getClient();
     if (!client) {

--- a/routes/api/v2/src20/tick/index.ts
+++ b/routes/api/v2/src20/tick/index.ts
@@ -29,6 +29,11 @@ import {
  *           minimum: 1
  *           default: 1
  *         description: The page number of transactions to retrieve
+ *       - in: query
+ *         name: op
+ *         schema:
+ *           type: string
+ *           default: DEPLOY
  *     responses:
  *       '200':
  *         description: Successful response with paginated src20 transactions
@@ -52,16 +57,17 @@ export const handler = async (
     const url = new URL(req.url);
     const limit = Number(url.searchParams.get("limit")) || 1000;
     const page = Number(url.searchParams.get("page")) || 1;
+    const op = url.searchParams.get("op") || "DEPLOY";
     const client = await getClient();
     const data = await Src20Class.get_valid_src20_tx_by_op_with_client(
       client,
-      "DEPLOY",
+      op,
       limit,
       page,
     );
     const total = await Src20Class.get_total_valid_src20_tx_by_op_with_client(
       client,
-      "DEPLOY",
+      op,
     );
     const last_block = await CommonClass.get_last_block_with_client(client);
 

--- a/schema.yml
+++ b/schema.yml
@@ -8,11 +8,10 @@ externalDocs:
   url: 'http://stampchain.io'
 servers:
   - url: 'https://stampchain.io'
+    description:  Production server (uses live data)
+  - url: "https://bitcoinstamps.xyz"
     description: Production server (uses live data)
   - url: 'http://localhost:8000'
-    description: Development server (local)
-  - url: 'https://btcstamps.deno.dev/'
-    description: Staging server (uses live data)
 paths:
 
 
@@ -67,7 +66,7 @@ paths:
 
   /api/v2/block/block_count/{number}:
     get:
-      summary: Get last blocks
+      summary: Get last x blocks
       parameters:
         - in: path
           name: number
@@ -123,7 +122,7 @@ paths:
           name: limit
           schema:
             type: integer
-          description: 'The maximum number of stamps to retrieve (default: 1000)'
+          description: 'The maximum number of stamps to retrieve (default: 50)'
         - in: query
           name: page
           schema:
@@ -152,7 +151,7 @@ paths:
           required: true
           schema:
             type: string
-          description: The ID or identifier of the stamp
+          description: Stamp number, cpid, or stamp_hash
       responses:
         '200':
           description: Successful response
@@ -202,17 +201,17 @@ paths:
           required: true
           schema:
             type: string
-          description: The ident of the stamp
+          description: The ident of the stamp (SRC-721, STAMP)
         - in: query
           name: limit
           schema:
             type: integer
-          description: 'The maximum number of stamps to retrieve (default: 1000)'
+          description: 'The maximum number of stamps to retrieve (default: 50)'
         - in: query
           name: page
           schema:
             type: integer
-          description: 'The page number of the results (default: 0)'
+          description: 'The page number of the results (default: 1)'
       responses:
         '200':
           description: OK
@@ -227,19 +226,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponseBody'
 
+  /api/v2/issuances/{id}:
+    get:
+      summary: Get stamp issuances by stamp number, cpid, or stamp_hash
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+          description: Stamp number, cpid, or stamp_hash
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StampsResponseBody'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponseBody'
 
 
   /api/v2/src20:
     get:
-      summary: Get paginated valid src20 transactions
-      description: Retrieve paginated valid src20 transactions with optional limit and page parameters
+      summary: Get paginated valid SRC-20 transactions
+      description: Retrieve paginated valid SRC-20 transactions with optional limit and page parameters
       parameters:
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
-            default: 1000
+            default: 50
           description: The maximum number of transactions to retrieve per page
         - in: query
           name: page
@@ -250,7 +272,7 @@ paths:
           description: The page number of transactions to retrieve
       responses:
         '200':
-          description: Successful response with paginated src20 transactions
+          description: Successful response with paginated SRC-20 transactions
           content:
             application/json:
               schema:
@@ -266,7 +288,7 @@ paths:
 
   /api/v2/src20/balance/{address}:
     get:
-      summary: Get src20 balance by address
+      summary: Get SRC-20 balances by BTC wallet address
       parameters:
         - in: path
           name: address
@@ -291,7 +313,7 @@ paths:
 
   /api/v2/src20/balance/{address}/{tick}:
     get:
-      summary: Get src20 balance by address and tick
+      summary: Get SRC-20 balance by address and tick
       parameters:
         - in: path
           name: address
@@ -319,10 +341,51 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponseBody'
 
+  /api/v2/src20/balance/snapshot/{tick}:
+    get:
+      summary: | 
+        Get SRC-20 balance snapshot by tick, based upon current block height.
+      description: |
+        Retrieve a snapshot of all owners for the SRC-20 tick value based upon the current block height.
+      parameters:
+        - in: path
+          name: tick
+          required: true
+          schema:
+            type: string
+          description: The SRC20 tick value
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            default: 200
+          description: The maximum number of transactions to retrieve per page
+        - in: query
+          name: page
+          schema:
+            type: integer
+            minimum: 1
+            default: 1
+          description: The page number of transactions to retrieve
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Src20SnapshotResponseBody'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponseBody'
+
 
   /api/v2/src20/block/{block_index}:
     get:
-      summary: Get paginated valid src20 transactions from a specific block
+      summary: Get paginated valid SRC-20 transactions from a specific block
       parameters:
         - in: path
           name: block_index
@@ -334,7 +397,7 @@ paths:
           name: limit
           schema:
             type: integer
-          description: 'The maximum number of transactions to retrieve (default: 1000)'
+          description: 'The maximum number of transactions to retrieve (default: 50)'
         - in: query
           name: page
           schema:
@@ -358,7 +421,7 @@ paths:
 
   /api/v2/src20/block/{block_index}/{tick}:
     get:
-      summary: Get valid src20 transactions from a specific block and tick.
+      summary: Get valid SRC-20 transactions from a specific block and tick.
       parameters:
         - in: path
           name: block_index
@@ -377,7 +440,7 @@ paths:
           schema:
             type: integer
             minimum: 1
-            default: 1000
+            default: 50
           description: The maximum number of transactions to return per page.
         - in: query
           name: page
@@ -388,7 +451,7 @@ paths:
           description: The page number.
       responses:
         '200':
-          description: Successful response with the list of valid src20 transactions.
+          description: Successful response with the list of valid SRC-20 transactions.
           content:
             application/json:
               schema:
@@ -399,7 +462,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ErrorResponseBody'
-
 
 
 
@@ -466,18 +528,17 @@ paths:
                     type: string
                     description: The error message.
 
-
   /api/v2/src20/tick:
     get:
-      summary: Get paginated valid src20 transactions by operation type
-      description: Retrieve paginated valid src20 transactions by operation type (DEPLOY)
+      summary: Get paginated valid SRC-20 transactions by operation type
+      description: Retrieve paginated valid SRC-20 transactions by operation type (DEPLOY, MINT, TRANSFER)
       parameters:
         - in: query
           name: limit
           schema:
             type: integer
             minimum: 1
-            default: 1000
+            default: 50
           description: The maximum number of transactions to retrieve per page
         - in: query
           name: page
@@ -486,9 +547,16 @@ paths:
             minimum: 1
             default: 1
           description: The page number of transactions to retrieve
+        - in: query
+          name: op
+          schema:
+            type: string
+            default: DEPLOY
+            enum: [TRANSFER, MINT, DEPLOY]
+          description: The operation type [TRANSFER, MINT, DEPLOY(DEFAULT)]
       responses:
         '200':
-          description: Successful response with paginated src20 transactions
+          description: Successful response with paginated SRC-20 transactions
           content:
             application/json:
               schema:
@@ -518,7 +586,7 @@ paths:
             type: string
         - in: query
           name: limit
-          description: 'Number of records per page (default: 1000)'
+          description: 'Number of records per page (default: 50)'
           schema:
             type: integer
         - in: query
@@ -602,7 +670,7 @@ paths:
           name: limit
           schema:
             type: integer
-          description: The maximum number of stamps to return per page. Defaults to 1000.
+          description: The maximum number of stamps to return per page. Defaults to 50.
         - in: query
           name: page
           schema:
@@ -625,13 +693,13 @@ paths:
 
   /api/v2/stamps/{id}:
     get:
-      summary: Get stamp by ID
-      description: Retrieve a stamp by its ID
+      summary: Get stamp by ID {tx_hash, stamp, cpid}
+      description: Retrieve a stamp by its ID one of tx_hash, stamp number, or cpid
       parameters:
         - in: path
           name: id
           required: true
-          description: ID of the stamp
+          description: ID {tx_hash, stamp, cpid} of the stamp
           schema:
             type: string
       responses:
@@ -662,7 +730,7 @@ paths:
             type: string
         - in: query
           name: limit
-          description: 'The maximum number of stamp balances to retrieve. default: 1000'
+          description: 'The maximum number of stamp balances to retrieve. default: 50'
           schema:
             type: integer
         - in: query
@@ -718,17 +786,17 @@ paths:
         - in: path
           name: ident
           required: true
-          description: The ident value
+          description: The ident value (SRC-721, STAMP)
           schema:
             type: string
         - in: query
           name: limit
-          description: 'The maximum number of stamps to retrieve (default: 1000)'
+          description: 'The maximum number of stamps to retrieve (default: 50)'
           schema:
             type: integer
         - in: query
           name: page
-          description: 'The page number of stamps to retrieve (default: 0)'
+          description: 'The page number of stamps to retrieve (default: 1)'
           schema:
             type: integer
       responses:
@@ -751,7 +819,144 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponseBody'
 
+  /api/v2/stamps/dispensers/{id}:
+    get:
+      summary: Get open dispensers by stamp number, cpid, or stamp_hash
+      description: Retrieve open dispensers by stamp number, cpid, or stamp_hash
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: Stamp number, cpid, or stamp_hash
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StampResponseBody'
+        '500':
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponseBody'
 
+  /api/v2/src20/create:
+    post:
+      summary: Deploy, Mint, Transfer SRC-20 Tokens
+      description: |
+        This returns an unsigned transaction ready for signing and broadcasting
+        via wallet or library. There is no validation that the input data provided
+        will conform to SRC-20 specifications or mint limit requirements. It is the 
+        users sole responsibility to confirm mint, deploy limits and confirm existing
+        balances prior to a transfer of tokens. The examples provided are for demonstration
+        purposes only.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InputData'
+            examples:
+              deploy:
+                value:
+                  toAddress: "bc1ql49ydapnjafl5t2cp9zqpjwe6pdgmxy98859v2"
+                  changeAddress: "bc1qazcm763858nkj2dj986etajv6wquslv8uxwczt"
+                  op: "deploy"
+                  tick: "KEVIN"
+                  feeRate: 60
+                  max: 2100000000
+                  lim: 100000
+                  dec: 18
+              mint:
+                value:
+                  toAddress: "bc1ql49ydapnjafl5t2cp9zqpjwe6pdgmxy98859v2"
+                  changeAddress: "bc1qazcm763858nkj2dj986etajv6wquslv8uxwczt"
+                  op: "mint"
+                  tick: "DOGE"
+                  feeRate: 150
+                  amt: 1000
+              transfer:
+                value:
+                  fromAddress: "bc1qdnksce7dgfsehtdxgz6fzdj2k6qfvmyf8uc2vv"
+                  toAddress: "bc1qazcm763858nkj2dj986etajv6wquslv8uxwczt"
+                  op: "transfer"
+                  tick: "STAMP"
+                  feeRate: 150
+                  amt: 100000
+      responses:
+        '200':
+          description: Successful response with the hex value.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hex:
+                    type: string
+                    description: The hex value.
+        '400':
+          description: Bad request error response.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message.
+
+  /api/v2/olga/mint:
+    post:
+      summary: Mint an OLGA STAMP.
+      description: |
+        This returns an unsigned transaction ready for signing and broadcasting
+        via wallet or library. There is no validation that the input data provided
+        will conform to all STAMP specifications. It is the users sole responsibility 
+        The examples provided are for demonstration purposes only.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MintStampInputData'
+            examples:
+              mint:
+                value:
+                  sourceWallet: "bc1ql49ydapnjafl5t2cp9zqpjwe6pdgmxy98859v2"
+                  qty: 1
+                  locked: true
+                  divisible: true
+                  filename: test.png
+                  file: "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgBAMAAACBVGfHAAAAG1BMVEUAAAALOzcKBiAJTzz/1lqZoxgIaSyfQuJmIslgvM+QAAAAAXRSTlMAQObYZgAAAMlJREFUeNp9kNVhAzEMQFVtYE+ge8HfxhsUFkjuFih4gPJ3Jz9mMPuJJVvjzkR0CBJf7CFQB05GKs75EVCwEbAa+3Wg9XmZ5rOz7gljoE9ZmSydzT67lqcdaWrhUCo8m8baKDEt7Qqz4wtVKTVHRI8R2N1bW7wqMb4GLya0KQOYVOUrXfIaHKWY1lsCTfKXyih0msQXeA1td/RoHGOk++8figPKo67o+dqappTnx8FakD2Vxf11QA78F+cZ6cC5BCrd0F+T8UDmIwdjIhoVAu1hnQAAAABJRU5ErkJggg=="
+                  satsPerKB: 20
+                  service_fee: null
+                  service_fee_address: null
+      responses:
+        '200':
+          description: Successful response with the hex value.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hex:
+                    type: string
+                    description: The hex value.
+        '400':
+          description: Bad request error response.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message.
+  
 
 components:
   schemas:
@@ -811,9 +1016,6 @@ components:
           type: number
         cpid:
           type: string
-        asset_longname:
-          oneOf:
-            - type: string
             
         creator:
           type: string
@@ -824,8 +1026,6 @@ components:
             - type: number
             
         locked:
-          type: number
-        message_index:
           type: number
         stamp_base64:
           type: string
@@ -855,10 +1055,6 @@ components:
         stamp_hash:
           type: string
         is_btc_stamp:
-          oneOf:
-            - type: number
-            
-        is_reissue:
           oneOf:
             - type: number
             
@@ -1012,6 +1208,7 @@ components:
           oneOf:
             - type: number
             - type: string
+    
     StampBalance:
       type: object
       properties:
@@ -1046,7 +1243,6 @@ components:
         creator_name:
           oneOf:
             - type: string
-            
         balance:
           oneOf:
             - type: number
@@ -1140,6 +1336,17 @@ components:
           $ref: "#/components/schemas/MintStatus"
         data:
           $ref: "#/components/schemas/Src20Detail"
+    Src20SnapshotResponseBody:
+      type: object
+      allOf:
+        - $ref: '#/components/schemas/Pagination'
+        - type: object
+          properties:
+            snapshot_block:
+              type: number
+            data:
+              $ref: "#/components/schemas/Src20SnapshotDetail"
+   
     StampsAndSrc20:
       type: object
       properties:
@@ -1167,16 +1374,6 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/Src20Detail"
-    Src20SnapshotResponseBody:
-      type: object
-      allOf:
-        - $ref: '#/components/schemas/Pagination'
-        - type: object
-          properties:
-            snapshot_block:
-              type: number
-            data:
-              $ref: "#/components/schemas/Src20SnapshotDetail"
     PaginatedBalanceResponseBody:
       type: object
       allOf:
@@ -1201,12 +1398,12 @@ components:
     StampsResponseBody:
       type: object
       properties:
+        last_block:
+          type: number
         data:
           type: array
           items:
             $ref: "#/components/schemas/StampRow"
-        last_block:
-          type: number
     PaginatedIdResponseBody:
       type: object
       allOf:
@@ -1365,6 +1562,10 @@ components:
           type: string
         changeAddress:
           type: string
+        fromAddress:
+          oneOf:
+            - type: string
+              nullable: true
         tick:
           type: string
         feeRate:
@@ -1373,13 +1574,46 @@ components:
           oneOf:
             - type: number
             - type: string
+              nullable: true
         lim:
           oneOf:
             - type: number
             - type: string
+              nullable: true
         dec:
           type: number
+          nullable: true
         amt:
           oneOf:
             - type: number
             - type: string
+              nullable: true
+    MintStampInputData:
+      type: object
+      properties:
+        sourceWallet:
+          type: string
+        assetName:
+          oneOf:
+            - type: string
+            - type: undefined
+        qty:
+          type: number
+        locked:
+          type: boolean
+        divisible:
+          type: boolean
+        filename:
+          type: string
+        file:
+          type: string
+        satsPerKB:
+          type: number
+        service_fee:
+          oneOf:
+            - type: number
+            - type: undefined
+        service_fee_address:
+          oneOf:
+            - type: string
+            - type: undefined

--- a/static/swagger/openapi.yml
+++ b/static/swagger/openapi.yml
@@ -12,9 +12,6 @@ servers:
   - url: "https://bitcoinstamps.xyz"
     description: Production server (uses live data)
   - url: 'http://localhost:8000'
-  #   description: Development server (local)
-  # - url: 'https://btcstamps.deno.dev/'
-  #   description: Staging server (uses live data)
 paths:
 
 
@@ -256,8 +253,8 @@ paths:
 
   /api/v2/src20:
     get:
-      summary: Get paginated valid src20 transactions
-      description: Retrieve paginated valid src20 transactions with optional limit and page parameters
+      summary: Get paginated valid SRC-20 transactions
+      description: Retrieve paginated valid SRC-20 transactions with optional limit and page parameters
       parameters:
         - in: query
           name: limit
@@ -275,7 +272,7 @@ paths:
           description: The page number of transactions to retrieve
       responses:
         '200':
-          description: Successful response with paginated src20 transactions
+          description: Successful response with paginated SRC-20 transactions
           content:
             application/json:
               schema:
@@ -291,7 +288,7 @@ paths:
 
   /api/v2/src20/balance/{address}:
     get:
-      summary: Get src20 balance by address
+      summary: Get SRC-20 balances by BTC wallet address
       parameters:
         - in: path
           name: address
@@ -316,7 +313,7 @@ paths:
 
   /api/v2/src20/balance/{address}/{tick}:
     get:
-      summary: Get src20 balance by address and tick
+      summary: Get SRC-20 balance by address and tick
       parameters:
         - in: path
           name: address
@@ -347,7 +344,7 @@ paths:
   /api/v2/src20/balance/snapshot/{tick}:
     get:
       summary: | 
-        Get src20 balance snapshot by tick, based upon current block height.
+        Get SRC-20 balance snapshot by tick, based upon current block height.
       description: |
         Retrieve a snapshot of all owners for the SRC-20 tick value based upon the current block height.
       parameters:
@@ -388,7 +385,7 @@ paths:
 
   /api/v2/src20/block/{block_index}:
     get:
-      summary: Get paginated valid src20 transactions from a specific block
+      summary: Get paginated valid SRC-20 transactions from a specific block
       parameters:
         - in: path
           name: block_index
@@ -424,7 +421,7 @@ paths:
 
   /api/v2/src20/block/{block_index}/{tick}:
     get:
-      summary: Get valid src20 transactions from a specific block and tick.
+      summary: Get valid SRC-20 transactions from a specific block and tick.
       parameters:
         - in: path
           name: block_index
@@ -454,7 +451,7 @@ paths:
           description: The page number.
       responses:
         '200':
-          description: Successful response with the list of valid src20 transactions.
+          description: Successful response with the list of valid SRC-20 transactions.
           content:
             application/json:
               schema:
@@ -466,10 +463,75 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponseBody'
 
+
+
+  /api/v2/src20/create:
+    post:
+      summary: Create a new SRC20 token or mint additional tokens.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InputData'
+      responses:
+        '200':
+          description: Successful response with the hex value.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hex:
+                    type: string
+                    description: The hex value.
+        '400':
+          description: Bad request error response.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message.
+
+
+  /api/v2/olga/mint:
+    post:
+      summary: Mint a new OLGA STAMP.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MintStampInputData'
+      responses:
+        '200':
+          description: Successful response with the hex value.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hex:
+                    type: string
+                    description: The hex value.
+        '400':
+          description: Bad request error response.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: The error message.
+
   /api/v2/src20/tick:
     get:
-      summary: Get paginated valid src20 transactions by operation type
-      description: Retrieve paginated valid src20 transactions by operation type (DEPLOY)
+      summary: Get paginated valid SRC-20 transactions by operation type
+      description: Retrieve paginated valid SRC-20 transactions by operation type (DEPLOY, MINT, TRANSFER)
       parameters:
         - in: query
           name: limit
@@ -485,9 +547,16 @@ paths:
             minimum: 1
             default: 1
           description: The page number of transactions to retrieve
+        - in: query
+          name: op
+          schema:
+            type: string
+            default: DEPLOY
+            enum: [TRANSFER, MINT, DEPLOY]
+          description: The operation type [TRANSFER, MINT, DEPLOY(DEFAULT)]
       responses:
         '200':
-          description: Successful response with paginated src20 transactions
+          description: Successful response with paginated SRC-20 transactions
           content:
             application/json:
               schema:
@@ -751,7 +820,7 @@ paths:
                 $ref: '#/components/schemas/ErrorResponseBody'
 
   /api/v2/stamps/dispensers/{id}:
-      get:
+    get:
       summary: Get open dispensers by stamp number, cpid, or stamp_hash
       description: Retrieve open dispensers by stamp number, cpid, or stamp_hash
       parameters:
@@ -891,6 +960,17 @@ paths:
 
 components:
   schemas:
+    Pagination:
+      type: object
+      properties:
+        page:
+          type: number
+        limit:
+          type: number
+        totalPages:
+          type: number
+        total:
+          type: number
     SUBPROTOCOLS:
       type: string
       enum:
@@ -1196,17 +1276,7 @@ components:
       properties:
         query:
           $ref: "#/components/schemas/PaginationQueryParams"
-    Pagination:
-      type: object
-      properties:
-        page:
-          type: number
-        limit:
-          type: number
-        totalPages:
-          type: number
-        total:
-          type: number
+
     PaginatedStampResponseBody:
       type: object
       allOf:


### PR DESCRIPTION
cleanup swagger docs, and add the deploy img url to the src20 balance api call:

http://dev.bitcoinstamps.xyz/api/v2/src20/balance/1GotRejB6XsGgMsM79TvcypeanDJRJbMtg