### PR TITLE
Select Buy listings

### DIFF
--- a/components/shared/HoldersGraph.tsx
+++ b/components/shared/HoldersGraph.tsx
@@ -13,9 +13,9 @@ interface HoldersGraphProps {
 }
 
 const tableHeaders = [
-  { key: "address", label: "Address" },
-  { key: "amount", label: "Amount" },
-  { key: "percent", label: "Percent" },
+  { key: "address", label: "Address", width: "w-[50%]", align: "text-left" },
+  { key: "amount", label: "Amount", width: "w-[25%]", align: "text-center" },
+  { key: "percent", label: "Percent", width: "w-[25%]", align: "text-right" },
 ];
 
 const dataLabel =
@@ -26,41 +26,37 @@ const tableLabel =
   "text-sm mobileLg:text-base font-light text-stamp-grey-darker uppercase";
 const tableValue =
   "text-xs mobileLg:text-sm font-normal text-stamp-grey-light w-full";
-const row = "h-8 hover:bg-stamp-purple/10";
+const row = "h-8 hover:bg-stamp-purple/10 group cursor-pointer";
 
 function HolderRow({ holder }: { holder: Holder }) {
-  const handleClick = (e: MouseEvent, address: string) => {
-    e.preventDefault();
-    globalThis.location.href = `/wallet/${address}`;
-  };
+  if (!holder.address) {
+    return (
+      <tr className={row}>
+        <td className="text-left">Unknown</td>
+        <td className="text-center">{holder.amt}</td>
+        <td className="text-right">{holder.percentage}%</td>
+      </tr>
+    );
+  }
 
   return (
     <tr className={row}>
-      <td className="text-left">
-        {holder.address
-          ? (
-            <a
-              href={`/wallet/${holder.address}`}
-              onClick={(e) => handleClick(e, holder.address)}
-              className="hover:text-stamp-purple-bright cursor-pointer"
-            >
-              <span className="mobileLg:hidden">
-                {abbreviateAddress(holder.address, 8)}
-              </span>
-              <span className="hidden mobileLg:inline">
-                {holder.address}
-              </span>
-            </a>
-          )
-          : (
-            "Unknown"
-          )}
-      </td>
-      <td className="text-center">
-        {holder.amt}
-      </td>
-      <td className="text-right">
-        {holder.percentage}%
+      <td colSpan={3} className="p-0">
+        <a
+          href={`/wallet/${holder.address}`}
+          className="flex w-full"
+        >
+          <span className="w-[50%] text-left group-hover:text-stamp-purple-bright">
+            <span className="mobileLg:hidden">
+              {abbreviateAddress(holder.address, 8)}
+            </span>
+            <span className="hidden mobileLg:inline">
+              {holder.address}
+            </span>
+          </span>
+          <span className="w-[25%] text-center">{holder.amt}</span>
+          <span className="w-[25%] text-right">{holder.percentage}%</span>
+        </a>
       </td>
     </tr>
   );
@@ -93,17 +89,11 @@ export function HoldersGraph({ holders = [] }: HoldersGraphProps) {
             <table className={`${tableValue} table-auto`}>
               <thead className={tableLabel}>
                 <tr>
-                  {tableHeaders.map(({ key, label }) => (
+                  {tableHeaders.map(({ key, label, width, align }) => (
                     <th
                       key={key}
                       scope="col"
-                      class={`${tableLabel} pb-1.5 ${
-                        key === "address"
-                          ? "text-left"
-                          : key === "percent"
-                          ? "text-right"
-                          : "text-center"
-                      }`}
+                      className={`${tableLabel} pb-1.5 ${width} ${align}`}
                     >
                       {label}
                     </th>

--- a/components/stampDetails/StampListingsAll.tsx
+++ b/components/stampDetails/StampListingsAll.tsx
@@ -1,0 +1,126 @@
+import {
+  abbreviateAddress,
+  formatNumber,
+  formatSatoshisToBTC,
+} from "$lib/utils/formatUtils.ts";
+import { ScrollContainer } from "../shared/ScrollContainer.tsx";
+
+interface Dispenser {
+  source: string;
+  give_remaining: number;
+  escrow_quantity: number;
+  give_quantity: number;
+  satoshirate: number;
+  confirmed: boolean;
+  close_block_index: number;
+}
+
+interface StampListingsAllProps {
+  dispensers: Dispenser[];
+}
+
+const tableHeaders = [
+  { key: "price", label: "Price" },
+  { key: "escrow", label: "Escrow" },
+  { key: "give", label: "Give" },
+  { key: "remaining", label: "Remain" },
+  { key: "address", label: "Address" },
+  { key: "confirmed", label: "Confirmed" },
+  { key: "closeBlock", label: "Closed" },
+];
+
+const tableLabel =
+  "text-sm mobileLg:text-base font-light text-stamp-grey-darker uppercase";
+const tableValue =
+  "text-xs mobileLg:text-sm font-normal text-stamp-grey-light w-full";
+
+function DispenserRow({ dispenser }: { dispenser: Dispenser }) {
+  const isEmpty = dispenser.give_remaining === 0;
+  const rowDispensers = `${
+    isEmpty ? "text-stamp-grey-darker" : ""
+  } h-8 hover:bg-stamp-purple/10`;
+
+  return (
+    <tr class={rowDispensers}>
+      <td className="text-left">
+        {formatSatoshisToBTC(dispenser.satoshirate)}
+      </td>
+      <td className="text-center">
+        {formatNumber(dispenser.escrow_quantity, 0)}
+      </td>
+      <td className="text-center">
+        {formatNumber(dispenser.give_quantity, 0)}
+      </td>
+      <td className="text-center">
+        {formatNumber(dispenser.give_remaining, 0)}
+      </td>
+      <td className="text-center">
+        <span className="tablet:hidden">
+          {abbreviateAddress(dispenser.source, 4)}
+        </span>
+        <span className="hidden tablet:inline">
+          {abbreviateAddress(dispenser.source, 8)}
+        </span>
+      </td>
+      <td className="text-center">
+        {dispenser.confirmed ? "YES" : "NO"}
+      </td>
+      <td className="text-right">
+        {!dispenser.close_block_index || dispenser.close_block_index <= 0
+          ? "OPEN"
+          : dispenser.close_block_index}
+      </td>
+    </tr>
+  );
+}
+
+export function StampListings({ dispensers }: StampListingsAllProps) {
+  // TODO(@reinamora_137): the secondary sort should be by creation date
+  const sortedDispensers = [...dispensers].sort((a, b) =>
+    b.give_remaining - a.give_remaining
+  );
+
+  return (
+    <div class="relative w-full">
+      <ScrollContainer class="max-h-48">
+        <div class="w-[660px] min-[660px]:w-full">
+          <table class={tableValue}>
+            <colgroup>
+              <col class="w-[16%]" /> {/* Price */}
+              <col class="w-[10%]" /> {/* Escrow */}
+              <col class="w-[10%]" /> {/* Give */}
+              <col class="w-[10%]" /> {/* Remain */}
+              <col class="w-[26%]" /> {/* Address column */}
+              <col class="w-[14%]" /> {/* Confirmed */}
+              <col class="w-[14%]" /> {/* Closed */}
+            </colgroup>
+            <thead>
+              <tr>
+                {tableHeaders.map(({ key, label }) => (
+                  <th
+                    key={key}
+                    scope="col"
+                    class={`${tableLabel} pb-1.5 ${
+                      key === "price"
+                        ? "text-left"
+                        : key === "closeBlock"
+                        ? "text-right"
+                        : "text-center"
+                    }`}
+                  >
+                    {label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sortedDispensers.map((dispenser) => (
+                <DispenserRow key={dispenser.source} dispenser={dispenser} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </ScrollContainer>
+    </div>
+  );
+}

--- a/components/stampDetails/StampListingsAll.tsx
+++ b/components/stampDetails/StampListingsAll.tsx
@@ -74,7 +74,7 @@ function DispenserRow({ dispenser }: { dispenser: Dispenser }) {
   );
 }
 
-export function StampListings({ dispensers }: StampListingsAllProps) {
+export function StampListingsAll({ dispensers }: StampListingsAllProps) {
   // TODO(@reinamora_137): the secondary sort should be by creation date
   const sortedDispensers = [...dispensers].sort((a, b) =>
     b.give_remaining - a.give_remaining

--- a/components/stampDetails/StampListingsOpen.tsx
+++ b/components/stampDetails/StampListingsOpen.tsx
@@ -13,6 +13,7 @@ interface Dispenser {
 
 interface StampListingsOpenProps {
   dispensers: Dispenser[];
+  floorPrice: number;
 }
 
 const tableHeaders = [
@@ -27,14 +28,24 @@ const tableLabel =
 const tableValue =
   "text-xs mobileLg:text-sm font-normal text-stamp-grey-light w-full";
 
-function DispenserRow({ dispenser }: { dispenser: Dispenser }) {
+function DispenserRow(
+  { dispenser, floorPrice }: { dispenser: Dispenser; floorPrice: number },
+) {
   const isEmpty = dispenser.give_remaining === 0;
+
+  // Convert satoshirate to BTC for comparison
+  const dispenserBTC = dispenser.satoshirate / 100000000;
+
   const rowDispensers = `${
     isEmpty ? "text-stamp-grey-darker" : ""
-  } h-8 hover:bg-stamp-purple/10`;
+  } h-8 hover:bg-stamp-purple/10 ${
+    dispenserBTC === floorPrice
+      ? "text-stamp-grey-light"
+      : "text-stamp-grey-darker"
+  }`;
 
   return (
-    <tr class={rowDispensers}>
+    <tr className={rowDispensers}>
       <td className="text-left">
         {formatSatoshisToBTC(dispenser.satoshirate)}
       </td>
@@ -53,7 +64,9 @@ function DispenserRow({ dispenser }: { dispenser: Dispenser }) {
   );
 }
 
-export function StampListingsOpen({ dispensers }: StampListingsOpenProps) {
+export function StampListingsOpen(
+  { dispensers, floorPrice }: StampListingsOpenProps,
+) {
   const sortedDispensers = [...dispensers].sort((a, b) =>
     b.give_remaining - a.give_remaining
   );
@@ -90,7 +103,11 @@ export function StampListingsOpen({ dispensers }: StampListingsOpenProps) {
             </thead>
             <tbody>
               {sortedDispensers.map((dispenser) => (
-                <DispenserRow key={dispenser.source} dispenser={dispenser} />
+                <DispenserRow
+                  key={dispenser.source}
+                  dispenser={dispenser}
+                  floorPrice={floorPrice}
+                />
               ))}
             </tbody>
           </table>

--- a/components/stampDetails/StampListingsOpen.tsx
+++ b/components/stampDetails/StampListingsOpen.tsx
@@ -22,9 +22,10 @@ interface StampListingsOpenProps {
 
 const tableHeaders = [
   { key: "price", label: "Price" },
-  { key: "quantity", label: "Escrow/Give" },
-  { key: "remaining", label: "Remain" },
-  { key: "type", label: "Type" },
+  { key: "escrow", label: "Escrow" },
+  { key: "give", label: "Give" },
+  { key: "remain", label: "Remain" },
+  { key: "from", label: "From" },
 ];
 
 const tableLabel =
@@ -54,7 +55,7 @@ export function StampListingsOpen({
 
     const rowDispensers = `${
       isEmpty ? "text-stamp-grey-darker" : ""
-    } h-8 hover:bg-stamp-purple/10 cursor-pointer ${
+    } h-8 hover:bg-stamp-purple/10 cursor-pointer group ${
       isSelected || (!selectedDispenser && isFloorPrice)
         ? "text-stamp-grey-light"
         : "text-stamp-grey-darker"
@@ -65,13 +66,14 @@ export function StampListingsOpen({
         className={rowDispensers}
         onClick={onSelect}
       >
-        <td className="text-left">
+        <td className="text-left group-hover:text-stamp-purple-bright">
           {formatSatoshisToBTC(dispenser.satoshirate)}
         </td>
         <td className="text-center">
-          {`${formatNumber(dispenser.escrow_quantity, 0)}/${
-            formatNumber(dispenser.give_quantity, 0)
-          }`}
+          {formatNumber(dispenser.escrow_quantity, 0)}
+        </td>
+        <td className="text-center">
+          {formatNumber(dispenser.give_quantity, 0)}
         </td>
         <td className="text-center">
           {formatNumber(dispenser.give_remaining, 0)}
@@ -87,20 +89,35 @@ export function StampListingsOpen({
     return <div>No listings available</div>;
   }
 
-  const sortedDispensers = [...dispensers].sort((a, b) =>
-    b.give_remaining - a.give_remaining
-  );
+  const sortedDispensers = [...dispensers]
+    .filter((dispenser) => dispenser.give_remaining > 0)
+    .sort((a, b) => b.give_remaining - a.give_remaining);
+
+  if (sortedDispensers.length === 0) {
+    return <div>No listings available</div>;
+  }
 
   return (
     <div class="relative w-full">
       <ScrollContainer class="max-h-48">
-        <div class="w-[660px] min-[660px]:w-full">
-          <table class={tableValue}>
+        <div class="w-full">
+          <table class={`${tableValue} w-full`}>
             <colgroup>
-              <col class="w-[25%]" /> {/* Price */}
-              <col class="w-[25%]" /> {/* Quantity */}
-              <col class="w-[25%]" /> {/* Remain */}
-              <col class="w-[25%]" /> {/* Type */}
+              <col class="w-[35%] min-[420px]:w-[23%] min-[880px]:w-[35%] min-[1080px]:w-[23%]" />
+              {" "}
+              {/* Price */}
+              <col class="w-[14%] min-[420px]:w-[18%] min-[880px]:w-[14%] min-[1080px]:w-[18%]" />
+              {" "}
+              {/* Escrow */}
+              <col class="w-[14%] min-[420px]:w-[18%] min-[880px]:w-[14%] min-[1080px]:w-[18%]" />
+              {" "}
+              {/* Give */}
+              <col class="w-[14%] min-[420px]:w-[18%] min-[880px]:w-[14%] min-[1080px]:w-[18%]" />
+              {" "}
+              {/* Remain */}
+              <col class="w-[23%] min-[420px]:w-[23%] min-[880px]:w-[23%] min-[1080px]:w-[23%]" />
+              {" "}
+              {/* From */}
             </colgroup>
             <thead>
               <tr>
@@ -111,7 +128,7 @@ export function StampListingsOpen({
                     class={`${tableLabel} pb-1.5 ${
                       key === "price"
                         ? "text-left"
-                        : key === "type"
+                        : key === "from"
                         ? "text-right"
                         : "text-center"
                     }`}

--- a/components/stampDetails/StampListingsOpen.tsx
+++ b/components/stampDetails/StampListingsOpen.tsx
@@ -1,8 +1,4 @@
-import {
-  abbreviateAddress,
-  formatNumber,
-  formatSatoshisToBTC,
-} from "$lib/utils/formatUtils.ts";
+import { formatNumber, formatSatoshisToBTC } from "$lib/utils/formatUtils.ts";
 import { ScrollContainer } from "../shared/ScrollContainer.tsx";
 
 interface Dispenser {
@@ -15,18 +11,15 @@ interface Dispenser {
   close_block_index: number;
 }
 
-interface StampDispensersProps {
+interface StampListingsOpenProps {
   dispensers: Dispenser[];
 }
 
 const tableHeaders = [
   { key: "price", label: "Price" },
-  { key: "escrow", label: "Escrow" },
-  { key: "give", label: "Give" },
+  { key: "quantity", label: "Escrow/Give" },
   { key: "remaining", label: "Remain" },
-  { key: "address", label: "Address" },
-  { key: "confirmed", label: "Confirmed" },
-  { key: "closeBlock", label: "Closed" },
+  { key: "type", label: "Type" },
 ];
 
 const tableLabel =
@@ -46,36 +39,21 @@ function DispenserRow({ dispenser }: { dispenser: Dispenser }) {
         {formatSatoshisToBTC(dispenser.satoshirate)}
       </td>
       <td className="text-center">
-        {formatNumber(dispenser.escrow_quantity, 0)}
-      </td>
-      <td className="text-center">
-        {formatNumber(dispenser.give_quantity, 0)}
+        {`${formatNumber(dispenser.escrow_quantity, 0)}/${
+          formatNumber(dispenser.give_quantity, 0)
+        }`}
       </td>
       <td className="text-center">
         {formatNumber(dispenser.give_remaining, 0)}
       </td>
-      <td className="text-center">
-        <span className="tablet:hidden">
-          {abbreviateAddress(dispenser.source, 4)}
-        </span>
-        <span className="hidden tablet:inline">
-          {abbreviateAddress(dispenser.source, 8)}
-        </span>
-      </td>
-      <td className="text-center">
-        {dispenser.confirmed ? "YES" : "NO"}
-      </td>
       <td className="text-right">
-        {!dispenser.close_block_index || dispenser.close_block_index <= 0
-          ? "OPEN"
-          : dispenser.close_block_index}
+        DISPENSER
       </td>
     </tr>
   );
 }
 
-export function StampDispensers({ dispensers }: StampDispensersProps) {
-  // TODO(@reinamora_137): the secondary sort should be by creation date
+export function StampListingsOpen({ dispensers }: StampListingsOpenProps) {
   const sortedDispensers = [...dispensers].sort((a, b) =>
     b.give_remaining - a.give_remaining
   );
@@ -86,13 +64,10 @@ export function StampDispensers({ dispensers }: StampDispensersProps) {
         <div class="w-[660px] min-[660px]:w-full">
           <table class={tableValue}>
             <colgroup>
-              <col class="w-[16%]" /> {/* Price */}
-              <col class="w-[10%]" /> {/* Escrow */}
-              <col class="w-[10%]" /> {/* Give */}
-              <col class="w-[10%]" /> {/* Remain */}
-              <col class="w-[26%]" /> {/* Address column */}
-              <col class="w-[14%]" /> {/* Confirmed */}
-              <col class="w-[14%]" /> {/* Closed */}
+              <col class="w-[25%]" /> {/* Price */}
+              <col class="w-[25%]" /> {/* Quantity */}
+              <col class="w-[25%]" /> {/* Remain */}
+              <col class="w-[25%]" /> {/* Type */}
             </colgroup>
             <thead>
               <tr>
@@ -103,7 +78,7 @@ export function StampDispensers({ dispensers }: StampDispensersProps) {
                     class={`${tableLabel} pb-1.5 ${
                       key === "price"
                         ? "text-left"
-                        : key === "closeBlock"
+                        : key === "type"
                         ? "text-right"
                         : "text-center"
                     }`}

--- a/islands/stamp/details/StampImage.tsx
+++ b/islands/stamp/details/StampImage.tsx
@@ -582,7 +582,11 @@ export function StampImage(
 
       {src !== NOT_AVAILABLE_IMAGE && isHtml && (
         <div className={`${className} flex flex-col gap-3 mobileMd:gap-6`}>
-          <div className="relative dark-gradient rounded-lg p-3 mobileMd:p-6">
+          <div
+            className={`relative ${
+              flag ? "dark-gradient rounded-lg p-3 mobileMd:p-6" : ""
+            }`}
+          >
             <div className="stamp-container">
               <div className="relative pt-[100%]">
                 <iframe

--- a/islands/stamp/details/StampImage.tsx
+++ b/islands/stamp/details/StampImage.tsx
@@ -617,7 +617,23 @@ export function StampImage(
       )}
 
       {src !== NOT_AVAILABLE_IMAGE && isPlainText && (
-        <TextContentIsland src={src} />
+        <div className="flex flex-col gap-3 mobileMd:gap-6">
+          <div className="relative dark-gradient rounded-lg p-3 mobileMd:p-6">
+            <div className="stamp-container">
+              <div className="relative aspect-square">
+                <TextContentIsland src={src} className={className} />
+              </div>
+            </div>
+          </div>
+          {flag && (
+            <RightPanel
+              stamp={stamp}
+              toggleCodeModal={toggleCodeModal}
+              toggleFullScreenModal={toggleFullScreenModal}
+              showCodeButton={false}
+            />
+          )}
+        </div>
       )}
 
       {src !== NOT_AVAILABLE_IMAGE && isAudio && (
@@ -704,7 +720,11 @@ export function StampImage(
         <StampImageFullScreen
           src={src}
           handleCloseModal={handleCloseFullScreenModal}
-          contentType={stamp.stamp_mimetype === "text/html" ? "html" : "image"}
+          contentType={stamp.stamp_mimetype === "text/html"
+            ? "html"
+            : stamp.stamp_mimetype === "text/plain"
+            ? "text"
+            : "image"}
         />
       )}
     </>

--- a/islands/stamp/details/StampImageFullScreen.tsx
+++ b/islands/stamp/details/StampImageFullScreen.tsx
@@ -1,10 +1,11 @@
 import { useEffect } from "preact/hooks";
 import { handleImageError } from "$lib/utils/imageUtils.ts";
+import TextContentIsland from "$islands/stamp/details/StampTextContent.tsx";
 
 interface StampImageFullScreenProps {
   src: string | File;
   handleCloseModal: () => void;
-  contentType?: "html" | "image";
+  contentType?: "html" | "text" | "image";
 }
 
 const StampImageFullScreen = ({
@@ -69,6 +70,12 @@ const StampImageFullScreen = ({
                     loading="lazy"
                     title="Stamp Preview"
                   />
+                )
+                : contentType === "text"
+                ? (
+                  <div className="w-full h-full rounded-sm mobileMd:rounded-md aspect-square">
+                    <TextContentIsland src={imageUrl} />
+                  </div>
                 )
                 : (
                   <img

--- a/islands/stamp/details/StampInfo.tsx
+++ b/islands/stamp/details/StampInfo.tsx
@@ -586,6 +586,7 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
                       totalPages={totalPages}
                       onPageChange={handlePageChange}
                       isLoading={isLoadingDispensers}
+                      floorPrice={stamp.floorPrice}
                     />
                   )}
               </div>

--- a/islands/stamp/details/StampInfo.tsx
+++ b/islands/stamp/details/StampInfo.tsx
@@ -99,6 +99,8 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
     "absolute left-1/2 -translate-x-1/2 bg-[#000000BF] px-2 py-1 rounded-sm bottom-full text-[10px] mobileLg:text-xs text-stamp-grey-light whitespace-nowrap transition-opacity duration-300";
   const buttonPurpleFlat =
     "inline-flex items-center justify-center bg-stamp-purple border-2 border-stamp-purple rounded-md text-sm mobileLg:text-base font-extrabold text-black tracking-[0.05em] h-[42px] mobileLg:h-[48px] px-4 mobileLg:px-5 hover:border-stamp-purple-highlight hover:bg-stamp-purple-highlight transition-colors";
+  const buttonPurpleOutline =
+    "inline-flex items-center justify-center border-2 border-stamp-purple rounded-md text-sm mobileLg:text-base font-extrabold text-stamp-purple tracking-[0.05em] h-[42px] mobileLg:h-12 hover:border-stamp-purple-bright hover:text-stamp-purple-bright transition-colors";
 
   // Add tooltip states
   const [isDivisibleTooltipVisible, setIsDivisibleTooltipVisible] = useState(
@@ -594,81 +596,88 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
             </div>
           </div>
 
-          <div className="flex flex-col w-full pt-6 mobileLg:pt-12 text-right">
-            {/* Debug price values */}
-            {console.log("Rendering prices:", {
-              displayPrice,
-              displayPriceUSD,
-            })}
+          {(dispensers?.length > 0 || stamp.floorPrice)
+            ? (
+              <div className="flex flex-col w-full pt-6 mobileLg:pt-12 text-right">
+                {/* Debug price values */}
+                {console.log("Rendering prices:", {
+                  displayPrice,
+                  displayPriceUSD,
+                })}
 
-            {(displayPriceUSD || stamp.floorPriceUSD) && (
-              <p className={dataLabel}>
-                {displayPriceUSD?.toLocaleString("en-US", {
-                  maximumFractionDigits: 2,
-                }) || stamp.floorPriceUSD?.toLocaleString("en-US", {
-                  maximumFractionDigits: 2,
-                })} <span className="font-light">USD</span>
-              </p>
-            )}
+                {(displayPriceUSD || stamp.floorPriceUSD) && (
+                  <p className={dataLabel}>
+                    {displayPriceUSD?.toLocaleString("en-US", {
+                      maximumFractionDigits: 2,
+                    }) || stamp.floorPriceUSD?.toLocaleString("en-US", {
+                      maximumFractionDigits: 2,
+                    })} <span className="font-light">USD</span>
+                  </p>
+                )}
 
-            <p className={dataValueXl}>
-              {(!displayPrice || displayPrice === "NOT LISTED") &&
-                  stamp.marketCap &&
-                  typeof stamp.marketCap === "number"
-                ? formatBTCAmount(stamp.marketCap, { excludeSuffix: true })
-                : typeof displayPrice === "number"
-                ? formatBTCAmount(displayPrice, { excludeSuffix: true })
-                : displayPrice} {(typeof displayPrice === "number" ||
-                  (stamp.marketCap && typeof stamp.marketCap === "number")) && (
-                <span className="font-extralight">BTC</span>
-              )}
-            </p>
+                <div className="w-full">
+                  {/* Price and listings icon row */}
+                  <div className="flex w-full gap-3 mobileLg:gap-6 mb-3 mobileLg:mb-6 justify-between">
+                    <button
+                      onClick={() => setShowListings(!showListings)}
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 32 32"
+                        className="w-6 h-6 mobileLg:w-[28px] mobileLg:h-[28px] fill-stamp-grey-darker hover:fill-stamp-grey-light cursor-pointer"
+                        role="button"
+                        aria-label="Listings"
+                      >
+                        <path d="M4 8C4 7.73478 4.10536 7.48043 4.29289 7.29289C4.48043 7.10536 4.73478 7 5 7H27C27.2652 7 27.5196 7.10536 27.7071 7.29289C27.8946 7.48043 28 7.73478 28 8C28 8.26522 27.8946 8.51957 27.7071 8.70711C27.5196 8.89464 27.2652 9 27 9H5C4.73478 9 4.48043 8.89464 4.29289 8.70711C4.10536 8.51957 4 8.26522 4 8ZM5 17H12C12.2652 17 12.5196 16.8946 12.7071 16.7071C12.8946 16.5196 13 16.2652 13 16C13 15.7348 12.8946 15.4804 12.7071 15.2929C12.5196 15.1054 12.2652 15 12 15H5C4.73478 15 4.48043 15.1054 4.29289 15.2929C4.10536 15.4804 4 15.7348 4 16C4 16.2652 4.10536 16.5196 4.29289 16.7071C4.48043 16.8946 4.73478 17 5 17ZM14 23H5C4.73478 23 4.48043 23.1054 4.29289 23.2929C4.10536 23.4804 4 23.7348 4 24C4 24.2652 4.10536 24.5196 4.29289 24.7071C4.48043 24.8946 4.73478 25 5 25H14C14.2652 25 14.5196 24.8946 14.7071 24.7071C14.8946 24.5196 15 24.2652 15 24C15 23.7348 14.8946 23.4804 14.7071 23.2929C14.5196 23.1054 14.2652 23 14 23ZM29.6362 17.9725L26.8213 20.2962L27.6787 23.76C27.7258 23.951 27.7154 24.1516 27.649 24.3367C27.5826 24.5218 27.463 24.6832 27.3053 24.8008C27.1476 24.9183 26.9588 24.9867 26.7624 24.9975C26.566 25.0083 26.3708 24.9609 26.2013 24.8612L23 22.9775L19.7987 24.8612C19.6292 24.9609 19.434 25.0083 19.2376 24.9975C19.0412 24.9867 18.8524 24.9183 18.6947 24.8008C18.537 24.6832 18.4174 24.5218 18.351 24.3367C18.2846 24.1516 18.2742 23.951 18.3213 23.76L19.1775 20.2962L16.3638 17.9725C16.2103 17.8456 16.0983 17.6758 16.0419 17.4848C15.9856 17.2938 15.9876 17.0903 16.0476 16.9005C16.1076 16.7106 16.2229 16.543 16.3788 16.4191C16.5347 16.2952 16.724 16.2206 16.9225 16.205L20.6525 15.9163L22.0812 12.6038C22.1585 12.4241 22.2866 12.271 22.4499 12.1635C22.6132 12.0559 22.8045 11.9986 23 11.9986C23.1955 11.9986 23.3868 12.0559 23.5501 12.1635C23.7134 12.271 23.8415 12.4241 23.9188 12.6038L25.3475 15.9163L29.0775 16.205C29.276 16.2206 29.4653 16.2952 29.6212 16.4191C29.7771 16.543 29.8924 16.7106 29.9524 16.9005C30.0124 17.0903 30.0144 17.2938 29.9581 17.4848C29.9018 17.6758 29.7897 17.8456 29.6362 17.9725ZM26.4525 18.0075L24.5912 17.8638C24.4097 17.8498 24.2354 17.7866 24.0871 17.6808C23.9389 17.5751 23.8223 17.4309 23.75 17.2638L23 15.5238L22.25 17.2638C22.1777 17.4309 22.0611 17.5751 21.9129 17.6808C21.7646 17.7866 21.5903 17.8498 21.4088 17.8638L19.5475 18.0075L20.9363 19.155C21.0817 19.2749 21.1903 19.4334 21.2496 19.6123C21.3089 19.7912 21.3164 19.9833 21.2712 20.1663L20.8337 21.9312L22.4925 20.955C22.6463 20.8644 22.8215 20.8167 23 20.8167C23.1785 20.8167 23.3537 20.8644 23.5075 20.955L25.1663 21.9312L24.7288 20.1663C24.6836 19.9833 24.6911 19.7912 24.7504 19.6123C24.8097 19.4334 24.9183 19.2749 25.0637 19.155L26.4525 18.0075Z" />
+                      </svg>
+                    </button>
 
-            <div className="flex w-full justify-between items-end mt-3 mobileMd:mt-6">
-              <button
-                onClick={() => setShowListings((prev) => !prev)}
-                className="flex items-center"
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  viewBox="0 0 32 32"
-                  className="w-6 h-6 mobileLg:w-[28px] mobileLg:h-[28px] fill-stamp-grey-darker hover:fill-stamp-grey-light cursor-pointer"
-                  role="button"
-                  aria-label="Listings"
-                >
-                  <path d="M4 8C4 7.73478 4.10536 7.48043 4.29289 7.29289C4.48043 7.10536 4.73478 7 5 7H27C27.2652 7 27.5196 7.10536 27.7071 7.29289C27.8946 7.48043 28 7.73478 28 8C28 8.26522 27.8946 8.51957 27.7071 8.70711C27.5196 8.89464 27.2652 9 27 9H5C4.73478 9 4.48043 8.89464 4.29289 8.70711C4.10536 8.51957 4 8.26522 4 8ZM5 17H27C27.2652 17 27.5196 16.8946 27.7071 16.7071C27.8946 16.5196 28 16.2652 28 16C28 15.7348 27.8946 15.4804 27.7071 15.2929C27.5196 15.1054 27.2652 15 27 15H5C4.73478 15 4.48043 15.1054 4.29289 15.2929C4.10536 15.4804 4 15.7348 4 16C4 16.2652 4.10536 16.5196 4.29289 16.7071C4.48043 16.8946 4.73478 17 5 17ZM18 23H5C4.73478 23 4.48043 23.1054 4.29289 23.2929C4.10536 23.4804 4 23.7348 4 24C4 24.2652 4.10536 24.5196 4.29289 24.7071C4.48043 24.8946 4.73478 25 5 25H18C18.2652 25 18.5196 24.8946 18.7071 24.7071C18.8946 24.5196 19 24.2652 19 24C19 23.7348 18.8946 23.4804 18.7071 23.2929C18.5196 23.1054 18.2652 23 18 23ZM29 23H27V21C27 20.7348 26.8946 20.4804 26.7071 20.2929C26.5196 20.1054 26.2652 20 26 20C25.7348 20 25.4804 20.1054 25.2929 20.2929C25.1054 20.4804 25 20.7348 25 21V23H23C22.7348 23 22.4804 23.1054 22.2929 23.2929C22.1054 23.4804 22 23.7348 22 24C22 24.2652 22.1054 24.5196 22.2929 24.7071C22.4804 24.8946 22.7348 25 23 25H25V27C25 27.2652 25.1054 27.5196 25.2929 27.7071C25.4804 27.8946 25.7348 28 26 28C26.2652 28 26.5196 27.8946 26.7071 27.7071C26.8946 27.5196 27 27.2652 27 27V25H29C29.2652 25 29.5196 24.8946 29.7071 24.7071C29.8946 24.5196 30 24.2652 30 24C30 23.7348 29.8946 23.4804 29.7071 23.2929C29.5196 23.1054 29.2652 23 29 23Z" />
-                </svg>
-              </button>
-              {(selectedDispenser || lowestPriceDispenser) && (
-                <button
-                  className={`${buttonPurpleFlat}`}
-                  onClick={() =>
-                    toggleModal(selectedDispenser || lowestPriceDispenser)}
-                >
-                  BUY
-                </button>
-              )}
-            </div>
+                    <p className={dataValueXl}>
+                      {(!displayPrice || displayPrice === "NOT LISTED") &&
+                          stamp.marketCap &&
+                          typeof stamp.marketCap === "number"
+                        ? formatBTCAmount(stamp.marketCap, {
+                          excludeSuffix: true,
+                        })
+                        : typeof displayPrice === "number"
+                        ? formatBTCAmount(displayPrice, { excludeSuffix: true })
+                        : displayPrice} {(typeof displayPrice === "number" ||
+                          (stamp.marketCap &&
+                            typeof stamp.marketCap === "number")) &&
+                        <span className="font-extralight">BTC</span>}
+                    </p>
+                  </div>
 
-            {showListings && (
-              <div className="flex flex-col gap-2 text-stamp-grey-light text-sm text-left mt-3 mobileMd:mt-6">
-                {isLoadingDispensers
-                  ? <p>Loading listings...</p>
-                  : (
-                    <StampListingsOpen
-                      dispensers={dispensers}
-                      currentPage={currentPage}
-                      totalPages={totalPages}
-                      onPageChange={handlePageChange}
-                      isLoading={isLoadingDispensers}
-                      floorPrice={stamp.floorPrice}
-                      onSelectDispenser={handleDispenserSelect}
-                      selectedDispenser={selectedDispenser}
-                    />
+                  {/* Listings content */}
+                  {showListings && (
+                    <div className="w-full mb-3 mobileLg:mb-6">
+                      {isLoadingDispensers
+                        ? <p>Loading listings...</p>
+                        : (
+                          <StampListingsOpen
+                            dispensers={dispensers}
+                            floorPrice={stamp.floorPrice}
+                            onSelectDispenser={handleDispenserSelect}
+                            selectedDispenser={selectedDispenser}
+                          />
+                        )}
+                    </div>
                   )}
+
+                  {/* Buy button */}
+                  <div className="flex justify-end">
+                    <button
+                      className={`${buttonPurpleFlat}`}
+                      onClick={() =>
+                        toggleModal(selectedDispenser || lowestPriceDispenser)}
+                    >
+                      BUY
+                    </button>
+                  </div>
+                </div>
               </div>
-            )}
-          </div>
+            )
+            : null}
         </div>
 
         <div className="flex flex-col dark-gradient rounded-lg p-3 mobileLg:p-6">

--- a/islands/stamp/details/StampInfo.tsx
+++ b/islands/stamp/details/StampInfo.tsx
@@ -99,10 +99,7 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
     "absolute left-1/2 -translate-x-1/2 bg-[#000000BF] px-2 py-1 rounded-sm bottom-full text-[10px] mobileLg:text-xs text-stamp-grey-light whitespace-nowrap transition-opacity duration-300";
   const buttonPurpleFlat =
     "inline-flex items-center justify-center bg-stamp-purple border-2 border-stamp-purple rounded-md text-sm mobileLg:text-base font-extrabold text-black tracking-[0.05em] h-[42px] mobileLg:h-[48px] px-4 mobileLg:px-5 hover:border-stamp-purple-highlight hover:bg-stamp-purple-highlight transition-colors";
-  const buttonPurpleOutline =
-    "inline-flex items-center justify-center border-2 border-stamp-purple rounded-md text-sm mobileLg:text-base font-extrabold text-stamp-purple tracking-[0.05em] h-[42px] mobileLg:h-12 hover:border-stamp-purple-bright hover:text-stamp-purple-bright transition-colors";
 
-  // Add tooltip states
   const [isDivisibleTooltipVisible, setIsDivisibleTooltipVisible] = useState(
     false,
   );
@@ -273,7 +270,7 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
             const divStyle = doc.querySelector("div")?.getAttribute("style");
 
             // Parse dimensions from style
-            const getDimension = (style: string | null) => {
+            const getDimension = (style: string | null | undefined) => {
               if (!style) return null;
               const widthMatch = style.match(/width:\s*(\d+)(px|rem|em)/);
               const heightMatch = style.match(/height:\s*(\d+)(px|rem|em)/);
@@ -473,7 +470,7 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
   // First, ensure our calculations are correct
   const displayPrice = selectedDispenser
     ? parseInt(selectedDispenser.satoshirate.toString(), 10) / 100000000
-    : stamp.floorPrice;
+    : (typeof stamp.floorPrice === "number" ? stamp.floorPrice : 0);
 
   const displayPriceUSD = selectedDispenser && btcPrice
     ? (parseInt(selectedDispenser.satoshirate.toString(), 10) / 100000000) *
@@ -602,83 +599,77 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
 
           {(dispensers?.length > 0 || stamp.floorPrice)
             ? (
-              <div className="flex flex-col w-full pt-6 mobileLg:pt-12 text-right">
-                {(displayPriceUSD || stamp.floorPriceUSD) && (
-                  <p className={dataLabel}>
-                    {displayPriceUSD?.toLocaleString("en-US", {
-                      maximumFractionDigits: 2,
-                    }) || stamp.floorPriceUSD?.toLocaleString("en-US", {
-                      maximumFractionDigits: 2,
-                    })} <span className="font-light">USD</span>
-                  </p>
-                )}
+              <div className="flex flex-col w-full pt-6 mobileLg:pt-12">
+                <div
+                  className={`flex w-full gap-3 mobileLg:gap-6 mb-3 mobileLg:mb-6 items-end ${
+                    activeDispensers?.length >= 2
+                      ? "justify-between"
+                      : "justify-end"
+                  }`}
+                >
+                  {activeDispensers?.length >= 2 && (
+                    <button
+                      onClick={() => setShowListings(!showListings)}
+                      className="pb-1.5"
+                    >
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 32 32"
+                        className="w-6 h-6 mobileLg:w-[28px] mobileLg:h-[28px] fill-stamp-grey-darker hover:fill-stamp-grey-light cursor-pointer"
+                        role="button"
+                        aria-label="Listings"
+                      >
+                        <path d="M4 8C4 7.73478 4.10536 7.48043 4.29289 7.29289C4.48043 7.10536 4.73478 7 5 7H27C27.2652 7 27.5196 7.10536 27.7071 7.29289C27.8946 7.48043 28 7.73478 28 8C28 8.26522 27.8946 8.51957 27.7071 8.70711C27.5196 8.89464 27.2652 9 27 9H5C4.73478 9 4.48043 8.89464 4.29289 8.70711C4.10536 8.51957 4 8.26522 4 8ZM5 17H12C12.2652 17 12.5196 16.8946 12.7071 16.7071C12.8946 16.5196 13 16.2652 13 16C13 15.7348 12.8946 15.4804 12.7071 15.2929C12.5196 15.1054 12.2652 15 12 15H5C4.73478 15 4.48043 15.1054 4.29289 15.2929C4.10536 15.4804 4 15.7348 4 16C4 16.2652 4.10536 16.5196 4.29289 16.7071C4.48043 16.8946 4.73478 17 5 17ZM14 23H5C4.73478 23 4.48043 23.1054 4.29289 23.2929C4.10536 23.4804 4 23.7348 4 24C4 24.2652 4.10536 24.5196 4.29289 24.7071C4.48043 24.8946 4.73478 25 5 25H14C14.2652 25 14.5196 24.8946 14.7071 24.7071C14.8946 24.5196 15 24.2652 15 24C15 23.7348 14.8946 23.4804 14.7071 23.2929C14.5196 23.1054 14.2652 23 14 23ZM29.6362 17.9725L26.8213 20.2962L27.6787 23.76C27.7258 23.951 27.7154 24.1516 27.649 24.3367C27.5826 24.5218 27.463 24.6832 27.3053 24.8008C27.1476 24.9183 26.9588 24.9867 26.7624 24.9975C26.566 25.0083 26.3708 24.9609 26.2013 24.8612L23 22.9775L19.7987 24.8612C19.6292 24.9609 19.434 25.0083 19.2376 24.9975C19.0412 24.9867 18.8524 24.9183 18.6947 24.8008C18.537 24.6832 18.4174 24.5218 18.351 24.3367C18.2846 24.1516 18.2742 23.951 18.3213 23.76L19.1775 20.2962L16.3638 17.9725C16.2103 17.8456 16.0983 17.6758 16.0419 17.4848C15.9856 17.2938 15.9876 17.0903 16.0476 16.9005C16.1076 16.7106 16.2229 16.543 16.3788 16.4191C16.5347 16.2952 16.724 16.2206 16.9225 16.205L20.6525 15.9163L22.0812 12.6038C22.1585 12.4241 22.2866 12.271 22.4499 12.1635C22.6132 12.0559 22.8045 11.9986 23 11.9986C23.1955 11.9986 23.3868 12.0559 23.5501 12.1635C23.7134 12.271 23.8415 12.4241 23.9188 12.6038L25.3475 15.9163L29.0775 16.205C29.276 16.2206 29.4653 16.2952 29.6212 16.4191C29.7771 16.543 29.8924 16.7106 29.9524 16.9005C30.0124 17.0903 30.0144 17.2938 29.9581 17.4848C29.9018 17.6758 29.7897 17.8456 29.6362 17.9725ZM26.4525 18.0075L24.5912 17.8638C24.4097 17.8498 24.2354 17.7866 24.0871 17.6808C23.9389 17.5751 23.8223 17.4309 23.75 17.2638L23 15.5238L22.25 17.2638C22.1777 17.4309 22.0611 17.5751 21.9129 17.6808C21.7646 17.7866 21.5903 17.8498 21.4088 17.8638L19.5475 18.0075L20.9363 19.155C21.0817 19.2749 21.1903 19.4334 21.2496 19.6123C21.3089 19.7912 21.3164 19.9833 21.2712 20.1663L20.8337 21.9312L22.4925 20.955C22.6463 20.8644 22.8215 20.8167 23 20.8167C23.1785 20.8167 23.3537 20.8644 23.5075 20.955L25.1663 21.9312L24.7288 20.1663C24.6836 19.9833 24.6911 19.7912 24.7504 19.6123C24.8097 19.4334 24.9183 19.2749 25.0637 19.155L26.4525 18.0075Z" />
+                      </svg>
+                    </button>
+                  )}
 
-                <div className="w-full">
-                  <div
-                    className={`flex w-full gap-3 mobileLg:gap-6 mb-2 ${
-                      activeDispensers?.length >= 2
-                        ? "justify-between"
-                        : "justify-end"
-                    }`}
-                  >
-                    {activeDispensers?.length >= 2 && (
-                      <button onClick={() => setShowListings(!showListings)}>
-                        <svg
-                          xmlns="http://www.w3.org/2000/svg"
-                          viewBox="0 0 32 32"
-                          className="w-6 h-6 mobileLg:w-[28px] mobileLg:h-[28px] fill-stamp-grey-darker hover:fill-stamp-grey-light cursor-pointer"
-                          role="button"
-                          aria-label="Listings"
-                        >
-                          <path d="M4 8C4 7.73478 4.10536 7.48043 4.29289 7.29289C4.48043 7.10536 4.73478 7 5 7H27C27.2652 7 27.5196 7.10536 27.7071 7.29289C27.8946 7.48043 28 7.73478 28 8C28 8.26522 27.8946 8.51957 27.7071 8.70711C27.5196 8.89464 27.2652 9 27 9H5C4.73478 9 4.48043 8.89464 4.29289 8.70711C4.10536 8.51957 4 8.26522 4 8ZM5 17H12C12.2652 17 12.5196 16.8946 12.7071 16.7071C12.8946 16.5196 13 16.2652 13 16C13 15.7348 12.8946 15.4804 12.7071 15.2929C12.5196 15.1054 12.2652 15 12 15H5C4.73478 15 4.48043 15.1054 4.29289 15.2929C4.10536 15.4804 4 15.7348 4 16C4 16.2652 4.10536 16.5196 4.29289 16.7071C4.48043 16.8946 4.73478 17 5 17ZM14 23H5C4.73478 23 4.48043 23.1054 4.29289 23.2929C4.10536 23.4804 4 23.7348 4 24C4 24.2652 4.10536 24.5196 4.29289 24.7071C4.48043 24.8946 4.73478 25 5 25H14C14.2652 25 14.5196 24.8946 14.7071 24.7071C14.8946 24.5196 15 24.2652 15 24C15 23.7348 14.8946 23.4804 14.7071 23.2929C14.5196 23.1054 14.2652 23 14 23ZM29.6362 17.9725L26.8213 20.2962L27.6787 23.76C27.7258 23.951 27.7154 24.1516 27.649 24.3367C27.5826 24.5218 27.463 24.6832 27.3053 24.8008C27.1476 24.9183 26.9588 24.9867 26.7624 24.9975C26.566 25.0083 26.3708 24.9609 26.2013 24.8612L23 22.9775L19.7987 24.8612C19.6292 24.9609 19.434 25.0083 19.2376 24.9975C19.0412 24.9867 18.8524 24.9183 18.6947 24.8008C18.537 24.6832 18.4174 24.5218 18.351 24.3367C18.2846 24.1516 18.2742 23.951 18.3213 23.76L19.1775 20.2962L16.3638 17.9725C16.2103 17.8456 16.0983 17.6758 16.0419 17.4848C15.9856 17.2938 15.9876 17.0903 16.0476 16.9005C16.1076 16.7106 16.2229 16.543 16.3788 16.4191C16.5347 16.2952 16.724 16.2206 16.9225 16.205L20.6525 15.9163L22.0812 12.6038C22.1585 12.4241 22.2866 12.271 22.4499 12.1635C22.6132 12.0559 22.8045 11.9986 23 11.9986C23.1955 11.9986 23.3868 12.0559 23.5501 12.1635C23.7134 12.271 23.8415 12.4241 23.9188 12.6038L25.3475 15.9163L29.0775 16.205C29.276 16.2206 29.4653 16.2952 29.6212 16.4191C29.7771 16.543 29.8924 16.7106 29.9524 16.9005C30.0124 17.0903 30.0144 17.2938 29.9581 17.4848C29.9018 17.6758 29.7897 17.8456 29.6362 17.9725ZM26.4525 18.0075L24.5912 17.8638C24.4097 17.8498 24.2354 17.7866 24.0871 17.6808C23.9389 17.5751 23.8223 17.4309 23.75 17.2638L23 15.5238L22.25 17.2638C22.1777 17.4309 22.0611 17.5751 21.9129 17.6808C21.7646 17.7866 21.5903 17.8498 21.4088 17.8638L19.5475 18.0075L20.9363 19.155C21.0817 19.2749 21.1903 19.4334 21.2496 19.6123C21.3089 19.7912 21.3164 19.9833 21.2712 20.1663L20.8337 21.9312L22.4925 20.955C22.6463 20.8644 22.8215 20.8167 23 20.8167C23.1785 20.8167 23.3537 20.8644 23.5075 20.955L25.1663 21.9312L24.7288 20.1663C24.6836 19.9833 24.6911 19.7912 24.7504 19.6123C24.8097 19.4334 24.9183 19.2749 25.0637 19.155L26.4525 18.0075Z" />
-                        </svg>
-                      </button>
+                  <div className="text-right">
+                    {displayPriceUSD && (
+                      <p className={dataLabel}>
+                        {displayPriceUSD.toLocaleString("en-US", {
+                          maximumFractionDigits: 2,
+                        })} <span className="font-light">USD</span>
+                      </p>
                     )}
-
                     <p className={dataValueXl}>
-                      {(!displayPrice || displayPrice === "NOT LISTED") &&
-                          stamp.marketCap &&
-                          typeof stamp.marketCap === "number"
-                        ? formatBTCAmount(stamp.marketCap, {
-                          excludeSuffix: true,
-                        })
-                        : typeof displayPrice === "number"
-                        ? formatBTCAmount(displayPrice, { excludeSuffix: true })
-                        : displayPrice} {(typeof displayPrice === "number" ||
-                          (stamp.marketCap &&
-                            typeof stamp.marketCap === "number")) &&
-                        <span className="font-extralight">BTC</span>}
+                      {formatBTCAmount(
+                        typeof displayPrice === "number" ? displayPrice : 0,
+                        { excludeSuffix: true },
+                      )} <span className="font-extralight">BTC</span>
                     </p>
                   </div>
+                </div>
 
-                  {(activeDispensers?.length >= 2)
-                    ? (
-                      showListings && (
-                        <div className="w-full mb-3 mobileLg:mb-6">
-                          {isLoadingDispensers
-                            ? <p>Loading listings...</p>
-                            : (
-                              <StampListingsOpen
-                                dispensers={activeDispensers}
-                                floorPrice={stamp.floorPrice}
-                                onSelectDispenser={handleDispenserSelect}
-                                selectedDispenser={selectedDispenser}
-                              />
-                            )}
-                        </div>
-                      )
+                {(activeDispensers?.length >= 2)
+                  ? (
+                    showListings && (
+                      <div className="w-full mb-3 mobileLg:mb-6">
+                        {isLoadingDispensers
+                          ? <p>Loading listings...</p>
+                          : (
+                            <StampListingsOpen
+                              dispensers={activeDispensers}
+                              floorPrice={typeof stamp.floorPrice === "number"
+                                ? stamp.floorPrice
+                                : 0}
+                              onSelectDispenser={handleDispenserSelect}
+                              selectedDispenser={selectedDispenser}
+                            />
+                          )}
+                      </div>
                     )
-                    : null}
+                  )
+                  : null}
 
-                  <div className="flex justify-end">
-                    <button
-                      className={`${buttonPurpleFlat}`}
-                      onClick={() =>
-                        toggleModal(selectedDispenser || lowestPriceDispenser)}
-                    >
-                      BUY
-                    </button>
-                  </div>
+                <div className="flex justify-end">
+                  <button
+                    className={`${buttonPurpleFlat}`}
+                    onClick={() =>
+                      toggleModal(selectedDispenser || lowestPriceDispenser)}
+                  >
+                    BUY
+                  </button>
                 </div>
               </div>
             )
@@ -751,7 +742,7 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
                   </div>
                 </div>
               )}
-              {stamp.locked == true && (
+              {stamp.locked && (
                 <div
                   className="relative group"
                   onMouseEnter={handleLockedMouseEnter}
@@ -774,7 +765,7 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
                   </div>
                 </div>
               )}
-              {stamp.locked != true && (
+              {!stamp.locked && (
                 <div
                   className="relative group"
                   onMouseEnter={handleUnlockedMouseEnter}

--- a/islands/stamp/details/StampInfo.tsx
+++ b/islands/stamp/details/StampInfo.tsx
@@ -389,6 +389,9 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
     return () => globalThis.removeEventListener("resize", updateScale);
   }, []);
 
+  // Move the showListings state to be preserved across dispenser data updates
+  const [showListings, setShowListings] = useState(false);
+
   return (
     <>
       <StampSearchClient
@@ -456,51 +459,85 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
             </div>
           </div>
 
-          <div className="flex flex-col pt-6 mobileLg:pt-12 items-end">
-            <div className="flex flex-col w-full text-right">
-              {(stamp.floorPriceUSD || stamp.marketCapUSD) && (
-                <p className={dataLabel}>
-                  {stamp.floorPriceUSD
-                    ? `${
-                      stamp.floorPriceUSD.toLocaleString("en-US", {
-                        maximumFractionDigits: 2,
+          <div className="flex flex-col w-full pt-6 mobileLg:pt-12 text-right">
+            {!showListings
+              ? (
+                // Default price view
+                <>
+                  {(stamp.floorPriceUSD || stamp.marketCapUSD) && (
+                    <p className={dataLabel}>
+                      {stamp.floorPriceUSD
+                        ? `${
+                          stamp.floorPriceUSD.toLocaleString("en-US", {
+                            maximumFractionDigits: 2,
+                          })
+                        }`
+                        : stamp.marketCapUSD
+                        ? `${
+                          stamp.marketCapUSD.toLocaleString("en-US", {
+                            maximumFractionDigits: 2,
+                          })
+                        }`
+                        : null}
+                      <span className="font-light">
+                        {" "}USD
+                      </span>
+                    </p>
+                  )}
+
+                  <p className={dataValueXl}>
+                    {(!stamp.floorPrice || stamp.floorPrice === "NOT LISTED") &&
+                        stamp.marketCap && typeof stamp.marketCap === "number"
+                      ? formatBTCAmount(stamp.marketCap, {
+                        excludeSuffix: true,
                       })
-                    }`
-                    : stamp.marketCapUSD
-                    ? `${
-                      stamp.marketCapUSD.toLocaleString("en-US", {
-                        maximumFractionDigits: 2,
+                      : typeof stamp.floorPrice === "number"
+                      ? formatBTCAmount(stamp.floorPrice, {
+                        excludeSuffix: true,
                       })
-                    }`
-                    : null}
-                  <span className="font-light">
-                    {" "}USD
-                  </span>
-                </p>
+                      : stamp.floorPrice}
+                    {(typeof stamp.floorPrice === "number" ||
+                      (stamp.marketCap &&
+                        typeof stamp.marketCap === "number")) && (
+                      <span className="font-extralight">{" "}BTC</span>
+                    )}
+                  </p>
+                </>
+              )
+              : (
+                // Expanded listings view
+                <div className="flex flex-col gap-2 text-stamp-grey-light text-sm text-left">
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed
+                    do eiusmod tempor incididunt ut labore.
+                  </p>
+                  <p>
+                    Ut enim ad minim veniam, quis nostrud exercitation ullamco
+                    laboris nisi ut aliquip ex ea commodo.
+                  </p>
+                  <p>
+                    Duis aute irure dolor in reprehenderit in voluptate velit
+                    esse cillum dolore eu fugiat nulla.
+                  </p>
+                </div>
               )}
 
-              <p className={dataValueXl}>
-                {(!stamp.floorPrice || stamp.floorPrice === "NOT LISTED") &&
-                    stamp.marketCap && typeof stamp.marketCap === "number"
-                  ? formatBTCAmount(stamp.marketCap, { excludeSuffix: true })
-                  : typeof stamp.floorPrice === "number"
-                  ? formatBTCAmount(stamp.floorPrice, { excludeSuffix: true })
-                  : stamp.floorPrice}
-                {(typeof stamp.floorPrice === "number" ||
-                  (stamp.marketCap && typeof stamp.marketCap === "number")) && (
-                  <span className="font-extralight">{" "}BTC</span>
-                )}
-              </p>
-            </div>
-
-            {lowestPriceDispenser && (
+            <div className="flex w-full justify-between items-end mt-3 mobileMd:mt-6">
               <button
-                className={`${buttonPurpleFlat} float-right mt-3 mobileMd:mt-6`}
-                onClick={toggleModal}
+                onClick={() => setShowListings((prev) => !prev)}
+                className="text-[#8257FF] text-sm mobileLg:text-base font-light uppercase hover:text-[#9e7cff] transition-colors duration-300"
               >
-                BUY
+                SELECT LISTING
               </button>
-            )}
+              {lowestPriceDispenser && (
+                <button
+                  className={`${buttonPurpleFlat}`}
+                  onClick={toggleModal}
+                >
+                  BUY
+                </button>
+              )}
+            </div>
           </div>
         </div>
 

--- a/islands/stamp/details/StampInfo.tsx
+++ b/islands/stamp/details/StampInfo.tsx
@@ -307,6 +307,15 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
           console.error("Failed to fetch HTML content:", error);
           setImageDimensions(null);
         });
+    } else if (stamp.stamp_mimetype === "text/plain") {
+      // Add handling for plain text files
+      fetch(stamp.stamp_url)
+        .then((response) => response.text())
+        .then((text) => {
+          const blob = new Blob([text], { type: "text/plain" });
+          setFileSize(blob.size);
+        })
+        .catch((error) => console.error("Failed to fetch text size:", error));
     } else if (
       stamp.stamp_mimetype === "text/javascript" ||
       stamp.stamp_mimetype === "application/javascript"
@@ -332,13 +341,20 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
   }, [stamp.stamp_mimetype, stamp.stamp_url]);
 
   // Format file size
-  const formatFileSize = (bytes: number | null) => {
-    if (!bytes) return "N/A";
-    return `${(bytes / 1024).toFixed(2)} KB`;
+  const formatFileSize = (size: number) => {
+    if (stamp.stamp_mimetype === "text/plain") {
+      return `${size} B`;
+    }
+
+    if (size < 1024) return size + " B";
+    return (size / 1024).toFixed(1) + " KB";
   };
 
   // Format dimensions display
   const getDimensionsDisplay = (dims: DimensionsType | null) => {
+    if (stamp.stamp_mimetype === "text/plain") {
+      return "FLUID";
+    }
     if (!dims) return "N/A";
     if (dims.unit === "responsive") return "RESPONSIVE";
     return `${dims.width} x ${dims.height} ${dims.unit.toUpperCase()}`;

--- a/islands/stamp/details/StampInfo.tsx
+++ b/islands/stamp/details/StampInfo.tsx
@@ -516,73 +516,54 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
           </div>
 
           <div className="flex flex-col w-full pt-6 mobileLg:pt-12 text-right">
-            {!showListings
-              ? (
-                // Default price view
-                <>
-                  {(stamp.floorPriceUSD || stamp.marketCapUSD) && (
-                    <p className={dataLabel}>
-                      {stamp.floorPriceUSD
-                        ? `${
-                          stamp.floorPriceUSD.toLocaleString("en-US", {
-                            maximumFractionDigits: 2,
-                          })
-                        }`
-                        : stamp.marketCapUSD
-                        ? `${
-                          stamp.marketCapUSD.toLocaleString("en-US", {
-                            maximumFractionDigits: 2,
-                          })
-                        }`
-                        : null}
-                      <span className="font-light">
-                        {" "}USD
-                      </span>
-                    </p>
-                  )}
+            {(stamp.floorPriceUSD || stamp.marketCapUSD) && (
+              <p className={dataLabel}>
+                {stamp.floorPriceUSD
+                  ? `${
+                    stamp.floorPriceUSD.toLocaleString("en-US", {
+                      maximumFractionDigits: 2,
+                    })
+                  }`
+                  : stamp.marketCapUSD
+                  ? `${
+                    stamp.marketCapUSD.toLocaleString("en-US", {
+                      maximumFractionDigits: 2,
+                    })
+                  }`
+                  : null}
+                <span className="font-light">
+                  {" "}USD
+                </span>
+              </p>
+            )}
 
-                  <p className={dataValueXl}>
-                    {(!stamp.floorPrice || stamp.floorPrice === "NOT LISTED") &&
-                        stamp.marketCap && typeof stamp.marketCap === "number"
-                      ? formatBTCAmount(stamp.marketCap, {
-                        excludeSuffix: true,
-                      })
-                      : typeof stamp.floorPrice === "number"
-                      ? formatBTCAmount(stamp.floorPrice, {
-                        excludeSuffix: true,
-                      })
-                      : stamp.floorPrice}
-                    {(typeof stamp.floorPrice === "number" ||
-                      (stamp.marketCap &&
-                        typeof stamp.marketCap === "number")) && (
-                      <span className="font-extralight">{" "}BTC</span>
-                    )}
-                  </p>
-                </>
-              )
-              : (
-                // Expanded listings view
-                <div className="flex flex-col gap-2 text-stamp-grey-light text-sm text-left">
-                  {isLoadingDispensers
-                    ? <p>Loading listings...</p>
-                    : (
-                      <StampListingsOpen
-                        dispensers={dispensers}
-                        currentPage={currentPage}
-                        totalPages={totalPages}
-                        onPageChange={handlePageChange}
-                        isLoading={isLoadingDispensers}
-                      />
-                    )}
-                </div>
+            <p className={dataValueXl}>
+              {(!stamp.floorPrice || stamp.floorPrice === "NOT LISTED") &&
+                  stamp.marketCap && typeof stamp.marketCap === "number"
+                ? formatBTCAmount(stamp.marketCap, { excludeSuffix: true })
+                : typeof stamp.floorPrice === "number"
+                ? formatBTCAmount(stamp.floorPrice, { excludeSuffix: true })
+                : stamp.floorPrice}
+              {(typeof stamp.floorPrice === "number" ||
+                (stamp.marketCap && typeof stamp.marketCap === "number")) && (
+                <span className="font-extralight">{" "}BTC</span>
               )}
+            </p>
 
             <div className="flex w-full justify-between items-end mt-3 mobileMd:mt-6">
               <button
                 onClick={() => setShowListings((prev) => !prev)}
-                className="text-sm mobileLg:text-base font-light uppercase text-stamp-grey-darker hover:text-stamp-grey-light"
+                className="flex items-center"
               >
-                {showListings ? "CLOSE" : "SELECT LISTING"}
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 32 32"
+                  className="w-6 h-6 mobileLg:w-[28px] mobileLg:h-[28px] fill-stamp-grey-darker hover:fill-stamp-grey-light cursor-pointer"
+                  role="button"
+                  aria-label="Listings"
+                >
+                  <path d="M4 8C4 7.73478 4.10536 7.48043 4.29289 7.29289C4.48043 7.10536 4.73478 7 5 7H27C27.2652 7 27.5196 7.10536 27.7071 7.29289C27.8946 7.48043 28 7.73478 28 8C28 8.26522 27.8946 8.51957 27.7071 8.70711C27.5196 8.89464 27.2652 9 27 9H5C4.73478 9 4.48043 8.89464 4.29289 8.70711C4.10536 8.51957 4 8.26522 4 8ZM5 17H27C27.2652 17 27.5196 16.8946 27.7071 16.7071C27.8946 16.5196 28 16.2652 28 16C28 15.7348 27.8946 15.4804 27.7071 15.2929C27.5196 15.1054 27.2652 15 27 15H5C4.73478 15 4.48043 15.1054 4.29289 15.2929C4.10536 15.4804 4 15.7348 4 16C4 16.2652 4.10536 16.5196 4.29289 16.7071C4.48043 16.8946 4.73478 17 5 17ZM18 23H5C4.73478 23 4.48043 23.1054 4.29289 23.2929C4.10536 23.4804 4 23.7348 4 24C4 24.2652 4.10536 24.5196 4.29289 24.7071C4.48043 24.8946 4.73478 25 5 25H18C18.2652 25 18.5196 24.8946 18.7071 24.7071C18.8946 24.5196 19 24.2652 19 24C19 23.7348 18.8946 23.4804 18.7071 23.2929C18.5196 23.1054 18.2652 23 18 23ZM29 23H27V21C27 20.7348 26.8946 20.4804 26.7071 20.2929C26.5196 20.1054 26.2652 20 26 20C25.7348 20 25.4804 20.1054 25.2929 20.2929C25.1054 20.4804 25 20.7348 25 21V23H23C22.7348 23 22.4804 23.1054 22.2929 23.2929C22.1054 23.4804 22 23.7348 22 24C22 24.2652 22.1054 24.5196 22.2929 24.7071C22.4804 24.8946 22.7348 25 23 25H25V27C25 27.2652 25.1054 27.5196 25.2929 27.7071C25.4804 27.8946 25.7348 28 26 28C26.2652 28 26.5196 27.8946 26.7071 27.7071C26.8946 27.5196 27 27.2652 27 27V25H29C29.2652 25 29.5196 24.8946 29.7071 24.7071C29.8946 24.5196 30 24.2652 30 24C30 23.7348 29.8946 23.4804 29.7071 23.2929C29.5196 23.1054 29.2652 23 29 23Z" />
+                </svg>
               </button>
               {lowestPriceDispenser && (
                 <button
@@ -593,6 +574,22 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
                 </button>
               )}
             </div>
+
+            {showListings && (
+              <div className="flex flex-col gap-2 text-stamp-grey-light text-sm text-left mt-3 mobileMd:mt-6">
+                {isLoadingDispensers
+                  ? <p>Loading listings...</p>
+                  : (
+                    <StampListingsOpen
+                      dispensers={dispensers}
+                      currentPage={currentPage}
+                      totalPages={totalPages}
+                      onPageChange={handlePageChange}
+                      isLoading={isLoadingDispensers}
+                    />
+                  )}
+              </div>
+            )}
           </div>
         </div>
 

--- a/islands/stamp/details/StampInfo.tsx
+++ b/islands/stamp/details/StampInfo.tsx
@@ -401,16 +401,16 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
   // Add state for dispensers and page info
   const [dispensers, setDispensers] = useState<any[]>([]);
   const [isLoadingDispensers, setIsLoadingDispensers] = useState(false);
-  const [currentPage, setCurrentPage] = useState(1);
-  const [totalPages, setTotalPages] = useState(1);
 
-  // Add fetch function based on StampRelatedInfo pattern
-  const fetchDispensers = async (page = 1) => {
+  // Add state for filtered dispensers
+  const [activeDispensers, setActiveDispensers] = useState<any[]>([]);
+
+  // Modify the fetch function to filter active dispensers
+  const fetchDispensers = async (page: number) => {
     if (isLoadingDispensers) return;
-
     setIsLoadingDispensers(true);
     try {
-      const encodedCpid = encodeURIComponent(stamp.cpid); // Make sure we're using the correct ID
+      const encodedCpid = encodeURIComponent(stamp.cpid);
       const params = new URLSearchParams({
         limit: "20",
         sort: "DESC",
@@ -426,32 +426,23 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
       }
 
       const data = await response.json();
-      console.log("Dispensers data:", data);
+      const openDispensers = data.data.filter((d: any) => d.status === "open");
 
-      if (data.data) {
-        setDispensers(data.data);
-        setTotalPages(data.totalPages || 1);
-        setCurrentPage(page);
-      }
+      setDispensers(data.data);
+      setActiveDispensers(openDispensers);
     } catch (error) {
       console.error("Error fetching dispensers:", error);
       setDispensers([]);
+      setActiveDispensers([]);
     } finally {
       setIsLoadingDispensers(false);
     }
   };
 
-  // Handle page change
-  const handlePageChange = (newPage: number) => {
-    fetchDispensers(newPage);
-  };
-
   // Fetch dispensers when expanded
   useEffect(() => {
-    if (showListings) {
-      fetchDispensers(1);
-    }
-  }, [showListings]);
+    fetchDispensers(1);
+  }, []);
 
   // Add state for selected dispenser
   const [selectedDispenser, setSelectedDispenser] = useState<Dispenser | null>(
@@ -514,20 +505,33 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
 
   // Add handler for dispenser selection
   const handleDispenserSelect = (dispenser: Dispenser) => {
-    console.log("handleDispenserSelect - Before state update:", {
-      current: selectedDispenser,
-      new: dispenser,
-      btcPrice,
-    });
-
-    // Force satoshirate to be a number and create new object
     const updatedDispenser = {
       ...dispenser,
       satoshirate: parseInt(dispenser.satoshirate.toString(), 10),
     };
-
     setSelectedDispenser(updatedDispenser);
   };
+
+  // At the top of component, add logging for initial check
+  const hasMultipleDispensers = dispensers?.length >= 2;
+  console.log("Initial checks:", {
+    dispensersLength: dispensers?.length,
+    hasMultipleDispensers,
+    showListings,
+    hasFloorPrice: !!stamp.floorPrice,
+    dispensers: dispensers,
+  });
+
+  // Add this useEffect to track dispensers state
+  useEffect(() => {
+    console.log("Dispensers state changed:", {
+      dispensersLength: dispensers?.length,
+      hasDispensers: dispensers?.length > 0,
+      hasMultiple: dispensers?.length >= 2,
+      rawDispensers: dispensers,
+      floorPrice: stamp.floorPrice,
+    });
+  }, [dispensers]);
 
   return (
     <>
@@ -599,12 +603,6 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
           {(dispensers?.length > 0 || stamp.floorPrice)
             ? (
               <div className="flex flex-col w-full pt-6 mobileLg:pt-12 text-right">
-                {/* Debug price values */}
-                {console.log("Rendering prices:", {
-                  displayPrice,
-                  displayPriceUSD,
-                })}
-
                 {(displayPriceUSD || stamp.floorPriceUSD) && (
                   <p className={dataLabel}>
                     {displayPriceUSD?.toLocaleString("en-US", {
@@ -616,21 +614,26 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
                 )}
 
                 <div className="w-full">
-                  {/* Price and listings icon row */}
-                  <div className="flex w-full gap-3 mobileLg:gap-6 mb-3 mobileLg:mb-6 justify-between">
-                    <button
-                      onClick={() => setShowListings(!showListings)}
-                    >
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 32 32"
-                        className="w-6 h-6 mobileLg:w-[28px] mobileLg:h-[28px] fill-stamp-grey-darker hover:fill-stamp-grey-light cursor-pointer"
-                        role="button"
-                        aria-label="Listings"
-                      >
-                        <path d="M4 8C4 7.73478 4.10536 7.48043 4.29289 7.29289C4.48043 7.10536 4.73478 7 5 7H27C27.2652 7 27.5196 7.10536 27.7071 7.29289C27.8946 7.48043 28 7.73478 28 8C28 8.26522 27.8946 8.51957 27.7071 8.70711C27.5196 8.89464 27.2652 9 27 9H5C4.73478 9 4.48043 8.89464 4.29289 8.70711C4.10536 8.51957 4 8.26522 4 8ZM5 17H12C12.2652 17 12.5196 16.8946 12.7071 16.7071C12.8946 16.5196 13 16.2652 13 16C13 15.7348 12.8946 15.4804 12.7071 15.2929C12.5196 15.1054 12.2652 15 12 15H5C4.73478 15 4.48043 15.1054 4.29289 15.2929C4.10536 15.4804 4 15.7348 4 16C4 16.2652 4.10536 16.5196 4.29289 16.7071C4.48043 16.8946 4.73478 17 5 17ZM14 23H5C4.73478 23 4.48043 23.1054 4.29289 23.2929C4.10536 23.4804 4 23.7348 4 24C4 24.2652 4.10536 24.5196 4.29289 24.7071C4.48043 24.8946 4.73478 25 5 25H14C14.2652 25 14.5196 24.8946 14.7071 24.7071C14.8946 24.5196 15 24.2652 15 24C15 23.7348 14.8946 23.4804 14.7071 23.2929C14.5196 23.1054 14.2652 23 14 23ZM29.6362 17.9725L26.8213 20.2962L27.6787 23.76C27.7258 23.951 27.7154 24.1516 27.649 24.3367C27.5826 24.5218 27.463 24.6832 27.3053 24.8008C27.1476 24.9183 26.9588 24.9867 26.7624 24.9975C26.566 25.0083 26.3708 24.9609 26.2013 24.8612L23 22.9775L19.7987 24.8612C19.6292 24.9609 19.434 25.0083 19.2376 24.9975C19.0412 24.9867 18.8524 24.9183 18.6947 24.8008C18.537 24.6832 18.4174 24.5218 18.351 24.3367C18.2846 24.1516 18.2742 23.951 18.3213 23.76L19.1775 20.2962L16.3638 17.9725C16.2103 17.8456 16.0983 17.6758 16.0419 17.4848C15.9856 17.2938 15.9876 17.0903 16.0476 16.9005C16.1076 16.7106 16.2229 16.543 16.3788 16.4191C16.5347 16.2952 16.724 16.2206 16.9225 16.205L20.6525 15.9163L22.0812 12.6038C22.1585 12.4241 22.2866 12.271 22.4499 12.1635C22.6132 12.0559 22.8045 11.9986 23 11.9986C23.1955 11.9986 23.3868 12.0559 23.5501 12.1635C23.7134 12.271 23.8415 12.4241 23.9188 12.6038L25.3475 15.9163L29.0775 16.205C29.276 16.2206 29.4653 16.2952 29.6212 16.4191C29.7771 16.543 29.8924 16.7106 29.9524 16.9005C30.0124 17.0903 30.0144 17.2938 29.9581 17.4848C29.9018 17.6758 29.7897 17.8456 29.6362 17.9725ZM26.4525 18.0075L24.5912 17.8638C24.4097 17.8498 24.2354 17.7866 24.0871 17.6808C23.9389 17.5751 23.8223 17.4309 23.75 17.2638L23 15.5238L22.25 17.2638C22.1777 17.4309 22.0611 17.5751 21.9129 17.6808C21.7646 17.7866 21.5903 17.8498 21.4088 17.8638L19.5475 18.0075L20.9363 19.155C21.0817 19.2749 21.1903 19.4334 21.2496 19.6123C21.3089 19.7912 21.3164 19.9833 21.2712 20.1663L20.8337 21.9312L22.4925 20.955C22.6463 20.8644 22.8215 20.8167 23 20.8167C23.1785 20.8167 23.3537 20.8644 23.5075 20.955L25.1663 21.9312L24.7288 20.1663C24.6836 19.9833 24.6911 19.7912 24.7504 19.6123C24.8097 19.4334 24.9183 19.2749 25.0637 19.155L26.4525 18.0075Z" />
-                      </svg>
-                    </button>
+                  <div
+                    className={`flex w-full gap-3 mobileLg:gap-6 mb-2 ${
+                      activeDispensers?.length >= 2
+                        ? "justify-between"
+                        : "justify-end"
+                    }`}
+                  >
+                    {activeDispensers?.length >= 2 && (
+                      <button onClick={() => setShowListings(!showListings)}>
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 32 32"
+                          className="w-6 h-6 mobileLg:w-[28px] mobileLg:h-[28px] fill-stamp-grey-darker hover:fill-stamp-grey-light cursor-pointer"
+                          role="button"
+                          aria-label="Listings"
+                        >
+                          <path d="M4 8C4 7.73478 4.10536 7.48043 4.29289 7.29289C4.48043 7.10536 4.73478 7 5 7H27C27.2652 7 27.5196 7.10536 27.7071 7.29289C27.8946 7.48043 28 7.73478 28 8C28 8.26522 27.8946 8.51957 27.7071 8.70711C27.5196 8.89464 27.2652 9 27 9H5C4.73478 9 4.48043 8.89464 4.29289 8.70711C4.10536 8.51957 4 8.26522 4 8ZM5 17H12C12.2652 17 12.5196 16.8946 12.7071 16.7071C12.8946 16.5196 13 16.2652 13 16C13 15.7348 12.8946 15.4804 12.7071 15.2929C12.5196 15.1054 12.2652 15 12 15H5C4.73478 15 4.48043 15.1054 4.29289 15.2929C4.10536 15.4804 4 15.7348 4 16C4 16.2652 4.10536 16.5196 4.29289 16.7071C4.48043 16.8946 4.73478 17 5 17ZM14 23H5C4.73478 23 4.48043 23.1054 4.29289 23.2929C4.10536 23.4804 4 23.7348 4 24C4 24.2652 4.10536 24.5196 4.29289 24.7071C4.48043 24.8946 4.73478 25 5 25H14C14.2652 25 14.5196 24.8946 14.7071 24.7071C14.8946 24.5196 15 24.2652 15 24C15 23.7348 14.8946 23.4804 14.7071 23.2929C14.5196 23.1054 14.2652 23 14 23ZM29.6362 17.9725L26.8213 20.2962L27.6787 23.76C27.7258 23.951 27.7154 24.1516 27.649 24.3367C27.5826 24.5218 27.463 24.6832 27.3053 24.8008C27.1476 24.9183 26.9588 24.9867 26.7624 24.9975C26.566 25.0083 26.3708 24.9609 26.2013 24.8612L23 22.9775L19.7987 24.8612C19.6292 24.9609 19.434 25.0083 19.2376 24.9975C19.0412 24.9867 18.8524 24.9183 18.6947 24.8008C18.537 24.6832 18.4174 24.5218 18.351 24.3367C18.2846 24.1516 18.2742 23.951 18.3213 23.76L19.1775 20.2962L16.3638 17.9725C16.2103 17.8456 16.0983 17.6758 16.0419 17.4848C15.9856 17.2938 15.9876 17.0903 16.0476 16.9005C16.1076 16.7106 16.2229 16.543 16.3788 16.4191C16.5347 16.2952 16.724 16.2206 16.9225 16.205L20.6525 15.9163L22.0812 12.6038C22.1585 12.4241 22.2866 12.271 22.4499 12.1635C22.6132 12.0559 22.8045 11.9986 23 11.9986C23.1955 11.9986 23.3868 12.0559 23.5501 12.1635C23.7134 12.271 23.8415 12.4241 23.9188 12.6038L25.3475 15.9163L29.0775 16.205C29.276 16.2206 29.4653 16.2952 29.6212 16.4191C29.7771 16.543 29.8924 16.7106 29.9524 16.9005C30.0124 17.0903 30.0144 17.2938 29.9581 17.4848C29.9018 17.6758 29.7897 17.8456 29.6362 17.9725ZM26.4525 18.0075L24.5912 17.8638C24.4097 17.8498 24.2354 17.7866 24.0871 17.6808C23.9389 17.5751 23.8223 17.4309 23.75 17.2638L23 15.5238L22.25 17.2638C22.1777 17.4309 22.0611 17.5751 21.9129 17.6808C21.7646 17.7866 21.5903 17.8498 21.4088 17.8638L19.5475 18.0075L20.9363 19.155C21.0817 19.2749 21.1903 19.4334 21.2496 19.6123C21.3089 19.7912 21.3164 19.9833 21.2712 20.1663L20.8337 21.9312L22.4925 20.955C22.6463 20.8644 22.8215 20.8167 23 20.8167C23.1785 20.8167 23.3537 20.8644 23.5075 20.955L25.1663 21.9312L24.7288 20.1663C24.6836 19.9833 24.6911 19.7912 24.7504 19.6123C24.8097 19.4334 24.9183 19.2749 25.0637 19.155L26.4525 18.0075Z" />
+                        </svg>
+                      </button>
+                    )}
 
                     <p className={dataValueXl}>
                       {(!displayPrice || displayPrice === "NOT LISTED") &&
@@ -648,23 +651,25 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
                     </p>
                   </div>
 
-                  {/* Listings content */}
-                  {showListings && (
-                    <div className="w-full mb-3 mobileLg:mb-6">
-                      {isLoadingDispensers
-                        ? <p>Loading listings...</p>
-                        : (
-                          <StampListingsOpen
-                            dispensers={dispensers}
-                            floorPrice={stamp.floorPrice}
-                            onSelectDispenser={handleDispenserSelect}
-                            selectedDispenser={selectedDispenser}
-                          />
-                        )}
-                    </div>
-                  )}
+                  {(activeDispensers?.length >= 2)
+                    ? (
+                      showListings && (
+                        <div className="w-full mb-3 mobileLg:mb-6">
+                          {isLoadingDispensers
+                            ? <p>Loading listings...</p>
+                            : (
+                              <StampListingsOpen
+                                dispensers={activeDispensers}
+                                floorPrice={stamp.floorPrice}
+                                onSelectDispenser={handleDispenserSelect}
+                                selectedDispenser={selectedDispenser}
+                              />
+                            )}
+                        </div>
+                      )
+                    )
+                    : null}
 
-                  {/* Buy button */}
                   <div className="flex justify-end">
                     <button
                       className={`${buttonPurpleFlat}`}

--- a/islands/stamp/details/StampRelatedInfo.tsx
+++ b/islands/stamp/details/StampRelatedInfo.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
 
-import { StampListingsOpen } from "$components/stampDetails/StampListingsOpen.tsx";
+import { StampListingsAll } from "$components/stampDetails/StampListingsAll.tsx";
 import { StampSales } from "$components/stampDetails/StampSales.tsx";
 import { StampTransfers } from "$components/stampDetails/StampTransfers.tsx";
 
@@ -222,7 +222,7 @@ export function StampRelatedInfo({ _stampId, cpid }: StampRelatedInfoProps) {
   const renderTabContent = () => {
     switch (selectedTab) {
       case "dispensers": {
-        return <StampListingsOpen dispensers={dispensers} />;
+        return <StampListingsAll dispensers={dispensers} />;
       }
       case "sales": {
         return <StampSales dispenses={dispensesWithRates} />;

--- a/islands/stamp/details/StampRelatedInfo.tsx
+++ b/islands/stamp/details/StampRelatedInfo.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "preact/hooks";
 
-import { StampDispensers } from "$components/stampDetails/StampDispensers.tsx";
+import { StampListingsOpen } from "$components/stampDetails/StampListingsOpen.tsx";
 import { StampSales } from "$components/stampDetails/StampSales.tsx";
 import { StampTransfers } from "$components/stampDetails/StampTransfers.tsx";
 
@@ -222,7 +222,7 @@ export function StampRelatedInfo({ _stampId, cpid }: StampRelatedInfoProps) {
   const renderTabContent = () => {
     switch (selectedTab) {
       case "dispensers": {
-        return <StampDispensers dispensers={dispensers} />;
+        return <StampListingsOpen dispensers={dispensers} />;
       }
       case "sales": {
         return <StampSales dispenses={dispensesWithRates} />;
@@ -244,7 +244,7 @@ export function StampRelatedInfo({ _stampId, cpid }: StampRelatedInfoProps) {
         id: "dispensers",
         label: (
           <div class="flex flex-col text-left">
-            DISPENSERS
+            LISTINGS
             <div
               class={`${dataValueXLlinkClassName} ${
                 selectedTab === "dispensers"

--- a/islands/stamp/details/StampRelatedInfo.tsx
+++ b/islands/stamp/details/StampRelatedInfo.tsx
@@ -232,9 +232,9 @@ export function StampRelatedInfo({ _stampId, cpid }: StampRelatedInfoProps) {
       }
     }
   };
-  const _dataLabelClassName =
+  const dataLabel =
     "text-base mobileLg:text-lg font-light text-stamp-grey-darker uppercase";
-  const dataValueXLlinkClassName =
+  const dataValueXLlink =
     "text-3xl mobileLg:text-4xl font-black text-stamp-grey -mt-1";
 
   // Update getTabsWithCounts to use totalCounts
@@ -246,7 +246,7 @@ export function StampRelatedInfo({ _stampId, cpid }: StampRelatedInfoProps) {
           <div class="flex flex-col text-left">
             LISTINGS
             <div
-              class={`${dataValueXLlinkClassName} ${
+              class={`${dataValueXLlink} ${
                 selectedTab === "dispensers"
                   ? "text-stamp-grey-light"
                   : "text-stamp-grey-darker"
@@ -263,7 +263,7 @@ export function StampRelatedInfo({ _stampId, cpid }: StampRelatedInfoProps) {
           <div class="flex flex-col text-center">
             SALES
             <div
-              class={`${dataValueXLlinkClassName} ${
+              class={`${dataValueXLlink} ${
                 selectedTab === "sales"
                   ? "text-stamp-grey-light"
                   : "text-stamp-grey-darker"
@@ -280,7 +280,7 @@ export function StampRelatedInfo({ _stampId, cpid }: StampRelatedInfoProps) {
           <div class="flex flex-col text-right">
             TRANSFERS
             <div
-              class={`${dataValueXLlinkClassName} ${
+              class={`${dataValueXLlink} ${
                 selectedTab === "transfers"
                   ? "text-stamp-grey-light"
                   : "text-stamp-grey-darker"
@@ -296,7 +296,9 @@ export function StampRelatedInfo({ _stampId, cpid }: StampRelatedInfoProps) {
 
   return (
     <div class="dark-gradient rounded-lg p-3 mobileMd:p-6">
-      <div class="flex justify-between w-full -mb-1 mobileLg:mb-2 text-base mobileLg:text-lg text-stamp-grey-darker font-light">
+      <div
+        class={`${dataLabel}  flex justify-between w-full -mb-1 mobileLg:mb-2`}
+      >
         {getTabsWithCounts().map(({ id, label }) => (
           <p
             key={id}

--- a/islands/stamp/details/StampTextContent.tsx
+++ b/islands/stamp/details/StampTextContent.tsx
@@ -1,8 +1,32 @@
-import { useEffect, useState } from "preact/hooks";
+import { useEffect, useRef, useState } from "preact/hooks";
 
 export default function TextContentIsland({ src }: { src: string }) {
   const [content, setContent] = useState<string>("Loading...");
   const [error, setError] = useState<string | null>(null);
+  const [fontSize, setFontSize] = useState("8px");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const updateFontSize = () => {
+      if (containerRef.current) {
+        const containerWidth = containerRef.current.clientWidth;
+        const calculatedSize = Math.min(Math.max(containerWidth * 0.04, 8), 48);
+        setFontSize(`${calculatedSize}px`);
+      }
+    };
+
+    // Initial size calculation
+    updateFontSize();
+
+    // Create ResizeObserver to watch container size changes
+    const resizeObserver = new ResizeObserver(updateFontSize);
+    if (containerRef.current) {
+      resizeObserver.observe(containerRef.current);
+    }
+
+    // Cleanup
+    return () => resizeObserver.disconnect();
+  }, []);
 
   useEffect(() => {
     fetch(src)
@@ -19,8 +43,16 @@ export default function TextContentIsland({ src }: { src: string }) {
   if (error) return <div className="text-red-500">Error: {error}</div>;
 
   return (
-    <div className="w-full h-full overflow-auto p-4 text-sm !text-gray-500 flex items-center justify-center">
-      <pre className="whitespace-pre-wrap break-words max-w-full">{content}</pre>
+    <div
+      ref={containerRef}
+      className="flex items-center justify-center w-full h-full overflow-auto bg-[#F7931A] rounded"
+    >
+      <pre
+        className="whitespace-pre-wrap break-words max-w-full text-black text-center"
+        style={{ fontSize }}
+      >
+        {content}
+      </pre>
     </div>
   );
 }


### PR DESCRIPTION
**Added user selection for open dispensers on the Stamp Detail page**
- displays a listings iconButton - if activeDispensers >=2 (there is at least two dispensers open with stamps remaining)
- onClick of listings iconButton - a dropdown table displays all open dispensers with stamps for sale (remain>0)
- onClick of row - the dispenser is selected and the price/remain/dispenserAddy data is sent to BuyButton and price in BTC/USD updated
- onClick of buyButton - the modal opens with updated data

I have tested the BuyModal and as far as I can see, the data is passed correctly
- kept floorPrice code

**Updated Holders/PieChart table to match styling/functionality of the listings table**
- table code had to be changed to enable row linking

**BuyModal**
- finetuned html image preview styling

**Plaintext stamps**
- changed styling of the background and text raw data - the text size is responsive to it's container (between 8px and 48px) (can be additionally customised to adapt to character amount - if important)
- updated stamp detail page image layout and included copy/Xshare/share/fullscreen icons
- displays size and dimension data

**SIZE DATA**
- changed so that anything under 1 KB displays in bytes instead (eg. 0.9 = 914 B)