### PR TITLE
Add fmt reviewdog step and update checkout versions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,15 @@
+name: Actionlint
+on:
+  push:
+  pull_request:
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: reviewdog/action-actionlint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Cache npm dependencies
       - name: Setup Node.js
@@ -52,6 +52,16 @@ jobs:
           key: ${{ runner.os }}-deno-${{ hashFiles('**/deps.ts') }}
           restore-keys: |
             ${{ runner.os }}-deno-
+
+      - name: Run format check
+        id: fmtcheck
+        run: deno task check:fmt
+        continue-on-error: true
+
+      - name: Run lint check
+        id: lintcheck
+        run: deno task check:lint
+        continue-on-error: true
 
       - name: Install reviewdog
         uses: reviewdog/action-setup@v1
@@ -204,12 +214,19 @@ jobs:
           
           echo "Starting lint checks..."
           process_files lint
-          
+
           exit 0
+
+      - name: Actionlint
+        id: actionlint
+        uses: reviewdog/action-actionlint@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
 
       # Fail the workflow if any checks failed
       - name: Check for failures
-        if: steps.fmt.outcome == 'failure' || steps.lint.outcome == 'failure'
+        if: steps.fmtcheck.outcome == 'failure' || steps.lintcheck.outcome == 'failure' || steps.actionlint.outcome == 'failure'
         run: exit 1
 
       # Build check

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
       # Cache npm dependencies
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -44,7 +44,7 @@ jobs:
           deno-version: v2.3.3
           
       - name: Cache Deno dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.deno
@@ -72,6 +72,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # shellcheck disable=SC2317
           # Enable debug output and error handling
           set -x
           set -e
@@ -93,6 +94,7 @@ jobs:
           ls -la ./scripts/
           
           # Error handling function
+          # shellcheck disable=SC2317
           error() {
             echo "ERROR: $*" >&2
             exit 1
@@ -200,7 +202,6 @@ jobs:
               rm -rf "$batch_dir"
               rm -f "$temp_dir/${check_type}_${batch_num}.json"
               
-              rm -f "${check_type}_${batch_num}.json"
               ((batch_num++))
               
               # Add a small delay between batches to avoid rate limiting

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -17,7 +17,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,9 @@ Use `deno task dev:safe` to clean up before running the dev server.
   - `check:types` – type checking.
 - Excluded paths: `server/`, `_fresh/`, `node_modules/`, `dist/`, and
   other generated files (see `deno.json`).
+- CI runs `deno task check:fmt` and `deno task check:lint` with Reviewdog to
+  annotate formatting and lint issues and executes `actionlint` to validate
+  GitHub Actions workflows.
 
 ## 8. Testing
 - Use the built‑in Deno test runner.


### PR DESCRIPTION
## Summary
- run `deno task check:fmt` in the quality workflow
- ensure checkout actions use v4 in all workflows
- update failure conditions for quality workflow
- document fmt & lint reviewdog checks in AGENTS guidelines

## Testing
- `deno task check` *(fails to download @types/bitcoinjs-lib)*