### PR TITLE
Fix transparent background for stamp images

### DIFF
--- a/islands/stamp/StampCard.tsx
+++ b/islands/stamp/StampCard.tsx
@@ -251,13 +251,15 @@ export function StampCard({
 
     // Regular images
     return (
-      <img
-        src={src}
-        loading="lazy"
-        alt={`Stamp No. ${stamp.stamp}`}
-        class="absolute inset-0 w-full h-full object-contain pixelart"
-        onError={handleImageError}
-      />
+      <div class="stamp-container">
+        <img
+          src={src}
+          loading="lazy"
+          alt={`Stamp No. ${stamp.stamp}`}
+          class="absolute inset-0 w-full h-full object-contain pixelart stamp-image"
+          onError={handleImageError}
+        />
+      </div>
     );
   };
 


### PR DESCRIPTION
Add transparent background to stamp images on the `/stamp` route.

* Modify `islands/stamp/StampCard.tsx` to add `stamp-container` class to the image container and ensure `stamp-image` class is applied to the image.
* Adjust z-index to ensure correct layering.

