### PR TITLE
fix: use UNHEX() for collection_market_data queries

### DIFF
--- a/server/database/marketDataRepository.ts
+++ b/server/database/marketDataRepository.ts
@@ -452,7 +452,7 @@ export class MarketDataRepository {
   static async getCollectionMarketData(collectionId: string): Promise<CollectionMarketData | null> {
     const query = `
       SELECT
-        collection_id,
+        HEX(collection_id) as collection_id,
         min_floor_price_btc,
         max_floor_price_btc,
         avg_floor_price_btc,
@@ -469,7 +469,7 @@ export class MarketDataRepository {
         last_updated,
         TIMESTAMPDIFF(MINUTE, last_updated, UTC_TIMESTAMP()) as cache_age_minutes
       FROM collection_market_data
-      WHERE collection_id = ?
+      WHERE collection_id = UNHEX(?)
       LIMIT 1
     `;
 


### PR DESCRIPTION
## Summary
- Backend confirmed `collection_market_data.collection_id` is **BINARY(16)**, not VARCHAR
- All queries must use `UNHEX()` to convert hex string params for matching
- `HEX()` added in SELECT to return readable hex strings for map keys
- Fixes market data always returning `null` for all collections (PRs #903-907 all had wrong assumption)

## Changes
- `collectionRepository.ts`: `getCollectionById()` query: `WHERE collection_id = UNHEX(?)`
- `collectionRepository.ts`: `getCollectionDetailsWithMarketData()` batch query: `WHERE collection_id IN (UNHEX(?), ...)`  with `HEX(collection_id)` in SELECT
- `marketDataRepository.ts`: `getCollectionMarketData()` query: same UNHEX fix

## Root Cause
All previous attempts (#903-#907) assumed `collection_market_data.collection_id` was VARCHAR storing hex strings. Backend confirmed it's BINARY(16) — same type as `collections.collection_id`. Raw hex string comparison against BINARY column returns 0 rows silently.

## Test plan
- [ ] Verify `curl https://stampchain.io/api/v2/collections/015F0478516E4273DD90FE59C766DD98` returns populated `marketData` with floor prices
- [ ] Run Newman smoke tests (18 assertions)
- [ ] Check ECS logs for errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)