### PR TITLE
add initEccLib

### DIFF
--- a/server/services/src101/psbt/src101MultisigPSBTService.ts
+++ b/server/services/src101/psbt/src101MultisigPSBTService.ts
@@ -13,6 +13,8 @@ import * as msgpack from "msgpack";
 import { estimateTransactionSize } from "$lib/utils/minting/transactionSizes.ts";
 import { QuicknodeService } from "$server/services/quicknode/quicknodeService.ts";
 
+bitcoin.initEccLib(ecc);
+
 export class SRC101MultisigPSBTService {
   private static readonly RECIPIENT_DUST = 789;
   private static readonly MULTISIG_DUST = 809;


### PR DESCRIPTION
If use a taproot type address, an error will occur.
Error in prepareSrc101TX: Error: No ECC Library provided. You must call initEccLib() with a valid TinySecp256k1Interface instance

After investigation, it was found that an initialization was missing.

Please check if this problem also exists in src20.