### PR TITLE
fix: use correct collection_market_data column names

### DIFF
--- a/components/card/CollectionCard.tsx
+++ b/components/card/CollectionCard.tsx
@@ -109,8 +109,8 @@ export function CollectionCard(
             <h5 class={`${labelSm} -mt-0.5 hidden mobileLg:block`}>
               VOLUME{" "}
               <span class={valueSm}>
-                {collection.marketData?.totalVolume24hBTC
-                  ? formatVolume(collection.marketData.totalVolume24hBTC)
+                {collection.marketData?.volume24hBTC
+                  ? formatVolume(collection.marketData.volume24hBTC)
                   : "N/A"}
               </span>{"  "}
               <span class="text-color-grey-light">BTC</span>
@@ -121,8 +121,8 @@ export function CollectionCard(
               <span class="min-[400px]:hidden">PRICE</span>
               <span class="hidden min-[400px]:inline">FLOOR PRICE</span>{" "}
               <span class={valueSm}>
-                {collection.marketData?.minFloorPriceBTC
-                  ? formatBTC(collection.marketData.minFloorPriceBTC)
+                {collection.marketData?.floorPriceBTC
+                  ? formatBTC(collection.marketData.floorPriceBTC)
                   : "N/A"}
               </span>{" "}
               <span class="text-color-grey-light">BTC</span>
@@ -131,10 +131,10 @@ export function CollectionCard(
               <span class="min-[400px]:hidden">MCAP</span>
               <span class="hidden min-[400px]:inline">MARKETCAP</span>{" "}
               <span class={valueSm}>
-                {collection.marketData?.minFloorPriceBTC &&
+                {collection.marketData?.floorPriceBTC &&
                     collection.total_editions
                   ? formatMarketCap(
-                    collection.marketData.minFloorPriceBTC *
+                    collection.marketData.floorPriceBTC *
                       collection.total_editions,
                   )
                   : "N/A"}

--- a/islands/header/CollectionDetailHeader.tsx
+++ b/islands/header/CollectionDetailHeader.tsx
@@ -107,11 +107,11 @@ export const CollectionDetailHeader = (
             MARKETCAP
           </h5>
           <h6 class={value3xl}>
-            {collection.marketData?.minFloorPriceBTC !== null &&
-                collection.marketData?.minFloorPriceBTC !== undefined &&
+            {collection.marketData?.floorPriceBTC !== null &&
+                collection.marketData?.floorPriceBTC !== undefined &&
                 collection.total_editions
               ? formatMarketCap(
-                collection.marketData.minFloorPriceBTC *
+                collection.marketData.floorPriceBTC *
                   collection.total_editions,
               )
               : "N/A"} <span class="font-light">BTC</span>
@@ -123,9 +123,9 @@ export const CollectionDetailHeader = (
               HOLDERS
             </h5>
             <h6 class={valueSm}>
-              {collection.marketData?.totalUniqueHolders
+              {collection.marketData?.uniqueHolders
                 ? formatNumberWithCommas(
-                  collection.marketData.totalUniqueHolders,
+                  collection.marketData.uniqueHolders,
                 )
                 : "N/A"}
             </h6>
@@ -151,9 +151,9 @@ export const CollectionDetailHeader = (
               FLOOR PRICE
             </h5>
             <h6 class={valueSm}>
-              {collection.marketData?.minFloorPriceBTC !== null &&
-                  collection.marketData?.minFloorPriceBTC !== undefined
-                ? `${formatBTC(collection.marketData.minFloorPriceBTC)} BTC`
+              {collection.marketData?.floorPriceBTC !== null &&
+                  collection.marketData?.floorPriceBTC !== undefined
+                ? `${formatBTC(collection.marketData.floorPriceBTC)} BTC`
                 : "N/A BTC"}
             </h6>
           </div>
@@ -162,8 +162,8 @@ export const CollectionDetailHeader = (
               24H VOLUME
             </h5>
             <h6 class={valueSm}>
-              {collection.marketData?.totalVolume24hBTC !== undefined
-                ? `${formatVolume(collection.marketData.totalVolume24hBTC)} BTC`
+              {collection.marketData?.volume24hBTC !== undefined
+                ? `${formatVolume(collection.marketData.volume24hBTC)} BTC`
                 : "N/A BTC"}
             </h6>
           </div>
@@ -172,9 +172,9 @@ export const CollectionDetailHeader = (
               AVG PRICE
             </h5>
             <h6 class={valueSm}>
-              {collection.marketData?.avgFloorPriceBTC !== null &&
-                  collection.marketData?.avgFloorPriceBTC !== undefined
-                ? `${formatBTC(collection.marketData.avgFloorPriceBTC)} BTC`
+              {collection.marketData?.avgPriceBTC !== null &&
+                  collection.marketData?.avgPriceBTC !== undefined
+                ? `${formatBTC(collection.marketData.avgPriceBTC)} BTC`
                 : "N/A BTC"}
             </h6>
           </div>

--- a/lib/types/api.d.ts
+++ b/lib/types/api.d.ts
@@ -1366,18 +1366,20 @@ export interface Collection {
   first_stamp_image?: string | null;
   stamp_images?: string[] | null;
   img: string;
-  // Market data fields
+  // Market data from collection_market_data table
   marketData?: {
-    minFloorPriceBTC: number | null;
-    maxFloorPriceBTC: number | null;
-    avgFloorPriceBTC: number | null;
-    medianFloorPriceBTC: number | null;
-    totalVolume24hBTC: number;
-    stampsWithPricesCount: number;
-    minHolderCount: number;
-    maxHolderCount: number;
+    floorPriceBTC: number | null;
+    avgPriceBTC: number | null;
+    totalValueBTC: number;
+    volume24hBTC: number;
+    volume7dBTC: number;
+    volume30dBTC: number;
     totalVolumeBTC: number;
-    marketCapBTC: number | null;
+    totalStamps: number;
+    uniqueHolders: number;
+    listedStamps: number;
+    soldStamps24h: number;
+    lastUpdated: Date | null;
   };
 }
 

--- a/lib/types/marketData.d.ts
+++ b/lib/types/marketData.d.ts
@@ -167,24 +167,25 @@ export interface SRC20MarketDataRow {
 
 /**
  * Database row interface for collection_market_data table
- * All DECIMAL columns are represented as strings to preserve precision
+ * Actual columns: collection_id (BINARY(16)), floor_price_btc, avg_price_btc,
+ * total_value_btc, volume_24h_btc, volume_7d_btc, volume_30d_btc, total_volume_btc,
+ * total_stamps, unique_holders, listed_stamps, sold_stamps_24h, last_updated, created_at
  */
 export interface CollectionMarketDataRow {
   collection_id: string;
-  min_floor_price_btc: string | null;
-  max_floor_price_btc: string | null;
-  avg_floor_price_btc: string | null;
-  median_floor_price_btc: string | null;
-  total_volume_24h_btc: string;
-  stamps_with_prices_count: number;
-  min_holder_count: number;
-  max_holder_count: number;
-  avg_holder_count: string;
-  median_holder_count: number;
-  total_unique_holders: number;
-  avg_distribution_score: string;
-  total_stamps_count: number;
+  floor_price_btc: string | null;
+  avg_price_btc: string | null;
+  total_value_btc: string | null;
+  volume_24h_btc: string;
+  volume_7d_btc: string;
+  volume_30d_btc: string;
+  total_volume_btc: string;
+  total_stamps: number;
+  unique_holders: number;
+  listed_stamps: number;
+  sold_stamps_24h: number;
   last_updated: Date;
+  created_at: Date;
 }
 
 /**
@@ -251,19 +252,17 @@ export interface SRC20MarketData {
 
 export interface CollectionMarketData {
   collectionId: string;
-  minFloorPriceBTC: number | null;
-  maxFloorPriceBTC: number | null;
-  avgFloorPriceBTC: number | null;
-  medianFloorPriceBTC: number | null;
-  totalVolume24hBTC: number;
-  stampsWithPricesCount: number;
-  minHolderCount: number;
-  maxHolderCount: number;
-  avgHolderCount: number;
-  medianHolderCount: number;
-  totalUniqueHolders: number;
-  avgDistributionScore: number;
-  totalStampsCount: number;
+  floorPriceBTC: number | null;
+  avgPriceBTC: number | null;
+  totalValueBTC: number;
+  volume24hBTC: number;
+  volume7dBTC: number;
+  volume30dBTC: number;
+  totalVolumeBTC: number;
+  totalStamps: number;
+  uniqueHolders: number;
+  listedStamps: number;
+  soldStamps24h: number;
   lastUpdated: Date;
 }
 

--- a/lib/types/stamp.d.ts
+++ b/lib/types/stamp.d.ts
@@ -1395,22 +1395,21 @@ export interface StampMarketData {
 
 /**
  * CollectionMarketData - Migrated from marketData.d.ts
+ * Matches actual collection_market_data table columns
  */
 export interface CollectionMarketData {
   collectionId: string;
-  minFloorPriceBTC: number | null;
-  maxFloorPriceBTC: number | null;
-  avgFloorPriceBTC: number | null;
-  medianFloorPriceBTC: number | null;
-  totalVolume24hBTC: number;
-  stampsWithPricesCount: number;
-  minHolderCount: number;
-  maxHolderCount: number;
-  avgHolderCount: number;
-  medianHolderCount: number;
-  totalUniqueHolders: number;
-  avgDistributionScore: number;
-  totalStampsCount: number;
+  floorPriceBTC: number | null;
+  avgPriceBTC: number | null;
+  totalValueBTC: number;
+  volume24hBTC: number;
+  volume7dBTC: number;
+  volume30dBTC: number;
+  totalVolumeBTC: number;
+  totalStamps: number;
+  uniqueHolders: number;
+  listedStamps: number;
+  soldStamps24h: number;
   lastUpdated: Date;
 }
 

--- a/server/controller/collectionController.ts
+++ b/server/controller/collectionController.ts
@@ -138,20 +138,9 @@ export class CollectionController {
             img: collectionRow.img,
             first_stamp_image: firstStampImage,
             stamp_images: stamps,
-            // Convert marketData from CollectionMarketData to the expected format
+            // Pass through market data from collection_market_data table
             ...(collectionRow.marketData && {
-              marketData: {
-                minFloorPriceBTC: collectionRow.marketData.minFloorPriceBTC,
-                maxFloorPriceBTC: collectionRow.marketData.maxFloorPriceBTC,
-                avgFloorPriceBTC: collectionRow.marketData.avgFloorPriceBTC,
-                medianFloorPriceBTC: collectionRow.marketData.medianFloorPriceBTC,
-                totalVolume24hBTC: collectionRow.marketData.totalVolume24hBTC,
-                stampsWithPricesCount: collectionRow.marketData.stampsWithPricesCount,
-                minHolderCount: collectionRow.marketData.minHolderCount,
-                maxHolderCount: collectionRow.marketData.maxHolderCount,
-                totalVolumeBTC: collectionRow.marketData.totalVolume24hBTC, // Use 24h volume as total
-                marketCapBTC: null, // Not available in CollectionMarketData
-              }
+              marketData: collectionRow.marketData,
             }),
           };
 

--- a/server/types/collection.d.ts
+++ b/server/types/collection.d.ts
@@ -54,7 +54,7 @@ export interface CollectionWithOptionalMarketData extends CollectionRow {
     avg: number | null;
   } | null;
   totalVolume24h?: number | null;
-  totalUniqueHolders?: number | null;
+  uniqueHolders?: number | null;
 
   // Stamp image fields for gallery display
   first_stamp_image?: string;

--- a/server/types/collection_test.ts
+++ b/server/types/collection_test.ts
@@ -61,19 +61,17 @@ Deno.test("CollectionWithOptionalMarketData - market data structure", () => {
     img: "https://example.com/image.png",
     marketData: {
       collectionId: "collection_123",
-      minFloorPriceBTC: 0.01,
-      maxFloorPriceBTC: 0.05,
-      avgFloorPriceBTC: 0.03,
-      medianFloorPriceBTC: 0.04,
-      totalVolume24hBTC: 1.5,
-      stampsWithPricesCount: 5,
-      minHolderCount: 2,
-      maxHolderCount: 10,
-      avgHolderCount: 5,
-      medianHolderCount: 4,
-      totalUniqueHolders: 25,
-      avgDistributionScore: 0.6,
-      totalStampsCount: 10,
+      floorPriceBTC: 0.01,
+      avgPriceBTC: 0.03,
+      totalValueBTC: 0.5,
+      volume24hBTC: 1.5,
+      volume7dBTC: 5.0,
+      volume30dBTC: 15.0,
+      totalVolumeBTC: 25.0,
+      totalStamps: 10,
+      uniqueHolders: 25,
+      listedStamps: 5,
+      soldStamps24h: 2,
       lastUpdated: new Date(),
     },
     cacheStatus: "fresh",
@@ -85,7 +83,7 @@ Deno.test("CollectionWithOptionalMarketData - market data structure", () => {
   };
 
   assertExists(collection.marketData);
-  assertEquals(collection.marketData.totalVolume24hBTC, 1.5);
+  assertEquals(collection.marketData.volume24hBTC, 1.5);
   assertEquals(collection.cacheStatus, "fresh");
 });
 


### PR DESCRIPTION
## Summary
- Replace `SELECT *` with explicit column names matching the actual `collection_market_data` table schema
- Update all type definitions, queries, mappings, and UI references from assumed column names to actual DB columns
- Removes stale `SELECT *` workaround from PR #910 in favor of proper explicit columns

## Changes
**Database queries** (`collectionRepository.ts`, `marketDataRepository.ts`):
- Single + batch queries use explicit column names: `floor_price_btc`, `avg_price_btc`, `total_value_btc`, `volume_24h_btc`, etc.

**Type definitions** (`marketData.d.ts`, `api.d.ts`, `stamp.d.ts`, `collection.d.ts`):
- `CollectionMarketDataRow` and `CollectionMarketData` interfaces match actual schema
- Duplicate interface in `stamp.d.ts` synced

**UI components** (`CollectionCard.tsx`, `CollectionDetailHeader.tsx`):
- `minFloorPriceBTC` → `floorPriceBTC`
- `totalVolume24hBTC` → `volume24hBTC`
- `avgFloorPriceBTC` → `avgPriceBTC`
- `totalUniqueHolders` → `uniqueHolders`

## Actual DB Schema (from CloudWatch diagnostics)
```
collection_id (BINARY(16)), floor_price_btc, avg_price_btc, total_value_btc,
volume_24h_btc, volume_7d_btc, volume_30d_btc, total_volume_btc, total_stamps,
unique_holders, listed_stamps, sold_stamps_24h, last_updated, created_at
```

## Test plan
- [x] TypeScript type checking passes (`deno check .`)
- [x] Lint passes
- [ ] Verify `/api/v2/collections/KEVIN` returns marketData with new field names
- [ ] Verify `/api/v2/collections` list endpoint returns marketData per collection

🤖 Generated with [Claude Code](https://claude.com/claude-code)