### PR TITLE
Tables update

### DIFF
--- a/components/shared/HoldersGraph.tsx
+++ b/components/shared/HoldersGraph.tsx
@@ -50,19 +50,23 @@ export function HoldersGraph(
     );
   }
 
+  const dataLabelClassName =
+    "text-base mobileLg:text-lg font-light text-stamp-grey-darker uppercase";
+  const dataValueXLClassName =
+    "text-3xl mobileLg:text-4xl font-black text-stamp-grey-light -mt-1";
   const tableLabelClassName =
     "text-sm mobileLg:text-base font-light text-stamp-grey-darker uppercase";
   const tableValueClassName =
-    "w-full text-xs mobileLg:text-sm text-stamp-grey-light font-normal";
+    "text-xs mobileLg:text-sm font-normal text-stamp-grey-light w-full";
   const totalHolders = holders.length;
 
   return (
-    <div className="flex flex-col bg-gradient-to-br primary-gradient p-0 pt-24 relative">
+    <div className="flex flex-col dark-gradient p-0 pt-24 relative">
       <div className="absolute top-6 right-6 text-right">
-        <p className="text-base mobileLg:text-lg text-stamp-grey-darker font-light">
+        <p className={dataLabelClassName}>
           HOLDERS
         </p>
-        <p className="text-2xl mobileLg:text-3xl text-stamp-grey-light font-black -mt-1">
+        <p className={dataValueXLClassName}>
           {totalHolders}
         </p>
       </div>

--- a/components/shared/HoldersGraph.tsx
+++ b/components/shared/HoldersGraph.tsx
@@ -50,6 +50,10 @@ export function HoldersGraph(
     );
   }
 
