### PR TITLE
chore: add recent sales query to homepage

### DIFF
--- a/lib/controller/stampController.ts
+++ b/lib/controller/stampController.ts
@@ -177,8 +177,8 @@ export class StampController {
   ) {
     try {
       if (!type) {
-        const [stampCategories, src20Result, poshCollection] = await Promise
-          .all([
+        const [stampCategories, src20Result, poshCollection, recentSales] =
+          await Promise.all([
             this.getMultipleStampCategories([
               { types: ["STAMP", "SRC-721"], limit: 6 },
               { types: ["SRC-721"], limit: 6 },
@@ -190,11 +190,12 @@ export class StampController {
               page,
               limit: page_size,
             }),
-            CollectionService.getCollectionByName("posh"),
+            CollectionService.getCollectionByName("posh", 6),
+            StampService.getRecentSales(6),
           ]);
 
         return {
-          stamps_recent: stampCategories[0].stamps,
+          stamps_recent: recentSales,
           stamps_src721: stampCategories[1].stamps,
           stamps_art: stampCategories[2].stamps,
           stamps_src20: stampCategories[3].stamps,

--- a/lib/services/collectionService.ts
+++ b/lib/services/collectionService.ts
@@ -49,6 +49,7 @@ export class CollectionService {
 
   static async getCollectionByName(
     collectionName: string,
+    limit: number = 10,
   ): Promise<Collection | null> {
     const collectionResult = await CollectionRepository.getCollectionByName(
       collectionName,
@@ -60,7 +61,7 @@ export class CollectionService {
 
     const row = collectionResult.rows[0];
     const stamps = await StampRepository.getStampsFromDb({
-      limit: 10,
+      limit: limit,
       collectionId: row.collection_id,
       noPagination: true,
       type: "all",
@@ -70,7 +71,7 @@ export class CollectionService {
       collection_id: row.collection_id,
       collection_name: row.collection_name,
       creators: row.creators ? row.creators.split(",") : [],
-      stamps: stamps.rows,
+      stamps: stamps.rows.slice(0, limit), // Ensure we only return up to the limit
     };
   }
 }


### PR DESCRIPTION
 - recent sales from xcp v2 API endpoint
 - will require some optimization, it's likely we don't need to fetch all 500 rows, but perhaps we can. use some creative caching. 