### PR TITLE
fix: restore missing deno tasks for CI workflows

### DIFF
--- a/.github/workflows/production-validation.yml
+++ b/.github/workflows/production-validation.yml
@@ -45,7 +45,7 @@ jobs:
           restore-keys: deno-
 
       - name: Run TypeScript validation
-        run: deno task check:types
+        run: deno task check
 
       - name: Run test coverage validation
         run: deno task test:unit:coverage
@@ -275,7 +275,7 @@ jobs:
 
       - name: Run security checks
         run: |
-          deno task check:imports:ci
+          deno task check:imports
           deno task check:ssr
 
       - name: Check for hardcoded secrets

--- a/deno.json
+++ b/deno.json
@@ -47,7 +47,14 @@
     "decode_olga": "deno run -A utils/decodeSrc20OlgaTx.ts",
     "deploy:benchmark": "deno run --allow-all scripts/deployment/performance-benchmarking.ts",
     "deploy:rollback": "deno run --allow-all scripts/deployment/automated-rollback.ts ${ROLLBACK_MODE:---check}",
-    "deploy:regression": "deno run --allow-all scripts/deployment/regression-detection.ts ${REGRESSION_MODE:-}"
+    "deploy:rollback:test": "deno run --allow-all scripts/deployment/automated-rollback.ts --test",
+    "deploy:rollback:check": "deno run --allow-all scripts/deployment/automated-rollback.ts --check",
+    "deploy:regression": "deno run --allow-all scripts/deployment/regression-detection.ts ${REGRESSION_MODE:-}",
+    "validate:dependencies": "deno run --allow-all scripts/validation/dependency-graph-analyzer.ts",
+    "validate:dependencies:mermaid": "deno run --allow-all scripts/validation/dependency-graph-analyzer.ts --format=mermaid",
+    "validate:dependencies:json": "deno run --allow-all scripts/validation/dependency-graph-analyzer.ts --format=json",
+    "validate:client-server": "deno run --allow-all scripts/validation/dependency-graph-analyzer.ts --check-client-server",
+    "test:cross-module": "deno task test:integration"
   },
   "lint": {
     "rules": {


### PR DESCRIPTION
## Summary
- Restored missing  and related tasks to deno.json
- Fixed production-validation.yml workflow to use correct task names
- Fixed task references in CI that were causing failures

## Root Cause
These tasks were accidentally removed but the underlying scripts still exist in . The CI workflows were failing because they referenced tasks that no longer existed in deno.json.

## Changes
- ✅ Added back  task  
- ✅ Added  for mermaid format output
- ✅ Added  for JSON format output  
- ✅ Added  for client-server separation checks
- ✅ Added  as alias for 
- ✅ Added  and  tasks
- ✅ Fixed  ->  in production workflow
- ✅ Fixed  ->  in security validation

## Testing
- ✅ All tasks execute properly with `deno task validate`
- ✅ Individual tasks work: `deno task validate:dependencies`
- ✅ Pre-commit hooks pass

This fixes the CI failures in PR #816 and ensures all validation works locally and in CI.

🤖 Generated with [Claude Code](https://claude.ai/code)