### PR TITLE
fix(ci): run cross-module tests from tests/ directory

### DIFF
--- a/.github/workflows/production-validation.yml
+++ b/.github/workflows/production-validation.yml
@@ -159,7 +159,7 @@ jobs:
         run: deno task validate:dependencies
 
       - name: Run cross-module type compatibility tests
-        run: deno test --allow-all tests/integration/cross-module/ --no-check
+        run: cd tests && deno test --allow-all integration/cross-module/ --no-check
         env:
           DENO_ENV: test
           SKIP_REDIS_CONNECTION: "true"


### PR DESCRIPTION
## Summary

Fixes the `No test modules found` error in Cross-Module Integration Testing CI job.

The cross-module tests require the `tests/deno.json` import map to resolve `$types/`, `$server/`, etc. aliases. Running from the project root skips this config. Changed to `cd tests && deno test ...` matching the pattern used by `deno task test:integration`.

## Test plan
- [x] `cd tests && deno test --allow-all integration/cross-module/ --no-check` passes locally
- [ ] Cross-Module Integration Testing (5.0-5.3) jobs pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)