### PR TITLE
fix: prevent placeholder image flash (#790)

### DIFF
--- a/islands/card/StampCard.tsx
+++ b/islands/card/StampCard.tsx
@@ -88,7 +88,9 @@ export function StampCard({
     setLoading(true);
     const res = getStampImageSrc(stamp as StampRow);
     setSrc(res);
-    setLoading(false);
+    // Don't setLoading(false) here — wait for the browser to confirm
+    // the image loaded (via onLoad) or SVG validation to complete.
+    // This prevents the "no-image" placeholder flash.
   };
 
   /* ===== EFFECTS ===== */
@@ -96,6 +98,19 @@ export function StampCard({
   useEffect(() => {
     fetchStampImage();
   }, []);
+
+  // For non-SVG content types that don't need async validation,
+  // clear loading once src is resolved (audio, text, library, html
+  // all render immediately without an <img> load cycle).
+  useEffect(() => {
+    if (!src || stamp.stamp_mimetype === "image/svg+xml") return;
+    const mimetype = stamp.stamp_mimetype || "";
+    const needsImgLoad = mimetype.startsWith("image/") ||
+      mimetype === "text/html";
+    if (!needsImgLoad) {
+      setLoading(false);
+    }
+  }, [src, stamp.stamp_mimetype]);
 
   // Validate SVG content when source changes
   useEffect(() => {
@@ -124,6 +139,7 @@ export function StampCard({
                     loading="lazy"
                     alt={`Stamp No. ${stamp.stamp}`}
                     class="max-w-none object-contain rounded-2xl pixelart stamp-image h-full w-full"
+                    onLoad={() => setLoading(false)}
                     onError={handleImageError}
                   />
                 </div>
@@ -139,6 +155,7 @@ export function StampCard({
                     loading="lazy"
                     alt={`Stamp No. ${stamp.stamp}`}
                     class="max-w-none object-contain rounded-2xl pixelart stamp-image h-full w-full"
+                    onLoad={() => setLoading(false)}
                     onError={handleImageError}
                   />
                 </div>
@@ -154,6 +171,7 @@ export function StampCard({
               </div>
             </div>,
           );
+          setLoading(false);
         }
       }
     };
@@ -164,7 +182,7 @@ export function StampCard({
 
   /* ===== RENDER HELPERS ===== */
   const renderContent = () => {
-    if (loading && !src) {
+    if (loading) {
       return (
         <div class="stamp-container">
           <LoadingIcon />
@@ -238,6 +256,7 @@ export function StampCard({
               loading="lazy"
               alt={`Stamp No. ${stamp.stamp}`}
               class="max-w-none object-contain rounded-2xl pixelart stamp-image h-full w-full"
+              onLoad={() => setLoading(false)}
               onError={handleImageError}
             />
           </div>
@@ -275,6 +294,7 @@ export function StampCard({
             loading="lazy"
             alt={`Stamp No. ${stamp.stamp}`}
             class="max-w-none object-contain rounded-2xl pixelart stamp-image h-full w-full"
+            onLoad={() => setLoading(false)}
             onError={handleImageError}
           />
         </div>


### PR DESCRIPTION
## Summary
- Fixes the 3-step flash (spinner → "no-image" placeholder → actual image) when loading stamp images
- Root cause: `setLoading(false)` was called synchronously in `fetchStampImage()` before the browser downloaded the image
- Now keeps `loading=true` until the browser confirms the image via `onLoad` event handler
- Non-image content types (audio, text, library, iframe) clear loading immediately via useEffect

## Changes
- **StampCard.tsx**: Deferred loading state, added `onLoad` to all `<img>` tags
- **WalletStampCard.tsx**: Same fix pattern + fixed `handleImageError` to use transparent pixel (prevents infinite error loops from `src=""`)
- **StampImage.tsx**: Same fix pattern adapted for detail page component structure

## Test plan
- [ ] Verify stamp gallery loads without "no-image" placeholder flash
- [ ] Verify SVG stamps render correctly (both regular and recursive/external reference SVGs)
- [ ] Verify HTML stamps render correctly via preview images (StampCard) and iframes (StampImage)
- [ ] Verify audio, text/plain, and library file stamps still display correctly
- [ ] Verify wallet page stamp cards load without flash
- [ ] Verify stamp detail page images load without flash
- [ ] Verify error handling still shows proper fallback for broken images

Closes #790

🤖 Generated with [Claude Code](https://claude.com/claude-code)