### PR TITLE
fix: add bg gradient to the collections overview filters

### DIFF
--- a/islands/datacontrol/Filter.tsx
+++ b/islands/datacontrol/Filter.tsx
@@ -31,10 +31,6 @@ export function Filter({
   const [localFilters, setLocalFilters] = useState<FilterTypes[]>(initFilter);
   const { updateURL } = useURLUpdate();
 
-  const toggle = () => {
-    handleOpen(!open);
-  };
-
   useEffect(() => {
     setLocalFilters(initFilter);
   }, [initFilter]);
@@ -53,7 +49,7 @@ export function Filter({
     <div
       class={`${
         open ? "" : "cursor-pointer"
-      } border-2 border-[#8800CC] bg-transparent rounded-md flex flex-col items-center gap-1 h-fit relative z-[10] ${
+      } border-2 border-[#8800CC] bg-gradient-filters rounded-md flex flex-col items-center gap-1 h-fit relative z-[10] ${
         open ? "px-6 py-4" : "p-[10px]"
       }`}
       onClick={() => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -136,6 +136,8 @@ export default {
         "slide-content":
           "linear-gradient(to bottom, rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.75))",
         "gradient-top": "var(--gradient-top)",
+        "gradient-filters":
+          "linear-gradient(to bottom, #080808 100%, #080808 80%",
       },
       animation: {
         "fade-in": "fadeIn 0.3s ease-in-out",


### PR DESCRIPTION
this was not working locally for me. Im not familiar with the tailwind tooling, does it auto build custom classes or do you need to run some script before it builds new custom classes?