### PR TITLE
fix(cache): correct SRC20 transaction cache category detection

### DIFF
--- a/server/database/databaseManager.ts
+++ b/server/database/databaseManager.ts
@@ -908,15 +908,19 @@ class DatabaseManager {
       category = 'src101_balance';
     } else if (queryUpper.includes('STAMP_') && queryUpper.includes('BALANCE')) {
       category = 'stamp_balance';
-    } else if (queryUpper.includes('STAMP_MARKET_DATA') || queryUpper.includes('SRC20_MARKET_DATA')) {
-      category = 'market_data';
     } else if (queryUpper.includes('SRC20_TX') || queryUpper.includes('SRC_20_TX') ||
+               queryUpper.includes('SRC20VALID') ||
                (queryUpper.includes('SRC20') && queryUpper.includes('TRANSACTION'))) {
+      // SRC-20 transaction queries - MUST be checked BEFORE market_data since many
+      // SRC20Valid queries join src20_market_data for enrichment
       category = 'src20_transaction';
+    } else if (queryUpper.includes('STAMP_MARKET_DATA') || queryUpper.includes('SRC20_MARKET_DATA')) {
+      // Pure market data queries (not SRC20Valid transaction lookups)
+      category = 'market_data';
     } else if (queryUpper.includes('FROM SRC20') ||
                (queryUpper.includes('SRC20') && queryUpper.includes('COUNT')) ||
                (queryUpper.includes('SRC20') && queryUpper.includes('TICK'))) {
-      // SRC-20 queries that should be invalidated on new blocks
+      // Generic SRC-20 queries that should be invalidated on new blocks
       category = 'blockchain_data';
     } else if (queryUpper.includes('DISPENSER') || queryUpper.includes('dispensers')) {
       category = 'dispenser';


### PR DESCRIPTION
## Summary

- Move `src20_transaction` category check BEFORE `market_data` check in cache key registry
- Add `SRC20VALID` pattern to `src20_transaction` detection

## Problem

SRC20Valid queries were being categorized as `market_data` instead of `src20_transaction` because:
1. Most SRC20Valid queries join `src20_market_data` table for enrichment
2. The `market_data` pattern check came BEFORE `src20_transaction` check
3. This caused cache invalidation to miss these keys (logs showed "No keys to invalidate for category: src20_transaction")

## Impact

When users queried for SRC20 transactions that didn't exist yet, the "not found" result was cached but never invalidated when the transaction appeared in DB - because the keys were in the wrong category.

## Testing

- TypeScript compiles successfully
- Category detection logic verified against production query patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)