### PR TITLE
hotfix: fix Deno.cwd() crash breaking all images on stampchain.io

### DIFF
--- a/server/config/config.ts
+++ b/server/config/config.ts
@@ -57,7 +57,9 @@ type ServerConfig = {
 };
 
 const serverConfig: ServerConfig = {
-  APP_ROOT: Deno.cwd(),
+  get APP_ROOT() {
+    return Deno.cwd();
+  },
   MINTING_SERVICE_FEE_ENABLED: "0",
   MINTING_SERVICE_FEE_FIXED_SATS: "0",
 


### PR DESCRIPTION
## Summary
- PRs #916/#923 added `import { serverConfig }` to `lib/types/errors.ts`
- `errors.ts` is transitively imported by island code (header + section islands)
- `serverConfig` has `APP_ROOT: Deno.cwd()` — an eagerly-evaluated property
- When imported in the browser, `Deno.cwd()` throws `ReferenceError: Deno is not defined`
- This crashes **ALL** Fresh island hydration — zero islands mount, zero stamp images render

## Fix
Change `APP_ROOT: Deno.cwd()` from an eager property to a lazy getter (`get APP_ROOT() { return Deno.cwd(); }`), matching all other serverConfig properties. The getter only evaluates when actually accessed (server-side only).

## Validated with Playwright
- Before fix: 0 hydrated islands, 37 stuck loading spinners, "Deno is not defined" JS error
- After fix: All islands hydrate, stamp images render correctly

## Test plan
- [x] `deno task check` passes (fmt, lint, type check)
- [x] Import validation: 100% compliance
- [ ] Deploy to production and verify images load on stampchain.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)