### PR TITLE
Animate piechart

### DIFF
--- a/components/shared/HoldersGraph.tsx
+++ b/components/shared/HoldersGraph.tsx
@@ -1,5 +1,4 @@
-import PieChart from "$components/shared/PieChart.tsx";
-
+import { HoldersPieChart } from "../../islands/charts/HoldersPieChart.tsx";
 import { abbreviateAddress } from "$lib/utils/formatUtils.ts";
 
 interface Holder {
@@ -72,7 +71,7 @@ export function HoldersGraph(
       </div>
       <div className="flex flex-col tablet:flex-row w-full gap-6">
         <div className="mt-6 tablet:-mt-24 flex justify-center tablet:justify-start">
-          <PieChart holders={holders} />
+          <HoldersPieChart holders={holders} />
         </div>
 
         <div className="relative w-full max-w-full">

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -137,6 +137,7 @@ import * as $about_AboutTeam from "./islands/about/AboutTeam.tsx";
 import * as $block_BlockHeader from "./islands/block/BlockHeader.tsx";
 import * as $block_BlockSelector from "./islands/block/BlockSelector.tsx";
 import * as $block_BlockTransactions from "./islands/block/BlockTransactions.tsx";
+import * as $charts_HoldersPieChart from "./islands/charts/HoldersPieChart.tsx";
 import * as $collection_ArtistCollection from "./islands/collection/ArtistCollection.tsx";
 import * as $collection_CollectionCreateButton from "./islands/collection/CollectionCreateButton.tsx";
 import * as $collection_CollectionDetailsContent from "./islands/collection/CollectionDetailsContent.tsx";
@@ -378,6 +379,7 @@ const manifest = {
     "./islands/block/BlockHeader.tsx": $block_BlockHeader,
     "./islands/block/BlockSelector.tsx": $block_BlockSelector,
     "./islands/block/BlockTransactions.tsx": $block_BlockTransactions,
+    "./islands/charts/HoldersPieChart.tsx": $charts_HoldersPieChart,
     "./islands/collection/ArtistCollection.tsx": $collection_ArtistCollection,
     "./islands/collection/CollectionCreateButton.tsx":
       $collection_CollectionCreateButton,

--- a/islands/charts/HoldersPieChart.tsx
+++ b/islands/charts/HoldersPieChart.tsx
@@ -1,4 +1,4 @@
-import { Chart } from "$fresh_charts/mod.ts";
+import { Chart } from "$fresh_charts/island.tsx";
 
 interface PieChartProps {
   holders: Array<{
@@ -8,7 +8,7 @@ interface PieChartProps {
   }>;
 }
 
-const PieChart = ({ holders }: PieChartProps) => {
+export const HoldersPieChart = ({ holders }: PieChartProps) => {
   if (!holders?.length) {
     return <div class="text-center py-4">No holder data available</div>;
   }
@@ -83,5 +83,3 @@ const PieChart = ({ holders }: PieChartProps) => {
     return <div class="text-center py-6">Error rendering chart</div>;
   }
 };
-
-export default PieChart;


### PR DESCRIPTION
Per issue from @babalicious-io , https://github.com/stampchain-io/BTCStampsExplorer/issues/404, chart to be animated, which requires moving the chart to and island instead of being purely server rendered.

This PR will add animations and interactivity to the chart such as hover for additional info.

https://github.com/user-attachments/assets/d338bdb0-ae46-49aa-b35c-4695410bc55a

