### PR TITLE
hotfix: resolve image loading deadlock from #925

### DIFF
--- a/islands/content/stampDetailContent/StampImage.tsx
+++ b/islands/content/stampDetailContent/StampImage.tsx
@@ -473,9 +473,7 @@ export function StampImage(
     setLoading(true);
     const res = getStampImageSrc(stamp);
     setSrc(res ?? undefined);
-    // Don't setLoading(false) here — wait for the browser to confirm
-    // the image loaded (via onLoad) or SVG validation to complete.
-    // This prevents the "no-image" placeholder flash.
+    setLoading(false);
   };
 
   const fetchHtmlContent = async () => {
@@ -630,18 +628,6 @@ export function StampImage(
   useEffect(() => {
     fetchStampImage();
   }, []);
-
-  // For non-SVG content types that don't need an <img> load cycle,
-  // clear loading once src is resolved (audio, text, library, html/iframe
-  // all render immediately without waiting for browser image download).
-  useEffect(() => {
-    if (!src || stamp?.stamp_mimetype === "image/svg+xml") return;
-    const mimetype = stamp?.stamp_mimetype || "";
-    const needsImgLoad = mimetype.startsWith("image/");
-    if (!needsImgLoad) {
-      setLoading(false);
-    }
-  }, [src, stamp?.stamp_mimetype]);
 
   useEffect(() => {
     const isHtml = stamp?.stamp_mimetype === "text/html";


### PR DESCRIPTION
## HOTFIX - Production images broken

PR #925 introduced a loading state deadlock that breaks ALL images on stampchain.io.

### Root cause
Changing `if (loading && !src)` to `if (loading)` prevented `<img>` tags from ever rendering, so `onLoad` never fired, keeping `loading=true` forever — infinite spinner.

### Fix
- Revert render condition to `if (loading && !src)`
- Add targeted `isValidating` state for SVG validation (the actual source of the #790 "no-image" flash)
- Show spinner during async SVG validation instead of "no-image" placeholder
- Keep the `handleImageError` transparent pixel fix and `onLoad` handlers (harmless improvements)

### Files
- `islands/card/StampCard.tsx`
- `islands/card/WalletStampCard.tsx`
- `islands/content/stampDetailContent/StampImage.tsx`

Fixes the regression from #925.

🤖 Generated with [Claude Code](https://claude.com/claude-code)