### PR TITLE
Search popup modal - DO NOT MERGE

### DIFF
--- a/islands/stamp/StampSearch.tsx
+++ b/islands/stamp/StampSearch.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 import { Button } from "$components/shared/Button.tsx";
 
 export function StampSearchClient(
@@ -8,7 +8,6 @@ export function StampSearchClient(
   },
 ) {
   const [searchTerm, setSearchTerm] = useState("");
-  const searchContainerRef = useRef<HTMLDivElement>(null);
 
   const handleSearch = () => {
     if (searchTerm.trim()) {
@@ -23,51 +22,35 @@ export function StampSearchClient(
   };
 
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (
-        searchContainerRef.current &&
-        !searchContainerRef.current.contains(event.target as Node)
-      ) {
+    const handleKeyboardShortcut = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "f") {
+        e.preventDefault();
+        handleOpen2(true);
+      }
+      if (e.key === "Escape" && open2) {
         handleOpen2(false);
       }
     };
 
-    if (open2) {
-      document.addEventListener("mousedown", handleClickOutside);
-    }
+    document.addEventListener("keydown", handleKeyboardShortcut);
+    return () =>
+      document.removeEventListener("keydown", handleKeyboardShortcut);
+  }, [open2, handleOpen2]);
 
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutside);
-    };
-  }, [open2]);
+  const modalBgBlur =
+    "fixed inset-0 z-50 flex items-start tablet:items-center justify-center overflow-hidden bg-[#000000] bg-opacity-60 backdrop-filter backdrop-blur-md";
+
+  const animatedInputContainer = `
+    relative rounded-md !bg-[#100318]
+    before:absolute before:inset-[-2px] before:rounded-md before:z-[1]
+    before:bg-[conic-gradient(from_var(--angle),#660099,#8800CC,#AA00FF,#8800CC,#660099)]
+    before:[--angle:0deg] before:animate-rotate
+    hover:before:bg-[conic-gradient(from_var(--angle),#AA00FF,#AA00FF,#AA00FF,#AA00FF,#AA00FF)]
+    focus-within:before:bg-[conic-gradient(from_var(--angle),#AA00FF,#AA00FF,#AA00FF,#AA00FF,#AA00FF)]
+  `;
 
   return (
-    <div class="relative z-20" ref={searchContainerRef}>
-      {open2 && (
-        <div class="absolute right-0 flex items-center z-20">
-          <div class="relative">
-            <input
-              type="text"
-              class="min-w-[260px] mobileMd:min-w-[340px] mobileLg:min-w-[380px] desktop:min-w-[460px] h-7 mobileMd:h-9 desktop:h-[42px] bg-stamp-purple-bright pl-3 pr-2 py-3 rounded-md text-sm mobileLg:text-base leading-tight text-black font-medium placeholder:text-stamp-purple-darkest placeholder:font-medium outline-none"
-              placeholder="STAMP #, CPID, ADDY OR TX HASH"
-              value={searchTerm}
-              onInput={(e) =>
-                setSearchTerm((e.target as HTMLInputElement).value)}
-              onKeyPress={handleKeyPress}
-            />
-          </div>
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 32 32"
-            class="absolute top-[7px] right-[7px] mobileMd:top-[9px] mobileMd:right-[9px] desktop:top-[11px] desktop:right-[11px] w-[14px] h-[14px] mobileMd:w-[18px] mobileMd:h-[18px] desktop:w-[20px] desktop:h-[20px] cursor-pointer fill-black"
-            onClick={() => handleOpen2(false)}
-            role="button"
-            aria-label="Search"
-          >
-            <path d="M29.0611 26.9387L23.1248 21C24.9047 18.6805 25.7357 15.7709 25.4492 12.8614C25.1627 9.95181 23.7802 7.26016 21.5821 5.33244C19.3841 3.40471 16.535 2.38527 13.613 2.4809C10.6909 2.57653 7.9146 3.78008 5.84728 5.8474C3.77996 7.91472 2.57641 10.691 2.48078 13.6131C2.38514 16.5351 3.40459 19.3842 5.33231 21.5823C7.26004 23.7803 9.95169 25.1628 12.8613 25.4493C15.7708 25.7358 18.6804 24.9048 20.9998 23.125L26.9411 29.0674C27.0806 29.207 27.2463 29.3177 27.4286 29.3932C27.6109 29.4687 27.8063 29.5076 28.0036 29.5076C28.2009 29.5076 28.3963 29.4687 28.5786 29.3932C28.7609 29.3177 28.9265 29.207 29.0661 29.0674C29.2056 28.9279 29.3163 28.7623 29.3918 28.58C29.4673 28.3977 29.5062 28.2023 29.5062 28.0049C29.5062 27.8076 29.4673 27.6122 29.3918 27.4299C29.3163 27.2476 29.2056 27.082 29.0661 26.9424L29.0611 26.9387ZM5.49983 14C5.49983 12.3188 5.99835 10.6754 6.93234 9.2776C7.86633 7.87979 9.19385 6.79032 10.747 6.14698C12.3002 5.50363 14.0093 5.3353 15.6581 5.66328C17.3069 5.99125 18.8215 6.8008 20.0102 7.98954C21.199 9.17829 22.0085 10.6928 22.3365 12.3417C22.6645 13.9905 22.4961 15.6996 21.8528 17.2528C21.2095 18.8059 20.12 20.1334 18.7222 21.0674C17.3244 22.0014 15.681 22.5 13.9998 22.5C11.7462 22.4976 9.58554 21.6014 7.99198 20.0078C6.39842 18.4142 5.50215 16.2536 5.49983 14Z" />
-          </svg>
-        </div>
-      )}
+    <>
       <Button
         variant="icon"
         icon={
@@ -82,13 +65,47 @@ export function StampSearchClient(
           </svg>
         }
         iconAlt="Search"
-        class={`hover:bg-stamp-purple-bright hover:border-stamp-purple-bright cursor-pointer ${
-          open2 ? "invisible" : ""
-        }`}
+        class="hover:bg-stamp-purple-bright hover:border-stamp-purple-bright cursor-pointer"
         onClick={() => handleOpen2(true)}
         role="button"
         aria-label="Search"
       />
-    </div>
+
+      {open2 && (
+        <div
+          class={modalBgBlur}
+          onClick={(e) => {
+            if (e.target === e.currentTarget) handleOpen2(false);
+          }}
+        >
+          <div class="w-[90%] max-w-[600px] mt-[72px] mobileLg:mt-24 tablet:mt-0">
+            <div className={animatedInputContainer}>
+              <div class="relative">
+                <input
+                  type="text"
+                  placeholder="STAMP #, CPID, ADDY OR TX HASH"
+                  value={searchTerm}
+                  onInput={(e) =>
+                    setSearchTerm((e.target as HTMLInputElement).value)}
+                  onKeyPress={handleKeyPress}
+                  class="relative z-[2] h-[54px] mobileLg:h-[60px] w-full !bg-[#100318] rounded-md pl-6 pr-[68px] text-base mobileLg:text-lg font-light text-stamp-grey-light placeholder:!bg-[#100318] placeholder:!text-stamp-grey active:!outline-none focus:!bg-[#100318]"
+                  autoFocus
+                />
+                <div class="absolute z-[3] right-6 top-1/2 -translate-y-1/2 pointer-events-none">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 32 32"
+                    class="w-5 h-5 mobileLg:w-6 mobileLg:h-6 fill-stamp-purple-bright"
+                    aria-hidden="true"
+                  >
+                    <path d="M29.0611 26.9387L23.1248 21C24.9047 18.6805 25.7357 15.7709 25.4492 12.8614C25.1627 9.95181 23.7802 7.26016 21.5821 5.33244C19.3841 3.40471 16.535 2.38527 13.613 2.4809C10.6909 2.57653 7.9146 3.78008 5.84728 5.8474C3.77996 7.91472 2.57641 10.691 2.48078 13.6131C2.38514 16.5351 3.40459 19.3842 5.33231 21.5823C7.26004 23.7803 9.95169 25.1628 12.8613 25.4493C15.7708 25.7358 18.6804 24.9048 20.9998 23.125L26.9411 29.0674C27.0806 29.207 27.2463 29.3177 27.4286 29.3932C27.6109 29.4687 27.8063 29.5076 28.0036 29.5076C28.2009 29.5076 28.3963 29.4687 28.5786 29.3932C28.7609 29.3177 28.9265 29.207 29.0661 29.0674C29.2056 28.9279 29.3163 28.7623 29.3918 28.58C29.4673 28.3977 29.5062 28.2023 29.5062 28.0049C29.5062 27.8076 29.4673 27.6122 29.3918 27.4299C29.3163 27.2476 29.2056 27.082 29.0661 26.9424L29.0611 26.9387ZM5.49983 14C5.49983 12.3188 5.99835 10.6754 6.93234 9.2776C7.86633 7.87979 9.19385 6.79032 10.747 6.14698C12.3002 5.50363 14.0093 5.3353 15.6581 5.66328C17.3069 5.99125 18.8215 6.8008 20.0102 7.98954C21.199 9.17829 22.0085 10.6928 22.3365 12.3417C22.6645 13.9905 22.4961 15.6996 21.8528 17.2528C21.2095 18.8059 20.12 20.1334 18.7222 21.0674C17.3244 22.0014 15.681 22.5 13.9998 22.5C11.7462 22.4976 9.58554 21.6014 7.99198 20.0078C6.39842 18.4142 5.50215 16.2536 5.49983 14Z" />
+                  </svg>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
**DO NOT MERGE**

<img width="500" alt="Screenshot 2024-12-23 at 01 07 07" src="https://github.com/user-attachments/assets/a5e9b811-7738-4cf2-b109-07476922d12b" />
<img width="1180" alt="Screenshot 2024-12-23 at 01 06 52" src="https://github.com/user-attachments/assets/575afb11-ace4-423e-9298-ab5c6759b486" />


Experimenting with another design for the searchbar
Testing on stamp search (stamp overview - all)

Modal popup on press of search icon button or command/ctrl+F (find) - can be whatever key
Close on click outside of input field or ESC

We can create a global island component for the search functionality and add it to the root layout component
This means the user can keyboard access the searchbar anytime/anywhere on site by cmd/ctrl+F
We need to have global search at that point (search stamps/tokens/bitnames) for it to make sense)
Could start with including it on the stamp details pages - and the src20 search on token details pages

**DO NOT MERGE** - this is for testing only
