### PR TITLE
chore: update gitignore to use dashed filename for ssr-safety-report.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,4 +181,4 @@ coverage_psbt_final/*
 coverage_compression*/*
 
 coverage_report.json
-ssr_safety_report.json
+ssr-safety-report.json


### PR DESCRIPTION
## Summary
- Updates `.gitignore` to use the correct filename format `ssr-safety-report.json` (with dashes) instead of `ssr_safety_report.json` (with underscores)
- This aligns with the actual filename generated by the SSR safety scripts

## Test plan
- [x] Verified the change in `.gitignore`
- [x] Confirmed this matches the actual filename used by the SSR safety report generation

🤖 Generated with [Claude Code](https://claude.ai/code)