### PR TITLE
Stamp creator override

### DIFF
--- a/lib/utils/data/stampDisplayOverrides.ts
+++ b/lib/utils/data/stampDisplayOverrides.ts
@@ -1,0 +1,92 @@
+import type { StampRow } from "$types/stamp.d.ts";
+
+/**
+ * Stamp Display Overrides (UI / API response shaping)
+ * -----------------------------------------------------------------------------
+ * Purpose:
+ * - Provide a *narrow*, explicit mechanism to override certain display-only
+ *   fields for *specific* stamps without changing the underlying on-chain data.
+ *
+ * Why this exists:
+ * - Creator "names" are normally derived from wallet ownership / creators table
+ *   (see CreatorService / StampService). In some cases we intentionally need a
+ *   per-stamp "artist" display name that differs from the wallet-derived name.
+ *
+ * Guardrails / philosophy:
+ * - This MUST NOT change `stamp.creator` (the actual address).
+ * - This is NOT a general "metadata editing" feature; keep entries rare and
+ *   heavily commented so future maintainers can audit intent and provenance.
+ * - These overrides are applied opportunistically in web routes and API handlers
+ *   that return `StampRow` objects.
+ *
+ * Historical note:
+ * - 2025-12: Added a one-off override to display creator name "ZED" for a single
+ *   stamp whose on-chain creator wallet correctly maps to "ARWYN", but needs a
+ *   display override for the stamp detail page and API consumers.
+ */
+
+/**
+ * Map of stamp identifiers to overridden creator display name.
+ *
+ * Identifiers:
+ * - We support multiple identifiers because stamps can be addressed by:
+ *   - route param id (may be tx hash, stamp hash, or other identifier)
+ *   - `cpid`
+ *   - `tx_hash`
+ *   - `stamp_hash`
+ *   - `file_hash`
+ *   - `stamp` number (stringified)
+ *
+ * Keeping this as a Map makes lookup O(1) and avoids accidental partial matches.
+ */
+const CREATOR_NAME_OVERRIDE_BY_IDENTIFIER = new Map<string, string>([
+  /**
+   * Display override request:
+   * - Route: `/stamp/4bd03424dd35f2fe1fb319110a3dd28f971e5e59d1ed5004f6b2`
+   * - Desired display: "ZED"
+   *
+   * IMPORTANT:
+   * - This key is the exact identifier used in the URL.
+   * - We also check other canonical fields (tx_hash, stamp_hash, file_hash, cpid)
+   *   at runtime so the override still applies if the user navigates via a
+   *   different identifier.
+   */
+  ["4bd03424dd35f2fe1fb319110a3dd28f971e5e59d1ed5004f6b2", "ZED"],
+]);
+
+/**
+ * Apply display-only overrides to a single stamp row.
+ *
+ * @param stamp - Stamp row as returned from repository/service/controller
+ * @param requestIdentifier - Optional route/api identifier used to fetch stamp
+ * @returns StampRow (same object shape) with overrides applied
+ */
+export function applyStampDisplayOverrides(
+  stamp: StampRow,
+  requestIdentifier?: string,
+): StampRow {
+  // Collect candidate identifiers (ordered from most specific/contextual).
+  // NOTE: Avoid `filter(Boolean)` here to keep TypeScript narrowing strict.
+  const candidates: string[] = [];
+
+  if (requestIdentifier) candidates.push(requestIdentifier);
+  if (stamp.cpid) candidates.push(stamp.cpid);
+  if (stamp.tx_hash) candidates.push(stamp.tx_hash);
+  if (stamp.stamp_hash) candidates.push(stamp.stamp_hash);
+  if (stamp.file_hash) candidates.push(stamp.file_hash);
+  if (stamp.stamp !== null) candidates.push(String(stamp.stamp));
+
+  for (const key of candidates) {
+    const overrideCreatorName = CREATOR_NAME_OVERRIDE_BY_IDENTIFIER.get(key);
+    if (overrideCreatorName) {
+      return {
+        ...stamp,
+        // NOTE: We override `creator_name` only; the wallet address remains true.
+        creator_name: overrideCreatorName,
+      };
+    }
+  }
+
+  return stamp;
+}
+

--- a/routes/handlers/sharedStampHandler.ts
+++ b/routes/handlers/sharedStampHandler.ts
@@ -14,6 +14,7 @@ import {
 import { Handlers } from "$fresh/server.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
 import { WebResponseUtil } from "$lib/utils/api/responses/webResponseUtil.ts";
+import { applyStampDisplayOverrides } from "$lib/utils/data/stampDisplayOverrides.ts";
 import { getIdentifierType } from "$lib/utils/data/identifiers/identifierUtils.ts";
 import { getPaginationParams } from "$lib/utils/data/pagination/paginationUtils.ts";
 import { StampController } from "$server/controller/stampController.ts";
@@ -424,6 +425,15 @@ export const createStampHandler = (
           const { file_size_bytes: _file_size_bytes, ...v22Stamp } =
             stampData.data.stamp;
           stampData.data.stamp = v22Stamp;
+        }
+
+        // Apply any narrowly-scoped display overrides (e.g., one-off artist name fixes).
+        // NOTE: This keeps `creator` address intact and only affects `creator_name`.
+        if (stampData.data?.stamp) {
+          stampData.data.stamp = applyStampDisplayOverrides(
+            stampData.data.stamp as StampRow,
+            id,
+          );
         }
 
         return ApiResponseUtil.success(

--- a/routes/stamp/[id].tsx
+++ b/routes/stamp/[id].tsx
@@ -6,6 +6,7 @@ import { Head } from "$fresh/runtime.ts";
 import { Handlers } from "$fresh/server.ts";
 import { body, containerBackground, containerGap } from "$layout";
 import { logger, LogNamespace } from "$lib/utils/logger.ts";
+import { applyStampDisplayOverrides } from "$lib/utils/data/stampDisplayOverrides.ts";
 import { StampGallery } from "$section";
 import { StampController } from "$server/controller/stampController.ts";
 import { CounterpartyDispenserService } from "$server/services/counterpartyApiService.ts";
@@ -111,7 +112,9 @@ export const handler: Handlers<StampData> = {
       const stamp = stampData.data.stamp;
 
       // Stamp should already have market data from controller
-      const stampWithPrices = stamp;
+      // Apply any narrowly-scoped display overrides (e.g., one-off artist name fixes)
+      // without mutating the underlying on-chain creator address.
+      const stampWithPrices = applyStampDisplayOverrides(stamp, id);
 
       let htmlTitle = null;
       if (


### PR DESCRIPTION
Add a display override for a specific stamp's creator name to show "ZED" instead of the wallet-derived name.

This introduces a display-only override mechanism for `creator_name` on a per-stamp basis, allowing specific artist names to be shown without altering the underlying on-chain creator wallet address.

---
<a href="https://cursor.com/background-agent?bcId=bc-90e985c1-d953-49f1-bb96-cd5e0cad4b83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90e985c1-d953-49f1-bb96-cd5e0cad4b83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

