### PR TITLE
fix: update OpenAPI schema for collection market data fields

### DIFF
--- a/schema.yml
+++ b/schema.yml
@@ -3918,46 +3918,9 @@ components:
             type: integer
           description: Array of stamp numbers in this collection
         marketData:
-          type: object
+          $ref: "#/components/schemas/CollectionMarketData"
           nullable: true
           description: Aggregated market data for the collection from collection_market_data table
-          properties:
-            minFloorPriceBTC:
-              type: number
-              nullable: true
-              description: Minimum floor price in BTC across all stamps
-            maxFloorPriceBTC:
-              type: number
-              nullable: true
-              description: Maximum floor price in BTC across all stamps
-            avgFloorPriceBTC:
-              type: number
-              nullable: true
-              description: Average floor price in BTC across all stamps
-            medianFloorPriceBTC:
-              type: number
-              nullable: true
-              description: Median floor price in BTC across all stamps
-            totalVolume24hBTC:
-              type: number
-              description: Total 24-hour trading volume for all stamps in the collection
-            stampsWithPricesCount:
-              type: integer
-              description: Number of stamps with pricing data
-            minHolderCount:
-              type: integer
-              description: Minimum holder count across all stamps
-            maxHolderCount:
-              type: integer
-              description: Maximum holder count across all stamps
-            totalVolumeBTC:
-              type: number
-              nullable: true
-              description: Total trading volume (uses 24h volume)
-            marketCapBTC:
-              type: number
-              nullable: true
-              description: Market capitalization in BTC (may not be available)
 
     ErrorResponseBody:
       type: object
@@ -4655,61 +4618,55 @@ components:
       description: Database row format for collection market data from collection_market_data table (snake_case, string decimals)
       required:
         - collection_id
-        - total_volume_24h_btc
-        - stamps_with_prices_count
-        - total_stamps_count
         - last_updated
       properties:
         collection_id:
           type: string
-          description: Collection UUID identifier
-        min_floor_price_btc:
+          description: Collection UUID identifier (BINARY(16))
+        floor_price_btc:
           type: string
           nullable: true
-          description: Minimum floor price in BTC (DECIMAL stored as string)
-        max_floor_price_btc:
+          description: Floor price in BTC (DECIMAL stored as string)
+        avg_price_btc:
           type: string
           nullable: true
-          description: Maximum floor price in BTC (DECIMAL stored as string)
-        avg_floor_price_btc:
+          description: Average price in BTC (DECIMAL stored as string)
+        total_value_btc:
           type: string
           nullable: true
-          description: Average floor price in BTC (DECIMAL stored as string)
-        median_floor_price_btc:
+          description: Total value in BTC (DECIMAL stored as string)
+        volume_24h_btc:
           type: string
-          nullable: true
-          description: Median floor price in BTC (DECIMAL stored as string)
-        total_volume_24h_btc:
+          description: 24-hour volume in BTC (DECIMAL stored as string)
+        volume_7d_btc:
           type: string
-          description: Total 24-hour volume in BTC (DECIMAL stored as string)
-        stamps_with_prices_count:
-          type: integer
-          description: Number of stamps with pricing data
-        min_holder_count:
-          type: integer
-          description: Minimum holder count across stamps
-        max_holder_count:
-          type: integer
-          description: Maximum holder count across stamps
-        avg_holder_count:
+          description: 7-day volume in BTC (DECIMAL stored as string)
+        volume_30d_btc:
           type: string
-          description: Average holder count (DECIMAL stored as string)
-        median_holder_count:
-          type: integer
-          description: Median holder count
-        total_unique_holders:
-          type: integer
-          description: Total unique holders across collection
-        avg_distribution_score:
+          description: 30-day volume in BTC (DECIMAL stored as string)
+        total_volume_btc:
           type: string
-          description: Average distribution score (DECIMAL stored as string)
-        total_stamps_count:
+          description: Total volume in BTC (DECIMAL stored as string)
+        total_stamps:
           type: integer
           description: Total number of stamps in collection
+        unique_holders:
+          type: integer
+          description: Total unique holders across collection
+        listed_stamps:
+          type: integer
+          description: Number of stamps currently listed
+        sold_stamps_24h:
+          type: integer
+          description: Number of stamps sold in last 24 hours
         last_updated:
           type: string
           format: date-time
           description: Last update timestamp
+        created_at:
+          type: string
+          format: date-time
+          description: Row creation timestamp
 
     CollectionMarketData:
       type: object
@@ -4718,49 +4675,41 @@ components:
         collectionId:
           type: string
           description: Collection identifier
-        minFloorPriceBTC:
+        floorPriceBTC:
           type: number
           nullable: true
-          description: Minimum floor price in the collection
-        maxFloorPriceBTC:
+          description: Floor price in BTC
+        avgPriceBTC:
           type: number
           nullable: true
-          description: Maximum floor price in the collection
-        avgFloorPriceBTC:
+          description: Average price in BTC
+        totalValueBTC:
           type: number
-          nullable: true
-          description: Average floor price in the collection
-        medianFloorPriceBTC:
+          description: Total value in BTC
+        volume24hBTC:
           type: number
-          nullable: true
-          description: Median floor price in the collection
-        totalVolume24hBTC:
+          description: 24-hour trading volume in BTC
+        volume7dBTC:
           type: number
-          description: Total 24-hour volume for the collection
-        stampsWithPricesCount:
-          type: integer
-          description: Number of stamps with price data
-        minHolderCount:
-          type: integer
-          description: Minimum holder count in the collection
-        maxHolderCount:
-          type: integer
-          description: Maximum holder count in the collection
-        avgHolderCount:
+          description: 7-day trading volume in BTC
+        volume30dBTC:
           type: number
-          description: Average holder count
-        medianHolderCount:
-          type: integer
-          description: Median holder count
-        totalUniqueHolders:
-          type: integer
-          description: Total unique holders across collection
-        avgDistributionScore:
+          description: 30-day trading volume in BTC
+        totalVolumeBTC:
           type: number
-          description: Average distribution score
-        totalStampsCount:
+          description: Total trading volume in BTC
+        totalStamps:
           type: integer
           description: Total number of stamps in collection
+        uniqueHolders:
+          type: integer
+          description: Total unique holders across collection
+        listedStamps:
+          type: integer
+          description: Number of stamps currently listed
+        soldStamps24h:
+          type: integer
+          description: Number of stamps sold in last 24 hours
         lastUpdated:
           type: string
           format: date-time


### PR DESCRIPTION
## Summary
- Update `CollectionMarketData` schema to match actual database columns (`floorPriceBTC`, `avgPriceBTC`, `volume24hBTC`, `volume7dBTC`, `volume30dBTC`, `totalVolumeBTC`, `totalStamps`, `uniqueHolders`, `listedStamps`, `soldStamps24h`)
- Update `CollectionMarketDataRow` schema to match actual `collection_market_data` table columns
- Replace inline `marketData` property duplication with `$ref` to canonical `CollectionMarketData` schema
- Stamp filter query parameters (`minFloorPriceBTC`, `maxFloorPriceBTC`, `minHolderCount`, `maxHolderCount`) are unchanged — these are stamp-level API filters, not collection market data

## Test plan
- [x] Pre-commit validation passes (`deno task validate:quick`)
- [x] Schema matches the live API response from `https://stampchain.io/api/v2/collections/KEVIN`

🤖 Generated with [Claude Code](https://claude.com/claude-code)