### PR TITLE
fix(src101): make expire filter optional to fix domain availability check

### DIFF
--- a/routes/api/v2/src101/[deploy_hash]/[tokenid].ts
+++ b/routes/api/v2/src101/[deploy_hash]/[tokenid].ts
@@ -50,12 +50,18 @@ export const handler: Handlers = {
         return sortValidation.error!;
       }
 
+      // Support optional expire filter: ?expire=0 (active only), ?expire=1 (expired only)
+      // No expire param returns all records (needed for availability checks)
+      const expireParam = url.searchParams.get("expire");
+      const expire = expireParam !== null ? Number(expireParam) : undefined;
+
       const queryParams = {
         deploy_hash,
         tokenid,
         limit: limit || DEFAULT_PAGINATION.limit,
         page: page || DEFAULT_PAGINATION.page,
         ...(sortValidation.data && { sort: sortValidation.data }),
+        ...(expire !== undefined && { expire }),
       };
 
       const result = await Src101Controller.handleSrc101OwnerRequest(

--- a/server/database/src101Repository.ts
+++ b/server/database/src101Repository.ts
@@ -667,11 +667,15 @@ export class SRC101Repository {
       queryParams.push(params.index);
     }
 
-    if (params.expire && params.expire == 1) {
-      whereClauses.push(`expire_timestamp < ?`);
-      queryParams.push(new Date().getTime() / 1000);
-    } else {
-      whereClauses.push(`expire_timestamp > ?`);
+    // Only filter by expiry when explicitly requested:
+    // expire=1: expired records only, expire=0: non-expired only
+    // No expire param: return all records (needed for availability checks)
+    if (params.expire !== undefined && params.expire !== null) {
+      if (params.expire == 1) {
+        whereClauses.push(`expire_timestamp < ?`);
+      } else {
+        whereClauses.push(`expire_timestamp > ?`);
+      }
       queryParams.push(new Date().getTime() / 1000);
     }
 
@@ -715,11 +719,15 @@ export class SRC101Repository {
       queryParams.push(params.index);
     }
 
-    if (params.expire && params.expire == 1) {
-      whereClauses.push(`? > expire_timestamp`);
-      queryParams.push(new Date().getTime() / 1000);
-    } else {
-      whereClauses.push(`? < expire_timestamp`);
+    // Only filter by expiry when explicitly requested:
+    // expire=1: expired records only, expire=0: non-expired only
+    // No expire param: return all records (needed for availability checks)
+    if (params.expire !== undefined && params.expire !== null) {
+      if (params.expire == 1) {
+        whereClauses.push(`? > expire_timestamp`);
+      } else {
+        whereClauses.push(`? < expire_timestamp`);
+      }
       queryParams.push(new Date().getTime() / 1000);
     }
 


### PR DESCRIPTION
## Summary
- Fixes #687 — SRC-101 Domain Validation (Availability) Check Broken
- `getSrc101Owner()` and `getSrc101OwnerCount()` always applied an expiry filter, even when no `expire` parameter was passed
- The default `else` branch filtered for non-expired only (`current_time < expire_timestamp`), excluding domains with `expire_timestamp=0` (permanent registrations)
- This caused the availability check to show "available" for domains that were actually registered

## Changes
- **`server/database/src101Repository.ts`**: Made expire filter conditional in both `getSrc101Owner()` and `getSrc101OwnerCount()` — only filter when `expire` param is explicitly set (`0`=active, `1`=expired, omitted=all records)
- **`routes/api/v2/src101/[deploy_hash]/[tokenid].ts`**: Added `?expire=` query parameter support for explicit filtering

## Test plan
- [x] All 878 unit tests pass
- [ ] Deploy to AWS ECS and verify production
- [ ] Test SRC-101 availability check returns registered domains correctly
- [ ] Verify existing SRC-101 validation flows (transfer, setrecord, renew) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)