### PR TITLE
fix: make Cursed and Posh stamp filters mutually exclusive

### DIFF
--- a/server/database/stampRepository.ts
+++ b/server/database/stampRepository.ts
@@ -144,7 +144,8 @@ export class StampRepository {
     let stampCondition = "";
     if (type !== "all") {
       if (type === "cursed") {
-        stampCondition = "st.stamp < 0";
+        stampCondition =
+          "st.stamp < 0 AND NOT (st.cpid NOT LIKE 'A%' AND st.ident != 'SRC-20')";
       } else if (type === "stamps" && !identifier) {
         if (!isSearchQuery)
           stampCondition = "st.stamp >= 0 AND st.ident != 'SRC-20'";
@@ -1375,7 +1376,8 @@ export class StampRepository {
     let typeCondition = "";
     if (type !== STAMP_TYPE_CONSTANTS.ALL) {
       if (type === STAMP_TYPE_CONSTANTS.CURSED) {
-        typeCondition = "AND s.stamp < 0";
+        typeCondition =
+          "AND s.stamp < 0 AND NOT (s.cpid NOT LIKE 'A%' AND s.ident != 'SRC-20')";
       } else if (type === STAMP_TYPE_CONSTANTS.CLASSIC) {
         typeCondition = "AND s.stamp >= 0 AND s.cpid LIKE 'A%' AND s.ident != 'SRC-20'";
       } else if (type === STAMP_TYPE_CONSTANTS.STAMPS) {

--- a/tests/mocks/mockDatabaseManager.ts
+++ b/tests/mocks/mockDatabaseManager.ts
@@ -296,7 +296,16 @@ export class MockDatabaseManager {
         normalizedQuery.includes("st.ident != 'src-20'")
       ) {
         stamps = stamps.filter((s) => s.stamp >= 0 && s.ident !== "SRC-20");
-      } // Cursed stamps filter: (st.stamp < 0)
+      } // Cursed stamps filter: excludes posh (cpid NOT LIKE 'A%' AND ident != 'SRC-20')
+      else if (
+        normalizedQuery.includes("st.stamp < 0") &&
+        normalizedQuery.includes("not")
+      ) {
+        stamps = stamps.filter((s) =>
+          s.stamp < 0 &&
+          !(s.cpid && !s.cpid.startsWith("A") && s.ident !== "SRC-20")
+        );
+      } // Posh stamps filter: (st.stamp < 0 AND cpid NOT LIKE 'A%')
       else if (normalizedQuery.includes("st.stamp < 0")) {
         stamps = stamps.filter((s) => s.stamp < 0);
       } // Filter by CPID if present


### PR DESCRIPTION
## Summary

- **Fixes the Posh/Cursed filter overlap** where selecting the "Cursed" filter returned both cursed AND posh stamps
- POSH stamps are a subset of negative-ID stamps with `cpid NOT LIKE 'A%'` — the Cursed filter now explicitly excludes them
- Updated both query locations in `stampRepository.ts` and the test mock

## Root Cause

| Filter | Before (broken) | After (fixed) |
|--------|-----------------|---------------|
| **Cursed** | `stamp < 0` | `stamp < 0 AND NOT (cpid NOT LIKE 'A%' AND ident != 'SRC-20')` |
| **Posh** | `stamp < 0 AND cpid NOT LIKE 'A%' AND ident != 'SRC-20'` | *(unchanged)* |

Before: Cursed ⊃ Posh (overlap)  
After: Cursed ∩ Posh = ∅ (mutually exclusive)

## Files Changed

- `server/database/stampRepository.ts` — SQL filter conditions (2 locations)
- `tests/mocks/mockDatabaseManager.ts` — Mock filter logic to match

## Test plan

- [ ] Verify Cursed filter returns only non-posh negative stamps
- [ ] Verify Posh filter still returns only posh stamps
- [ ] Verify no stamps are "lost" (Cursed count + Posh count = total negative stamps)
- [ ] Verify SRC-20 cursed stamps still appear in Cursed results

Closes #869

🤖 Generated with [Claude Code](https://claude.com/claude-code)