### PR TITLE
fix(ci): run only cross-module tests in integration matrix job

### DIFF
--- a/.github/workflows/production-validation.yml
+++ b/.github/workflows/production-validation.yml
@@ -159,7 +159,10 @@ jobs:
         run: deno task validate:dependencies
 
       - name: Run cross-module type compatibility tests
-        run: deno task test:cross-module
+        run: deno test --allow-all tests/integration/cross-module/ --no-check
+        env:
+          DENO_ENV: test
+          SKIP_REDIS_CONNECTION: "true"
 
       - name: Generate dependency visualization
         run: deno task validate:dependencies:mermaid


### PR DESCRIPTION
## Summary

Fixes Cross-Module Integration Testing CI job (4 matrix variants) that was newly surfaced after PR #931 unblocked the dependency chain.

### Root Cause

`deno task test:cross-module` is mapped to `deno task test:integration` which runs **ALL** integration tests (including DB-dependent ones like `mintEndpoint.slow.test.ts`). The CI job should only run the cross-module type compatibility tests.

### Fix

Changed the CI step to run tests directly from `tests/integration/cross-module/` instead of using the misconfigured task alias:
```yaml
run: deno test --allow-all tests/integration/cross-module/ --no-check
env:
  DENO_ENV: test
  SKIP_REDIS_CONNECTION: "true"
```

The cross-module tests (`type-compatibility-matrix.test.ts`, `runtime-type-resolution.test.ts`, `integration-test-runner.test.ts`) are self-contained type validation tests that don't need DB.

## Test plan
- [ ] Cross-Module Integration Testing (5.0-5.3) jobs pass in CI
- [ ] No regression on other passing jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)