### PR TITLE
fix: resolve production CI failures for dev->main PR

### DIFF
--- a/.github/workflows/production-validation.yml
+++ b/.github/workflows/production-validation.yml
@@ -289,7 +289,7 @@ jobs:
       - name: Validate environment security
         run: |
           # Check for .env files in repository
-          if find . -name ".env*" -not -path "./.env.example" -not -path "./.env.template" | grep -q .; then
+          if find . -name ".env*" -not -path "./.env.example" -not -path "./.env.template" -not -path "./.env.sample" | grep -q .; then
             echo "❌ Environment files found in repository"
             exit 1
           fi

--- a/components/card/CollectionCard.tsx
+++ b/components/card/CollectionCard.tsx
@@ -7,7 +7,7 @@ import {
   formatVolume,
 } from "$lib/utils/ui/formatting/formatUtils.ts";
 import { labelSm, valueSm } from "$text";
-import type { CollectionWithOptionalMarketData } from "$types";
+import type { CollectionWithOptionalMarketData } from "$types/";
 
 /* ===== HELPERS ===== */
 function abbreviateCollectionName(name: string): string {

--- a/scripts/validate-import-maps.ts
+++ b/scripts/validate-import-maps.ts
@@ -123,7 +123,7 @@ function findMixedPatterns(content: string, filePath: string): Array<{ file: str
   
   lines.forEach((line, index) => {
     // Check for centralized imports (index.d.ts)
-    if (line.includes('from "$types/index.d.ts"') || line.includes('from "$types"')) {
+    if (line.includes('from "$types/index.d.ts"') || line.includes('from "$types/"')) {
       hasCentralizedImports = true;
       centralizedLines.push(index + 1);
     }

--- a/server/services/stampService.ts
+++ b/server/services/stampService.ts
@@ -18,7 +18,7 @@ import { MarketDataRepository } from "$server/database/marketDataRepository.ts";
 import { CreatorService } from "$server/services/creator/creatorService.ts";
 import { getCacheConfig, RouteType } from "$server/services/infrastructure/cacheService.ts";
 import { BTCPriceService } from "$server/services/price/btcPriceService.ts";
-import type { StampMarketData, XcpBalance } from "$types";
+import type { StampMarketData, XcpBalance } from "$types/";
 
 interface StampServiceOptions {
   cacheType: RouteType;


### PR DESCRIPTION
## Summary

Fixes critical production validation issues blocking PR #816 (dev->main merge).

## Issues Fixed

### 1. TypeScript Import Error ✅
**Error**: `Failed resolving types. Relative import path '$types' not prefixed with / or ./ or ../`

**Fix**: Changed incorrect `$types` imports to `$types/` in 3 files:
- `components/card/CollectionCard.tsx`
- `server/services/stampService.ts`
- `scripts/validate-import-maps.ts`

The import map defines `$types/` not `$types`, causing CI failure.

### 2. Security Validation Failure ✅
**Error**: `❌ Environment files found in repository`

**Fix**: Updated `.github/workflows/production-validation.yml` to exclude `.env.sample`

The workflow was checking for `.env*` files but only excluding `.env.example` and `.env.template`. 
`.env.sample` is an intentional template file tracked in the repository.

### 3. Dependency Health Check ⚠️
**Status**: Pre-existing codebase issue (29 circular deps + 10 orphaned types)

This is not introduced by the icon pack changes. The circular dependencies exist in the type system and should be addressed in a separate refactoring task. Health score is 96.6% which passes the threshold, but the workflow fails on critical issues count.

## Testing

- ✅ `deno task check` passes (TypeScript validation)
- ✅ `deno task check:imports` passes (Import validation)
- ✅ Local validation passes
- 🔄 Awaiting CI validation

## Related PRs

- Blocks: #816 (dev→main merge)
- Follows: #866 (new_icon_pack→dev merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>