### PR TITLE
fix(src101): encode availability check tokenid without TLD to match DB format

### DIFF
--- a/islands/tool/src101/RegisterTool.tsx
+++ b/islands/tool/src101/RegisterTool.tsx
@@ -244,9 +244,11 @@ export function SRC101RegisterTool({
   const checkAvailability = async (): Promise<boolean> => {
     setCheckStatus(false);
     try {
+      // Encode only the domain name without TLD to match DB storage format
+      // The mint operation stores btoa(toAddress), not btoa(toAddress + root)
       const url =
         `/api/v2/src101/77fb147b72a551cf1e2f0b37dccf9982a1c25623a7fe8b4d5efaac566cf63fed/${
-          btoa((formState.toAddress + formState.root)?.toLowerCase())
+          btoa(formState.toAddress?.toLowerCase())
         }`;
       const res = await fetch(url);
       const jsonData = await res.json();


### PR DESCRIPTION
## Summary

- Fixes the root cause of the SRC-101 domain availability check always showing domains as available
- The availability check was encoding `btoa(toAddress + root)` (e.g. `btoa("buy.btc")` = `YnV5LmJ0Yw==`) but the DB stores `btoa(toAddress)` (e.g. `btoa("buy")` = `YnV5`)
- This tokenid format mismatch meant the API lookup never matched existing registrations

This is the third and final fix for #687, complementing PR #919 (expire filter) and PR #920 (base64 validation regex).

Fixes #687

## Test plan

- [x] All 877 tests pass (1 pre-existing MARA test failure, unrelated)
- [x] Pre-commit hooks pass (fmt, lint, type check)
- [ ] Deploy to AWS and verify availability check returns correct data for registered domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)