### PR TITLE
chore: issue #189 change stamps displayed per row, and proper stamp data fetching

### DIFF
--- a/islands/stamp/StampCard.tsx
+++ b/islands/stamp/StampCard.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from "preact";
 import dayjs from "$dayjs/";
 import relativeTime from "$dayjs/plugin/relativeTime";
 import { StampRow } from "globals";
@@ -12,14 +13,7 @@ import {
 
 dayjs.extend(relativeTime);
 
-export function StampCard({
-  stamp,
-  kind = "stamp",
-  isRecentSale = false,
-  showInfo = true,
-  abbreviationLength = 6,
-  showDetails = false,
-}: {
+interface StampCardProps {
   stamp: StampRow & {
     sale_data?: { btc_amount: number; block_index: number; tx_hash: string };
   };
@@ -28,7 +22,20 @@ export function StampCard({
   showInfo?: boolean;
   abbreviationLength?: number;
   showDetails?: boolean;
-}) {
+  className?: string;
+  style?: JSX.CSSProperties;
+}
+
+export function StampCard({
+  stamp,
+  kind = "stamp",
+  isRecentSale = false,
+  showInfo = true,
+  abbreviationLength = 6,
+  showDetails = false,
+  className = "",
+  style,
+}: StampCardProps) {
   let src: string;
   const suffix = getFileSuffixFromMime(stamp.stamp_mimetype);
   src = `/content/${stamp.tx_hash}.${suffix}`;
@@ -108,8 +115,8 @@ export function StampCard({
         href={`/stamp/${stamp.tx_hash}`}
         target="_top"
         f-partial={`/stamp/${stamp.tx_hash}`}
-        className="text-white group relative z-0 flex flex-col 
-          p-stamp-card-lg mobile-md:p-3 
+        className={`text-white group relative z-0 flex flex-col 
+          p-stamp-card-lg mobile-md:p-3
           rounded-stamp transition-all 
           w-full
           max-w-[318px] 
@@ -120,7 +127,9 @@ export function StampCard({
           hover:shadow-stamp 
           hover:border-solid 
           border-2 border-transparent
-          bg-stamp-primary"
+          bg-stamp-primary
+          ${className}`}
+        style={style}
       >
         {/* Image Container */}
         <div className="relative w-full">

--- a/islands/stamping/stamp/LatestStamps.tsx
+++ b/islands/stamping/stamp/LatestStamps.tsx
@@ -1,55 +1,73 @@
 import { StampCard } from "$islands/stamp/StampCard.tsx";
+import type { StampRow } from "globals";
+import { useEffect, useState } from "preact/hooks";
 
-const mock_stamp = {
-  stamp: 548891,
-  block_index: 851847,
-  cpid: "GqgivDk87bkYkavFoERk",
-  creator: "bc1q5hue5dpy6p2k25mx5smd9qysjxuuvvjkn6h9h6",
-  creator_name: null,
-  divisible: null,
-  keyburn: 1,
-  locked: null,
-  stamp_base64: null,
-  stamp_mimetype: "image/svg+xml",
-  stamp_url:
-    "https://stampchain.io/stamps/183f422a302a727e40a8582d04a9fd24cbd64deba853d585b187fda774c18024.svg",
-  supply: null,
-  block_time: "2024-07-12T17:44:12.000Z",
-  tx_hash: "183f422a302a727e40a8582d04a9fd24cbd64deba853d585b187fda774c18024",
-  tx_index: 566963,
-  ident: "SRC-20",
-  stamp_hash: "GqgivDk87bkYkavFoERk",
-  is_btc_stamp: 1,
-  file_hash: "828c74eed07712301119019f0d47b07a",
-};
+interface LatestStampsProps {
+  stamps: StampRow[];
+}
 
-const LatestStamps = () => {
+export default function LatestStamps({ stamps }: LatestStampsProps) {
+  const [displayCount, setDisplayCount] = useState(9);
+
+  useEffect(() => {
+    const updateDisplayCount = () => {
+      const width = globalThis.innerWidth;
+      if (width >= 1440) setDisplayCount(8); // desktop
+      else if (width >= 1025) setDisplayCount(9); // tablet
+      else if (width >= 769) setDisplayCount(8); // mobile-lg
+      else if (width >= 569) setDisplayCount(6); // mobile-md
+      else if (width >= 420) setDisplayCount(6); // mobile-sm
+      else setDisplayCount(4); // default
+    };
+
+    // Initial check
+    updateDisplayCount();
+
+    // Add resize listener
+    globalThis.addEventListener("resize", updateDisplayCount);
+
+    // Cleanup
+    return () => globalThis.removeEventListener("resize", updateDisplayCount);
+  }, []);
+
   return (
     <div className="w-full md:w-1/2 flex flex-col gap-4 items-start md:items-end">
-      <h1 className="purple-gradient2 text-3xl md:text-6xl font-black">
+      <h1 className="bg-text-purple-4 bg-clip-text text-fill-transparent text-3xl md:text-6xl font-black">
         LATEST STAMPS
       </h1>
-      <p className="text-2xl md:text-5xl text-[#AA00FF]">LOREM IPSUM</p>
-      <div className="grid grid-cols-3 sm:grid-cols-4 gap-4">
-        {Array(8).fill(0).map((_, index) => {
-          return (
-            <StampCard
-              key={index}
-              stamp={mock_stamp}
-              kind="stamp"
-              isRecentSale={false}
-              showInfo={false}
-            />
-          );
-        })}
+
+      <div className="grid w-full gap-4
+                    grid-cols-2                    /* Default: 2x2 = 4 stamps */
+                    mobile-sm:grid-cols-3          /* 420px+: 3x2 = 6 stamps */
+                    mobile-md:grid-cols-3          /* 569px+: 3x2 = 6 stamps */
+                    mobile-lg:grid-cols-4          /* 769px+: 4x2 = 8 stamps */
+                    tablet:grid-cols-3             /* 1025px+: 3x3 = 9 stamps */
+                    desktop:grid-cols-4            /* 1440px+: 4x2 = 8 stamps */
+                    auto-rows-fr                   /* Equal height rows */
+      ">
+        {stamps.slice(0, displayCount).map((stamp) => (
+          <StampCard
+            key={stamp.cpid}
+            stamp={stamp}
+            kind="stamp"
+            isRecentSale={false}
+            showInfo={false}
+          />
+        ))}
       </div>
+
       <div className="w-full flex justify-end items-end">
-        <a className="text-[#660099] text-sm md:text-base font-extrabold border-2 border-[#660099] py-1 text-center min-w-[120px] rounded-md cursor-pointer">
+        <a
+          href="/stamps"
+          className="text-stamp-purple-dark hover:text-stamp-primary-hover 
+                     text-sm md:text-base font-extrabold border-2 
+                     border-stamp-purple-dark hover:border-stamp-primary-hover 
+                     py-1 text-center min-w-[120px] rounded-md cursor-pointer 
+                     transition-colors duration-200"
+        >
           View All
         </a>
       </div>
     </div>
   );
-};
-
-export default LatestStamps;
+}

--- a/routes/stamping/stamp.tsx
+++ b/routes/stamping/stamp.tsx
@@ -1,9 +1,38 @@
+import { Handlers, PageProps } from "$fresh/server.ts";
 import { OlgaContent } from "$islands/stamping/stamp/OlgaContent.tsx";
 import LatestStamps from "$islands/stamping/stamp/LatestStamps.tsx";
-
 import { FAQModule } from "$islands/modules/FAQStamping.tsx";
+import { StampController } from "../../server/controller/stampController.ts";
+import type { StampRow } from "globals";
 
-export function StampingStampPage() {
+interface StampPageData {
+  latestStamps: StampRow[];
+}
+
+export const handler: Handlers<StampPageData> = {
+  async GET(_, ctx) {
+    try {
+      const stampResult = await StampController.getStamps({
+        limit: 9,
+        sortBy: "DESC",
+        type: "stamps",
+        page: 1,
+      });
+
+      return ctx.render({
+        latestStamps: stampResult.data,
+      });
+    } catch (error) {
+      console.error("Error fetching stamps:", error);
+      // Return empty array if error occurs
+      return ctx.render({
+        latestStamps: [],
+      });
+    }
+  },
+};
+
+export function StampingStampPage({ data }: PageProps<StampPageData>) {
   return (
     <div className="flex flex-col gap-16">
       <div className="self-center max-w-[680px] w-full mx-auto">
@@ -13,9 +42,10 @@ export function StampingStampPage() {
         <div className="w-full md:w-1/2">
           <FAQModule />
         </div>
-        <LatestStamps />
+        <LatestStamps stamps={data.latestStamps} />
       </div>
     </div>
   );
 }
+
 export default StampingStampPage;


### PR DESCRIPTION
initial attempt at scaling # of stamps per breakpoint:

Desktop (1440px+): 8 stamps
Tablet (1025px-1439px): 9 stamps
Mobile-lg (769px-1024px): 8 stamps
Mobile-md (569px-768px): 6 stamps
Mobile-sm (420px-568px): 6 stamps
Default (<420px): 4 stamps