### PR TITLE
fix: use HEX() on both sides of collection_market_data JOIN

### DIFF
--- a/server/database/collectionRepository.ts
+++ b/server/database/collectionRepository.ts
@@ -263,9 +263,9 @@ export class CollectionRepository {
 
     // Join market data table if requested
     if (includeMarketData) {
-      // collection_market_data.collection_id stores hex string, collections.collection_id is BINARY(16)
+      // Use HEX() on both sides to guarantee matching regardless of column type
       query += `
-      LEFT JOIN collection_market_data cmd ON cmd.collection_id = HEX(c.collection_id)
+      LEFT JOIN collection_market_data cmd ON HEX(cmd.collection_id) = HEX(c.collection_id)
       `;
     }
 
@@ -477,9 +477,9 @@ export class CollectionRepository {
 
     // Join market data table if requested
     if (includeMarketData) {
-      // collection_market_data.collection_id stores hex string, collections.collection_id is BINARY(16)
+      // Use HEX() on both sides to guarantee matching regardless of column type
       query += `
-      LEFT JOIN collection_market_data cmd ON cmd.collection_id = HEX(c.collection_id)
+      LEFT JOIN collection_market_data cmd ON HEX(cmd.collection_id) = HEX(c.collection_id)
       `;
     }
 


### PR DESCRIPTION
## Summary
- Changed LEFT JOIN from `cmd.collection_id = HEX(c.collection_id)` to `HEX(cmd.collection_id) = HEX(c.collection_id)`
- This ensures correct matching regardless of whether `collection_market_data.collection_id` is BINARY(16) or VARCHAR

## Context
Previous HEX() on one side only may have been comparing different types (binary vs string), causing the JOIN to find no matches and returning `marketData: null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)