### PR TITLE
fix(src101): replace hardcoded 300-byte fee estimate with data-aware calculation

### DIFF
--- a/tests/unit/transactionSizeEstimator.test.ts
+++ b/tests/unit/transactionSizeEstimator.test.ts
@@ -393,12 +393,14 @@ describe("Transaction Size Estimator", () => {
       assert(Number.isInteger(result));
     });
 
-    it("should cap data chunks for SRC20/SRC101", () => {
-      const result = estimateTransactionSizeForType("src20", 10000);
+    it("should scale data chunks proportionally for SRC20/SRC101", () => {
+      const small = estimateTransactionSizeForType("src20", 100);
+      const large = estimateTransactionSizeForType("src20", 1000);
 
-      // Should cap at 5 chunks regardless of file size
-      assert(result < 1000); // Should not be enormous
-      assert(Number.isInteger(result));
+      // Larger data should produce larger estimates (62-byte chunk scaling)
+      assert(large > small);
+      assert(Number.isInteger(small));
+      assert(Number.isInteger(large));
     });
 
     it("should estimate send transaction size", () => {


### PR DESCRIPTION
## Summary

Fixes #688 — SRC-101 fee estimation was hardcoded at 300 bytes in 3 locations, causing 20-400% fee underestimation.

### Root cause
SRC-101 transactions use 3-of-3 bare multisig outputs to encode data in 62-byte chunks. Each multisig output adds ~114 vbytes. A typical mint operation produces 5-7 chunks (570-800+ vbytes), but the estimate was locked at 300.

### Changes
- **`routes/api/v2/src101/create.ts`** — dryRun now calculates chunk count from request body, applies proper vbyte formula (142 base + 114/chunk)
- **`client/hooks/userSRC101Form.ts`** — Phase 1 estimate uses operation-type-aware sizes (deploy: 400, mint: 350, transfer: 200 bytes)
- **`lib/utils/bitcoin/transactions/transactionSizeEstimator.ts`** — Fixed chunk size from 32 to 62 bytes for src20/src101, removed incorrect 5-chunk cap, added recipient output
- **`tests/unit/transactionSizeEstimator.test.ts`** — Updated test to verify proportional scaling instead of old 5-chunk cap

### Dust calculation fix
Also fixes dust value from hardcoded 546 sats to actual SRC-101 values: 789 sats (recipient) + 809 sats per multisig output.

## Test plan
- [x] All 878 unit tests pass
- [x] `deno fmt`, `deno lint`, `deno check` all clean
- [ ] Verify dryRun endpoint returns larger, more accurate estimates
- [ ] Verify client-side Phase 1 estimates match closer to actual PSBT fees
- [ ] AWS deployment validation

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>