### PR TITLE
Stamp Detail page - minor updates

### DIFF
--- a/islands/stamp/details/StampImage.tsx
+++ b/islands/stamp/details/StampImage.tsx
@@ -20,6 +20,10 @@ function RightPanel(
     showCodeButton: boolean;
   },
 ) {
+  if (stamp.ident === "SRC-20") {
+    return null;
+  }
+
   const url = `https://stampchain.io/stamp/${stamp.stamp}`;
   const text = "Check out what I found @Stampchain";
 

--- a/islands/stamp/details/StampInfo.tsx
+++ b/islands/stamp/details/StampInfo.tsx
@@ -340,6 +340,34 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
           setFileSize(blob.size);
         })
         .catch((error) => console.error("Failed to fetch GZIP size:", error));
+    } else if (
+      stamp.stamp_mimetype?.startsWith("video/mpeg") ||
+      stamp.stamp_mimetype?.startsWith("audio/mpeg") ||
+      fileExtension === "MP3" ||
+      fileExtension === "MP4" ||
+      fileExtension === "MPEG"
+    ) {
+      // Handle MPEG files
+      fetch(stamp.stamp_url)
+        .then((response) => {
+          // Try to get content length from headers first
+          const contentLength = response.headers.get("content-length");
+          if (contentLength) {
+            setFileSize(parseInt(contentLength, 10));
+            return;
+          }
+          // If no content length header, try to get the blob size
+          return response.blob();
+        })
+        .then((blob) => {
+          if (blob instanceof Blob) {
+            setFileSize(blob.size);
+          }
+        })
+        .catch((error) => {
+          console.error("Failed to fetch MPEG size:", error);
+          setFileSize(0);
+        });
     } else if (fileExtension === "BMN") {
       // Handle BMN files (lowest priority)
       fetch(stamp.stamp_url)
@@ -381,7 +409,7 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
   // Format dimensions display
   const getDimensionsDisplay = (dims: DimensionsType | null) => {
     if (stamp.stamp_mimetype === "text/plain") {
-      return "FLUID";
+      return "FIXED";
     }
     if (!dims) return "N/A";
     if (dims.unit === "responsive") return "RESPONSIVE";

--- a/islands/stamp/details/StampInfo.tsx
+++ b/islands/stamp/details/StampInfo.tsx
@@ -53,7 +53,7 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
     if (diffHours < 24) {
       // Show relative time for < 24 hours
       const hours = Math.floor(diffHours);
-      return `${hours} ${hours === 1 ? "hour" : "hours"} ago`;
+      return `${hours} ${hours === 1 ? "HOUR" : "HOURS"} AGO`;
     }
 
     // Otherwise show numeric date

--- a/islands/stamp/details/StampInfo.tsx
+++ b/islands/stamp/details/StampInfo.tsx
@@ -439,9 +439,11 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
       }
 
       const data = await response.json();
+
+      // Simply filter for open status dispensers only
       const openDispensers = data.data.filter((d: any) => d.status === "open");
 
-      setDispensers(data.data);
+      setDispensers(openDispensers);
       setActiveDispensers(openDispensers);
     } catch (error) {
       console.error("Error fetching dispensers:", error);
@@ -618,12 +620,10 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
               <div className="flex flex-col w-full pt-6 mobileLg:pt-12">
                 <div
                   className={`flex w-full gap-3 mobileLg:gap-6 mb-3 mobileLg:mb-6 items-end ${
-                    activeDispensers?.length >= 2
-                      ? "justify-between"
-                      : "justify-end"
+                    dispensers?.length >= 2 ? "justify-between" : "justify-end"
                   }`}
                 >
-                  {activeDispensers?.length >= 2 && (
+                  {dispensers?.length >= 2 && (
                     <button
                       onClick={() => setShowListings(!showListings)}
                       className="pb-1.5"
@@ -657,7 +657,7 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
                   </div>
                 </div>
 
-                {(activeDispensers?.length >= 2)
+                {(dispensers?.length >= 2)
                   ? (
                     showListings && (
                       <div className="w-full mb-3 mobileLg:mb-6">
@@ -665,7 +665,7 @@ export function StampInfo({ stamp, lowestPriceDispenser }: StampInfoProps) {
                           ? <p>Loading listings...</p>
                           : (
                             <StampListingsOpen
-                              dispensers={activeDispensers}
+                              dispensers={dispensers}
                               floorPrice={typeof stamp.floorPrice === "number"
                                 ? stamp.floorPrice
                                 : 0}


### PR DESCRIPTION
Finetuning of displayed dispensers (dropdown table onClick of listings iconButton) to also filter for closed dispensers with stamps still remaining in them.
**Does the floorPrice make this distinction ?**

Responsive html/posh text displays on load

Fixed browser tab title display 

Finetuning of stamp details data using conditional logic for
- mpeg/mp3/mp4
- bmn
- src20

I couldn't get the logic to work for 
DEPLOY/MINT/TRANSFER
had a hard time figuring out how to filter this
couldn't find the definitions in globals.d.ts - StampRow

`````
{isSrc20Stamp()
                  ? JSON.parse(stamp.stamp_base64)?.op === "DEPLOY"
                    ? "DEPLOY"
                    : JSON.parse(stamp.stamp_base64)?.op === "MINT"
                    ? "MINT"
                    : "TRANSFER"
                  : isMediaFile
`````

if someone else can update that - thanks
#c32d00