### PR TITLE
fix: use HEX() join for collection_market_data

### DIFF
--- a/server/database/collectionRepository.ts
+++ b/server/database/collectionRepository.ts
@@ -262,9 +262,9 @@ export class CollectionRepository {
 
     // Join market data table if requested
     if (includeMarketData) {
-      // collection_market_data.collection_id is BINARY(16), same as collections.collection_id
+      // collection_market_data.collection_id stores hex string, collections.collection_id is BINARY(16)
       query += `
-      LEFT JOIN collection_market_data cmd ON cmd.collection_id = c.collection_id
+      LEFT JOIN collection_market_data cmd ON cmd.collection_id = HEX(c.collection_id)
       `;
     }
 
@@ -476,10 +476,9 @@ export class CollectionRepository {
     // Join market data table if requested
     // Option C (Hybrid): Use pre-computed collection_market_data table for performance
     if (includeMarketData) {
-      // Join with collection_market_data table
-      // Both collection_market_data.collection_id and collections.collection_id are BINARY(16)
+      // collection_market_data.collection_id stores hex string, collections.collection_id is BINARY(16)
       query += `
-      LEFT JOIN collection_market_data cmd ON cmd.collection_id = c.collection_id
+      LEFT JOIN collection_market_data cmd ON cmd.collection_id = HEX(c.collection_id)
       `;
     }
 


### PR DESCRIPTION
## Summary
- Reverts the direct binary JOIN from PR #902 back to `HEX(c.collection_id)` for both `getCollectionById()` and `getCollectionDetailsWithMarketData()`
- `collection_market_data.collection_id` stores the hex string (not raw binary), confirmed by `marketDataRepository.ts` which queries it with `WHERE collection_id = ?` passing hex strings directly

## Root Cause
PR #902 changed the JOIN from `cmd.collection_id = HEX(c.collection_id)` to `cmd.collection_id = c.collection_id` based on the assumption both columns were BINARY(16). However, `collection_market_data.collection_id` stores the hex string representation while `collections.collection_id` is raw BINARY(16). The type mismatch caused the LEFT JOIN to return no matches, resulting in `marketData: null`.

## Test plan
- [ ] Verify `GET /api/v2/collections/015F0478516E4273DD90FE59C766DD98` returns populated `marketData` object
- [ ] Verify `marketDataRepository.getCollectionMarketData()` still works (uses same hex string format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)