### PR TITLE
fix: SRC20 search returns fully minted tokens

### DIFF
--- a/islands/tool/src20/MintTool.tsx
+++ b/islands/tool/src20/MintTool.tsx
@@ -239,7 +239,9 @@ export function SRC20MintTool({
     const delayDebounceFn = setTimeout(async () => {
       try {
         const response = await fetch(
-          `/api/v2/src20/search?q=${encodeURIComponent(searchTerm.trim())}`,
+          `/api/v2/src20/search?q=${
+            encodeURIComponent(searchTerm.trim())
+          }&mintable_only=true`,
         );
         const data = await response.json();
 

--- a/routes/api/v2/src20/search.ts
+++ b/routes/api/v2/src20/search.ts
@@ -7,8 +7,12 @@ export const handler: Handlers = {
     try {
       const url = new URL(req.url);
       const query = url.searchParams.get("q") || "";
+      const mintableOnly = url.searchParams.get("mintable_only") === "true";
 
-      const results = await SRC20Service.QueryService.searchSrc20Data(query);
+      const results = await SRC20Service.QueryService.searchSrc20Data(
+        query,
+        mintableOnly,
+      );
 
       return ApiResponseUtil.success({ data: results });
     } catch (error) {

--- a/server/database/src20Repository.ts
+++ b/server/database/src20Repository.ts
@@ -876,8 +876,15 @@ export class SRC20Repository {
     };
   }
 
-  static async searchValidSrc20TxFromDb(query: string) {
+  static async searchValidSrc20TxFromDb(
+    query: string,
+    mintableOnly = false,
+  ) {
     const sanitizedQuery = query.replace(/[^\w-]/g, "");
+
+    const mintableFilter = mintableOnly
+      ? "AND COALESCE(smd.progress_percentage, 0) < 100"
+      : "";
 
     const sqlQuery = `
     SELECT DISTINCT
@@ -899,8 +906,7 @@ export class SRC20Repository {
         src20.destination LIKE ?)
         AND src20.max IS NOT NULL
         AND src20.op = 'DEPLOY'
-        -- Use progress_percentage from market data instead of manual calculation
-        AND COALESCE(smd.progress_percentage, 0) < 100
+        ${mintableFilter}
     ORDER BY
         CASE
             WHEN src20.tick LIKE ? THEN 0

--- a/server/services/src20/queryService.ts
+++ b/server/services/src20/queryService.ts
@@ -348,7 +348,7 @@ export class SRC20QueryService {
     }
   }
 
-  static async searchSrc20Data(query: string) {
+  static async searchSrc20Data(query: string, mintableOnly = false) {
     try {
       // Input validation and sanitization
       if (!query || typeof query !== 'string') {
@@ -361,7 +361,10 @@ export class SRC20QueryService {
       }
 
       // Fetch raw data from repository
-      const rawResults = await SRC20Repository.searchValidSrc20TxFromDb(sanitizedQuery);
+      const rawResults = await SRC20Repository.searchValidSrc20TxFromDb(
+        sanitizedQuery,
+        mintableOnly,
+      );
 
       // Early return for empty results
       if (!rawResults || rawResults.length === 0) {


### PR DESCRIPTION
## Summary
- Fixes #857 — SRC20 search returning empty results for fully-minted tokens (e.g., KEVIN)
- Root cause: `searchValidSrc20TxFromDb()` hardcoded `COALESCE(smd.progress_percentage, 0) < 100`, filtering out any token at 100% mint progress
- Adds `mintable_only` query parameter to `/api/v2/src20/search` endpoint
- MintTool passes `mintable_only=true` (only shows mintable tokens)
- General search modal omits the param (shows all tokens including fully minted)

## Changes
| File | Change |
|------|--------|
| `server/database/src20Repository.ts` | `searchValidSrc20TxFromDb()` accepts `mintableOnly` param; filter is conditional |
| `server/services/src20/queryService.ts` | `searchSrc20Data()` passes `mintableOnly` through to repository |
| `routes/api/v2/src20/search.ts` | Parses `mintable_only` query parameter from URL |
| `islands/tool/src20/MintTool.tsx` | Appends `&mintable_only=true` to search fetch URL |

## Test plan
- [x] All 853 unit tests pass (2 pre-existing failures unrelated: logger leak, MARA config leak)
- [x] Pre-commit hooks pass (fmt, lint, type check on 573 files)
- [x] Manual: Search "KEVIN" in SRC20 search modal — should now return results
- [x] Manual: MintTool search should still only show mintable (< 100%) tokens
- [x] Manual: Verify other search terms (address, tx hash) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)