### PR TITLE
fix(src101): allow base64 tokenid in domain validation route

### DIFF
--- a/routes/api/v2/src101/[deploy_hash]/[tokenid].ts
+++ b/routes/api/v2/src101/[deploy_hash]/[tokenid].ts
@@ -27,10 +27,10 @@ export const handler: Handlers = {
         );
       }
 
-      // Validate tokenid format (should be numeric or alphanumeric)
-      if (!/^[a-zA-Z0-9-]+$/.test(tokenid)) {
+      // Validate tokenid format (base64 encoded: alphanumeric + /+=)
+      if (!/^[a-zA-Z0-9+/=-]+$/.test(tokenid)) {
         return ResponseUtil.badRequest(
-          `Invalid token ID format: ${tokenid}. Must be alphanumeric.`,
+          `Invalid token ID format: ${tokenid}. Must be valid base64.`,
         );
       }
 


### PR DESCRIPTION
## Summary
- Follow-up fix for #687 — the tokenid validation regex `[a-zA-Z0-9-]+` rejected base64-encoded tokenids containing `+`, `/`, or `=`
- The client sends `btoa()` encoded domain names (e.g., `btoa("satoshi.btc")` = `"c2F0b3NoaS5idGM="`) which always have `=` padding
- Updated regex to `[a-zA-Z0-9+/=-]+` to accept valid base64 characters

## Test plan
- [x] 877/878 tests pass (1 pre-existing MARA test failure, unrelated)
- [ ] Verify SRC-101 domain lookup works with base64 tokenids in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)