### PR TITLE
fix: suppress wallet-connection fee errors on tool pages

### DIFF
--- a/islands/tool/fairmint/FairmintTool.tsx
+++ b/islands/tool/fairmint/FairmintTool.tsx
@@ -258,24 +258,6 @@ export function FairmintTool({ fairminters }: FairmintToolProps) {
           }
         />
 
-        {/* ===== 🚨 FEE ESTIMATION ERROR HANDLING ===== */}
-        {feeEstimationError && (
-          <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-2xl">
-            <div className="flex items-center justify-between">
-              <span className="text-red-700 text-sm">
-                Fee estimation error: {feeEstimationError}
-              </span>
-              <button
-                type="button"
-                onClick={clearError}
-                className="text-red-500 hover:text-red-700 text-sm font-medium"
-              >
-                Clear
-              </button>
-            </div>
-          </div>
-        )}
-
         {/* ===== STATUS MESSAGES ===== */}
         <StatusMessages
           submissionMessage={submissionMessage}

--- a/islands/tool/src101/RegisterTool.tsx
+++ b/islands/tool/src101/RegisterTool.tsx
@@ -425,24 +425,6 @@ export function SRC101RegisterTool({
           }
         />
 
-        {/* ===== 🚨 FEE ESTIMATION ERROR HANDLING ===== */}
-        {feeEstimationError && (
-          <div className="mt-4 p-3 bg-red-50 border border-red-200 rounded-2xl">
-            <div className="flex items-center justify-between">
-              <span className="text-red-700 text-sm">
-                Fee estimation error: {feeEstimationError}
-              </span>
-              <button
-                type="button"
-                onClick={clearError}
-                className="text-red-500 hover:text-red-700 text-sm font-medium"
-              >
-                Clear
-              </button>
-            </div>
-          </div>
-        )}
-
         <StatusMessages
           submissionMessage={submissionMessage}
           apiError={apiError}

--- a/islands/tool/src20/DeployTool.tsx
+++ b/islands/tool/src20/DeployTool.tsx
@@ -597,20 +597,6 @@ export function SRC20DeployTool(
           }
         />
 
-        {/* Error Display */}
-        {feeEstimationError && (
-          <div className="mt-2 text-red-500 text-sm">
-            Fee estimation error: {feeEstimationError}
-            <button
-              type="button"
-              onClick={clearError}
-              className="ml-2 text-red-400 hover:text-red-300"
-            >
-              ✕
-            </button>
-          </div>
-        )}
-
         <StatusMessages
           submissionMessage={submissionMessage}
           apiError={apiError}

--- a/islands/tool/src20/MintTool.tsx
+++ b/islands/tool/src20/MintTool.tsx
@@ -637,20 +637,6 @@ export function SRC20MintTool({
           }
         />
 
-        {/* Error Display */}
-        {feeEstimationError && (
-          <div className="mt-2 text-red-500 text-sm">
-            Fee estimation error: {feeEstimationError}
-            <button
-              type="button"
-              onClick={clearError}
-              className="ml-2 text-red-400 hover:text-red-300"
-            >
-              ✕
-            </button>
-          </div>
-        )}
-
         {/* ===== STATUS MESSAGES ===== */}
         <StatusMessages
           submissionMessage={submissionMessage}

--- a/islands/tool/src20/TransferTool.tsx
+++ b/islands/tool/src20/TransferTool.tsx
@@ -449,20 +449,6 @@ export function SRC20TransferTool(
           }
         />
 
-        {/* Error Display */}
-        {feeEstimationError && (
-          <div className="mt-2 text-red-500 text-sm">
-            Fee estimation error: {feeEstimationError}
-            <button
-              type="button"
-              onClick={clearError}
-              className="ml-2 text-red-400 hover:text-red-300"
-            >
-              ✕
-            </button>
-          </div>
-        )}
-
         {/* ===== STATUS MESSAGES ===== */}
         <StatusMessages
           submissionMessage={submissionMessage}

--- a/islands/tool/stamp/StampingTool.tsx
+++ b/islands/tool/stamp/StampingTool.tsx
@@ -2291,9 +2291,7 @@ function StampingToolMain({ config }: { config: Config }) {
 
       <StatusMessages
         submissionMessage={submissionMessage}
-        apiError={apiError || maraError || (feeEstimationError
-          ? `Fee estimation error: ${feeEstimationError}`
-          : "")}
+        apiError={apiError || maraError || ""}
         transactionHex={debugTransactionHex}
         {...(debugTransactionHex
           ? {

--- a/lib/hooks/useTransactionConstructionService.ts
+++ b/lib/hooks/useTransactionConstructionService.ts
@@ -235,10 +235,14 @@ export function useTransactionConstructionService(options: EstimationOptions) {
         }
       } catch (error) {
         if (!isCancelled) {
-          dispatch({
-            type: "ESTIMATION_ERROR",
-            error: error instanceof Error ? error.message : String(error),
-          });
+          const errorMsg = error instanceof Error
+            ? error.message
+            : String(error);
+          // Don't surface wallet-connection errors — missing wallet is an
+          // expected state on tool pages, not an error worth displaying.
+          if (!/wallet.*connect|connect.*required/i.test(errorMsg)) {
+            dispatch({ type: "ESTIMATION_ERROR", error: errorMsg });
+          }
         }
       }
     };
@@ -326,7 +330,11 @@ export function useTransactionConstructionService(options: EstimationOptions) {
         const errorMessage = error instanceof Error
           ? error.message
           : String(error);
-        dispatch({ type: "ESTIMATION_ERROR", error: errorMessage });
+        // Don't surface wallet-connection errors — missing wallet is an
+        // expected state on tool pages, not an error worth displaying.
+        if (!/wallet.*connect|connect.*required/i.test(errorMessage)) {
+          dispatch({ type: "ESTIMATION_ERROR", error: errorMessage });
+        }
         throw error;
       }
     },


### PR DESCRIPTION
## Summary

- Fixes the "Connect Wallet" button bug where tool pages showed confusing red error banners instead of cleanly prompting wallet connection
- **Hook fix**: `useTransactionConstructionService` now filters out wallet-connection errors from `ESTIMATION_ERROR` dispatch — missing wallet is an expected state, not an error
- **UI cleanup**: Removed redundant standalone fee estimation error divs from 5 tool pages — `ProgressiveEstimationIndicator` already handles error display non-intrusively when wallet IS connected
- Affected pages: StampingTool, MintTool, DeployTool, TransferTool, FairmintTool, RegisterTool

Fixes #885

## Test plan

- [x] All 877 tests pass (1 pre-existing logger leak, unrelated)
- [x] Pre-commit hooks pass (fmt, lint, type check, import validation)
- [ ] Deploy to AWS and verify no error banners appear on tool pages without wallet

🤖 Generated with [Claude Code](https://claude.com/claude-code)