### PR TITLE
fix: filtering pop up not working when options selected

### DIFF
--- a/islands/datacontrol/Filter.tsx
+++ b/islands/datacontrol/Filter.tsx
@@ -123,7 +123,7 @@ export function Filter({
         ? prevFilters.filter((f) => f !== value)
         : [...prevFilters, value];
 
-      setFilterValue(newFilters);
+      setFilterValue?.(newFilters);
       updateURL({ filterBy: newFilters });
 
       const url = new URL(globalThis.location.href);

--- a/islands/datacontrol/Filter.tsx
+++ b/islands/datacontrol/Filter.tsx
@@ -49,7 +49,11 @@ export function Filter({
 
       if (e.key === "f") {
         e.preventDefault();
-        handleOpen(true);
+        if (!open) {
+          handleOpen(true);
+        } else {
+          handleOpen(false);
+        }
       }
       if (e.key === "Escape" && open) {
         handleOpen(false);


### PR DESCRIPTION
clicking on a filter option caused console errors. The function added in https://github.com/stampchain-io/BTCStampsExplorer/pull/591 can be `undefined`, which it is in the ART collection usage.

fixes https://github.com/stampchain-io/BTCStampsExplorer/issues/621