### PR TITLE
fix: use direct BINARY(16) join for collection_market_data

### DIFF
--- a/server/database/collectionRepository.ts
+++ b/server/database/collectionRepository.ts
@@ -263,8 +263,9 @@ export class CollectionRepository {
 
     // Join market data table if requested
     if (includeMarketData) {
+      // collection_market_data.collection_id is BINARY(16), same as collections.collection_id
       query += `
-      LEFT JOIN collection_market_data cmd ON cmd.collection_id = HEX(c.collection_id)
+      LEFT JOIN collection_market_data cmd ON cmd.collection_id = c.collection_id
       `;
     }
 
@@ -479,10 +480,9 @@ export class CollectionRepository {
     // Option C (Hybrid): Use pre-computed collection_market_data table for performance
     if (includeMarketData) {
       // Join with collection_market_data table
-      // collection_market_data.collection_id stores HEX string
-      // collections.collection_id stores BINARY(16), so convert with HEX()
+      // Both collection_market_data.collection_id and collections.collection_id are BINARY(16)
       query += `
-      LEFT JOIN collection_market_data cmd ON cmd.collection_id = HEX(c.collection_id)
+      LEFT JOIN collection_market_data cmd ON cmd.collection_id = c.collection_id
       `;
     }
 


### PR DESCRIPTION
## Summary
- Backend team confirmed `collection_market_data.collection_id` is `BINARY(16)`, same as `collections.collection_id`
- Changed JOIN from `HEX()` string comparison to direct binary-to-binary join
- This should allow market data to properly flow through to collection endpoints

## Context
The previous JOIN used `cmd.collection_id = HEX(c.collection_id)` which compared BINARY(16) to VARCHAR - a type mismatch. The correct join is `cmd.collection_id = c.collection_id` since both columns are BINARY(16).

Backend team confirms:
- `collection_market_data` table has 66 rows (all collections)
- 52 collections have floor prices
- Table refreshed every ~30 minutes
- Last updated minutes ago

## Test plan
- [x] `deno task check` passes
- [ ] Production verification: collection endpoint returns market data after deploy
- [ ] Fallback still works if column names don't match actual schema

Generated with [Claude Code](https://claude.com/claude-code)