### PR TITLE
fix: resolve CI failures - schema ref and test API mismatch

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -679,7 +679,7 @@ paths:
                   stamps:
                     type: array
                     items:
-                      $ref: "#/components/schemas/Stamp"
+                      $ref: "#/components/schemas/StampRow"
                     description: Paginated array of stamps in the collection
                   marketData:
                     $ref: "#/components/schemas/CollectionMarketData"

--- a/tests/unit/stampRepository.working.test.ts
+++ b/tests/unit/stampRepository.working.test.ts
@@ -58,8 +58,8 @@ Deno.test("StampRepository Unit Tests", async (t) => {
 
     // Check if either query contains stampstablev4 (case insensitive)
     const hasStampTable = queryHistory.some((h) =>
-      h.query.toLowerCase().includes("stampstablev4") ||
-      h.query.toLowerCase().includes("stamptablev4")
+      h.toLowerCase().includes("stampstablev4") ||
+      h.toLowerCase().includes("stamptablev4")
     );
     assertEquals(hasStampTable, true);
 
@@ -180,7 +180,7 @@ Deno.test("StampRepository Unit Tests", async (t) => {
     const queryHistory = mockDb.getQueryHistory();
 
     const countQuery = queryHistory.find((h) =>
-      h.query.toLowerCase().includes("count(*)")
+      h.toLowerCase().includes("count(*)")
     );
     assertExists(countQuery);
 
@@ -209,7 +209,7 @@ Deno.test("StampRepository Unit Tests", async (t) => {
       // Verify the query was called
       const queryHistory = mockDb.getQueryHistory();
       const countQuery = queryHistory.find((h) =>
-        h.query.toLowerCase().includes("count(*)")
+        h.toLowerCase().includes("count(*)")
       );
       assertExists(countQuery);
 


### PR DESCRIPTION
## Summary
- Fix unresolved `$ref` in `schema.yml` (#/components/schemas/Stamp -> StampRow)
- Fix `getQueryHistory()` API usage in stamp repository tests (returns `string[]` not `{query}[]`)

## Root Cause
PR #895 added new OpenAPI schemas but referenced a non-existent `Stamp` component. The test mock's `getQueryHistory()` API was changed to return `string[]` but some tests still accessed `.query` property.

## Test plan
- [x] `deno task check` passes locally
- [ ] CI Quality Checks pass (schema validation)
- [ ] CI Unit Tests pass (stamp repository tests)

Generated with [Claude Code](https://claude.com/claude-code)