+  const tableLabelClassName =
+    "text-sm mobileLg:text-base font-light text-stamp-grey-darker uppercase";
+  const tableValueClassName =
+    "w-full text-xs mobileLg:text-sm text-stamp-grey-light font-normal";
   const totalHolders = holders.length;
 
   return (
@@ -69,14 +73,14 @@ export function HoldersGraph(
 
         <div className="relative w-full max-w-full">
           <div className="max-h-64 overflow-x-auto p-6">
-            <table className="w-full text-sm mobileLg:text-base text-left text-stamp-grey-light">
-              <thead className="text-base mobileLg:text-lg text-stamp-grey-darker font-light uppercase">
+            <table className={tableValueClassName}>
+              <thead className={tableLabelClassName}>
                 <tr>
                   {tableHeaders.map(({ key, label }) => (
                     <th
                       key={key}
                       scope="col"
-                      class={`py-0 mobileLg:py-1 font-light ${
+                      class={`${tableLabelClassName} pb-1.5 ${
                         key === "address"
                           ? "text-left"
                           : key === "percent"

--- a/components/shared/PieChart.tsx
+++ b/components/shared/PieChart.tsx
@@ -80,7 +80,7 @@ const PieChart = ({ holders }: PieChartProps) => {
     );
   } catch (error) {
     console.error("Error rendering chart:", error);
-    return <div class="text-center py-4">Error rendering chart</div>;
+    return <div class="text-center py-6">Error rendering chart</div>;
   }
 };
 

--- a/components/stampDetails/StampDispensers.tsx
+++ b/components/stampDetails/StampDispensers.tsx
@@ -28,39 +28,41 @@ const tableHeaders = [
   { key: "closeBlock", label: "Closed" },
 ];
 
-const tableTextClassName =
-  "w-full text-sm mobileLg:text-base text-stamp-grey-light font-light";
-const dataLabelClassName =
-  "text-base mobileLg:text-lg font-light text-stamp-grey-darker uppercase";
+const tableLabelClassName =
+  "text-sm mobileLg:text-base font-light text-stamp-grey-darker uppercase";
+const tableValueClassName =
+  "w-full text-xs mobileLg:text-sm text-stamp-grey-light font-normal";
 
 function DispenserRow({ dispenser }: { dispenser: Dispenser }) {
   const isClosedDispenser = dispenser.close_block_index > 0;
-  const rowClassName = isClosedDispenser ? "text-[#666666]" : "";
+  const rowClassName = isClosedDispenser ? "text-stamp-grey-darker" : "";
 
   return (
     <tr class={rowClassName}>
-      <td className="text-left w-full">
+      <td className="text-left py-0">
         {formatSatoshisToBTC(dispenser.satoshirate)}
       </td>
-      <td className="text-center">
+      <td className="text-center py-0">
         {formatNumber(dispenser.escrow_quantity, 0)}
       </td>
-      <td className="text-center">
+      <td className="text-center py-0">
         {formatNumber(dispenser.give_quantity, 0)}
       </td>
-      <td className="text-center">
+      <td className="text-center py-0">
         {formatNumber(dispenser.give_remaining, 0)}
       </td>
-      <td className="text-center">
-        <span className="hidden tablet:inline">{dispenser.source}</span>
-        <span className="inline tablet:hidden">
-          {abbreviateAddress(dispenser.source)}
+      <td className="text-center py-0">
+        <span className="tablet:hidden">
+          {abbreviateAddress(dispenser.source, 4)}
+        </span>
+        <span className="hidden tablet:inline">
+          {abbreviateAddress(dispenser.source, 8)}
         </span>
       </td>
-      <td className="text-center">
+      <td className="text-center py-0">
         {dispenser.confirmed ? "YES" : "NO"}
       </td>
-      <td className="text-right">
+      <td className="text-right py-0">
         {!dispenser.close_block_index || dispenser.close_block_index <= 0
           ? "OPEN"
           : dispenser.close_block_index}
@@ -78,15 +80,15 @@ export function StampDispensers({ dispensers }: StampDispensersProps) {
   return (
     <div className="relative max-w-full">
       <div className="max-h-96 overflow-x-auto">
-        <table class={`${tableTextClassName} w-full table-fixed`}>
+        <table class={`${tableValueClassName} w-full table-fixed`}>
           <colgroup>
-            <col class="w-[16%] tablet:w-[12%]" /> {/* Price */}
-            <col class="w-[12%] tablet:w-[8%]" /> {/* Escrow */}
-            <col class="w-[12%] tablet:w-[8%]" /> {/* Give */}
-            <col class="w-[12%] tablet:w-[8%]" /> {/* Remain */}
-            <col class="w-[18%] tablet:w-[42%]" /> {/* Address column */}
-            <col class="w-[16%] tablet:w-[12%]" /> {/* Confirmed */}
-            <col class="w-[14%] tablet:w-[10%]" /> {/* Closed */}
+            <col class="w-[16%] tablet:w-[14%]" /> {/* Price */}
+            <col class="w-[12%] tablet:w-[10%]" /> {/* Escrow */}
+            <col class="w-[12%] tablet:w-[10%]" /> {/* Give */}
+            <col class="w-[12%] tablet:w-[10%]" /> {/* Remain */}
+            <col class="w-[20%] tablet:w-[28%]" /> {/* Address column */}
+            <col class="w-[14%] tablet:w-[14%]" /> {/* Confirmed */}
+            <col class="w-[14%] tablet:w-[14%]" /> {/* Closed */}
           </colgroup>
           <thead>
             <tr>
@@ -94,7 +96,7 @@ export function StampDispensers({ dispensers }: StampDispensersProps) {
                 <th
                   key={key}
                   scope="col"
-                  class={`${dataLabelClassName} ${
+                  class={`${tableLabelClassName} pb-1.5 ${
                     key === "price"
                       ? "text-left"
                       : key === "closeBlock"

--- a/components/stampDetails/StampDispensers.tsx
+++ b/components/stampDetails/StampDispensers.tsx
@@ -31,7 +31,7 @@ const tableHeaders = [
 const tableLabelClassName =
   "text-sm mobileLg:text-base font-light text-stamp-grey-darker uppercase";
 const tableValueClassName =
-  "w-full text-xs mobileLg:text-sm text-stamp-grey-light font-normal";
+  "text-xs mobileLg:text-sm font-normal text-stamp-grey-light w-full";
 
 function DispenserRow({ dispenser }: { dispenser: Dispenser }) {
   const isClosedDispenser = dispenser.close_block_index > 0;

--- a/components/stampDetails/StampSales.tsx
+++ b/components/stampDetails/StampSales.tsx
@@ -27,7 +27,7 @@ const tableHeaders = [
 const tableLabelClassName =
   "text-sm mobileLg:text-base font-light text-stamp-grey-darker uppercase";
 const tableValueClassName =
-  "w-full text-xs mobileLg:text-sm text-stamp-grey-light font-normal";
+  "text-xs mobileLg:text-sm font-normal text-stamp-grey-light w-full";
 
 function DispenseRow({ dispense }: { dispense: Dispense }) {
   return (

--- a/components/stampDetails/StampSales.tsx
+++ b/components/stampDetails/StampSales.tsx
@@ -24,31 +24,41 @@ const tableHeaders = [
   { key: "confirmed", label: "Confirmed" },
 ];
 
-const tableTextClassName =
-  "w-full text-sm mobileLg:text-base text-stamp-grey-light font-light";
-const dataLabelClassName =
-  "text-base mobileLg:text-lg font-light text-stamp-grey-darker uppercase";
+const tableLabelClassName =
+  "text-sm mobileLg:text-base font-light text-stamp-grey-darker uppercase";
+const tableValueClassName =
+  "w-full text-xs mobileLg:text-sm text-stamp-grey-light font-normal";
 
 function DispenseRow({ dispense }: { dispense: Dispense }) {
   return (
     <tr>
-      <td className="text-left w-full">
+      <td className="text-left py-0">
         <a href={`/wallet/${dispense.source}`}>
-          {abbreviateAddress(dispense.source)}
+          <span className="tablet:hidden">
+            {abbreviateAddress(dispense.source, 4)}
+          </span>
+          <span className="hidden tablet:inline">
+            {abbreviateAddress(dispense.source, 6)}
+          </span>
         </a>
       </td>
-      <td className="text-center">
+      <td className="text-center py-0">
         <a href={`/wallet/${dispense.destination}`}>
-          {abbreviateAddress(dispense.destination)}
+          <span className="tablet:hidden">
+            {abbreviateAddress(dispense.destination, 4)}
+          </span>
+          <span className="hidden tablet:inline">
+            {abbreviateAddress(dispense.destination, 6)}
+          </span>
         </a>
       </td>
-      <td className="text-center">
+      <td className="text-center py-0">
         {dispense.dispense_quantity}
       </td>
-      <td className="text-center">
+      <td className="text-center py-0">
         {formatSatoshisToBTC(dispense.satoshirate)}
       </td>
-      <td className="text-right">
+      <td className="text-right py-0">
         {dispense.confirmed ? "YES" : "NO"}
       </td>
     </tr>
@@ -59,7 +69,7 @@ export function StampSales({ dispenses }: StampSalesProps) {
   return (
     <div className="relative shadow-md max-w-full">
       <div className="max-h-96 overflow-x-auto">
-        <table className={`${tableTextClassName} w-full table-fixed`}>
+        <table className={`${tableValueClassName} w-full table-fixed`}>
           <colgroup>
             <col className="w-[20%]" /> {/* From column */}
             <col className="w-[20%]" /> {/* To */}
@@ -73,7 +83,7 @@ export function StampSales({ dispenses }: StampSalesProps) {
                 <th
                   key={key}
                   scope="col"
-                  className={`${dataLabelClassName} ${
+                  className={`${tableLabelClassName} ${
                     key === "from"
                       ? "text-left"
                       : key === "confirmed"

--- a/components/stampDetails/StampTransfers.tsx
+++ b/components/stampDetails/StampTransfers.tsx
@@ -26,7 +26,7 @@ const tableHeaders = [
 const tableLabelClassName =
   "text-sm mobileLg:text-base font-light text-stamp-grey-darker uppercase";
 const tableValueClassName =
-  "w-full text-xs mobileLg:text-sm text-stamp-grey-light font-normal";
+  "text-xs mobileLg:text-sm font-normal text-stamp-grey-light w-full";
 
 function TransferRow({ send }: { send: SendRow }) {
   return (

--- a/components/stampDetails/StampTransfers.tsx
+++ b/components/stampDetails/StampTransfers.tsx
@@ -23,30 +23,52 @@ const tableHeaders = [
   { key: "created", label: "Created" },
 ];
 
-const tableTextClassName =
-  "w-full text-sm mobileLg:text-base text-stamp-grey-light font-light";
-const dataLabelClassName =
-  "text-base mobileLg:text-lg font-light text-stamp-grey-darker uppercase";
+const tableLabelClassName =
+  "text-sm mobileLg:text-base font-light text-stamp-grey-darker uppercase";
+const tableValueClassName =
+  "w-full text-xs mobileLg:text-sm text-stamp-grey-light font-normal";
 
 function TransferRow({ send }: { send: SendRow }) {
   return (
     <tr key={send.tx_hash}>
-      <td className="text-left w-full">
-        {send.source ? abbreviateAddress(send.source) : "NULL"}
+      <td className="text-left py-0">
+        {send.source
+          ? (
+            <>
+              <span className="tablet:hidden">
+                {abbreviateAddress(send.source, 4)}
+              </span>
+              <span className="hidden tablet:inline">
+                {abbreviateAddress(send.source, 6)}
+              </span>
+            </>
+          )
+          : "NULL"}
       </td>
-      <td className="text-center">
-        {send.destination ? abbreviateAddress(send.destination) : "NULL"}
+      <td className="text-center py-0">
+        {send.destination
+          ? (
+            <>
+              <span className="tablet:hidden">
+                {abbreviateAddress(send.destination, 4)}
+              </span>
+              <span className="hidden tablet:inline">
+                {abbreviateAddress(send.destination, 6)}
+              </span>
+            </>
+          )
+          : "NULL"}
       </td>
-      <td className="text-center">
+      <td className="text-center py-0">
         {send.quantity}
       </td>
-      <td className="text-center uppercase">
+      <td className="text-center uppercase py-0">
         {send.memo || "transfer"}
       </td>
-      <td className="text-center">
+      <td className="text-center py-0">
         {abbreviateAddress(send.tx_hash)}
       </td>
-      <td className="text-right uppercase">
+      <td className="text-right uppercase py-0">
         {formatDate(new Date(send.block_time), {
           includeRelative: false,
         })}
@@ -59,7 +81,7 @@ export function StampTransfers({ sends }: StampTransfersProps) {
   return (
     <div className="relative max-w-full">
       <div className="max-h-96 overflow-x-auto">
-        <table className={`${tableTextClassName} w-full table-fixed`}>
+        <table className={`${tableValueClassName} w-full table-fixed`}>
           <colgroup>
             <col className="w-[20%]" /> {/* From column */}
             <col className="w-[20%]" /> {/* To */}
@@ -74,7 +96,7 @@ export function StampTransfers({ sends }: StampTransfersProps) {
                 <th
                   key={key}
                   scope="col"
-                  className={`${dataLabelClassName} ${
+                  className={`${tableLabelClassName} ${
                     key === "from"
                       ? "text-left"
                       : key === "created"

--- a/components/stampDetails/StampTransfers.tsx
+++ b/components/stampDetails/StampTransfers.tsx
@@ -19,8 +19,8 @@ const tableHeaders = [
   { key: "to", label: "To" },
   { key: "quantity", label: "Quantity" },
   { key: "memo", label: "Memo" },
-  { key: "txHash", label: "Tx hash" },
-  { key: "created", label: "Created" },
+  { key: "txHash", label: "Tx Hash" },
+  { key: "created", label: "Date" },
 ];
 
 const tableLabelClassName =
@@ -83,12 +83,12 @@ export function StampTransfers({ sends }: StampTransfersProps) {
       <div className="max-h-96 overflow-x-auto">
         <table className={`${tableValueClassName} w-full table-fixed`}>
           <colgroup>
-            <col className="w-[20%]" /> {/* From column */}
-            <col className="w-[20%]" /> {/* To */}
-            <col className="w-[20%]" /> {/* Quantity */}
-            <col className="w-[20%]" /> {/* Memo */}
-            <col className="w-[20%]" /> {/* Tx hash */}
-            <col className="w-[20%]" /> {/* Created */}
+            <col className="w-[18%]" /> {/* From column */}
+            <col className="w-[18%]" /> {/* To */}
+            <col className="w-[10%]" /> {/* Quantity */}
+            <col className="w-[18%]" /> {/* Memo */}
+            <col className="w-[18%]" /> {/* Tx hash */}
+            <col className="w-[18%]" /> {/* Created */}
           </colgroup>
           <thead>
             <tr>

--- a/islands/src20/details/SRC20TX.tsx
+++ b/islands/src20/details/SRC20TX.tsx
@@ -52,18 +52,21 @@ export function SRC20TX(props: SRC20TXProps) {
     if (type === "TRANSFER") {
       return (
         <tr class="w-full table table-fixed">
-          <th scope="col" class="px-6 py-3">from</th>
-          <th scope="col" class="px-6 py-3">to</th>
-          <th scope="col" class="px-6 py-3">amount</th>
-          <th scope="col" class="px-6 py-3">date</th>
+          <th scope="col" class="px-6 py-3">From</th>
+          <th scope="col" class="px-6 py-3">To</th>
+          <th scope="col" class="px-6 py-3">Amount</th>
+          <th scope="col" class="px-6 py-3">Tx Hash</th>
+          <th scope="col" class="px-6 py-3">Date</th>
         </tr>
       );
     } else if (type === "MINT") {
       return (
         <tr class="w-full table table-fixed">
-          <th scope="col" class="px-6 py-3">block</th>
-          <th scope="col" class="px-6 py-3">address</th>
-          <th scope="col" class="px-6 py-3">amount</th>
+          <th scope="col" class="px-6 py-3">Block</th>
+          <th scope="col" class="px-6 py-3">Address</th>
+          <th scope="col" class="px-6 py-3">Amount</th>
+          <th scope="col" class="px-6 py-3">Tx Hash</th>
+          <th scope="col" class="px-6 py-3">Date</th>
         </tr>
       );
     }
@@ -84,7 +87,10 @@ export function SRC20TX(props: SRC20TXProps) {
 
       if (type === "TRANSFER") {
         return (
-          <tr key={tx.tx_hash} class="w-full table table-fixed text-xs">
+          <tr
+            key={tx.tx_hash}
+            class="w-full table table-fixed text-xs mobileLg:text-sm font-normal text-stamp-grey-light"
+          >
             <td class="px-3 py-2">{abbreviateAddress(tx.creator)}</td>
             <td class="px-3 py-2">{abbreviateAddress(tx.destination)}</td>
             <td class="px-3 py-2">{formattedAmt}</td>

--- a/islands/stamp/details/StampRelatedInfo.tsx
+++ b/islands/stamp/details/StampRelatedInfo.tsx
@@ -220,6 +220,10 @@ export function StampRelatedInfo({ stampId, cpid }: StampRelatedInfoProps) {
       }
     }
   };
+  const dataLabelClassName =
+    "text-base mobileLg:text-lg font-light text-stamp-grey-darker uppercase";
+  const dataValueXLlinkClassName =
+    "text-3xl mobileLg:text-4xl font-black text-stamp-grey -mt-1";
 
   // Update getTabsWithCounts to use totalCounts
   function getTabsWithCounts() {
@@ -230,7 +234,7 @@ export function StampRelatedInfo({ stampId, cpid }: StampRelatedInfoProps) {
           <div class="flex flex-col text-left">
             DISPENSERS
             <div
-              class={`text-2xl mobileLg:text-3xl font-black -mt-1 ${
+              class={`${dataValueXLlinkClassName} ${
                 selectedTab === "dispensers"
                   ? "text-stamp-grey-light"
                   : "text-stamp-grey-darker"
@@ -247,7 +251,7 @@ export function StampRelatedInfo({ stampId, cpid }: StampRelatedInfoProps) {
           <div class="flex flex-col text-center">
             SALES
             <div
-              class={`text-2xl mobileLg:text-3xl font-black -mt-1 ${
+              class={`${dataValueXLlinkClassName} ${
                 selectedTab === "sales"
                   ? "text-stamp-grey-light"
                   : "text-stamp-grey-darker"
@@ -264,7 +268,7 @@ export function StampRelatedInfo({ stampId, cpid }: StampRelatedInfoProps) {
           <div class="flex flex-col text-right">
             TRANSFERS
             <div
-              class={`text-2xl mobileLg:text-3xl font-black -mt-1 ${
+              class={`${dataValueXLlinkClassName} ${
                 selectedTab === "transfers"
                   ? "text-stamp-grey-light"
                   : "text-stamp-grey-darker"


### PR DESCRIPTION
The stamp details page table is styled correctly

I started updating the tokens details page, but there are several columns of data missing and the build is not as logical as the stamp details page table (imo). So I haven't finished it and suggest we use the stamp details page table as the template for a global/master template that the token details page also uses.

An issue has been created
https://github.com/stampchain-io/BTCStampsExplorer/issues/407