### PR TITLE
fix(ci): install Newman in Docker and fix report directory paths

### DIFF
--- a/scripts/run-newman-with-openapi.sh
+++ b/scripts/run-newman-with-openapi.sh
@@ -4,14 +4,20 @@ echo "=== Newman with OpenAPI Contract Testing ==="
 echo "Node version:" && node --version
 echo "NPM version:" && npm --version
 
-echo "=== Installing Local Dependencies for OpenAPI Validation ==="
-npm install --no-fund --silent
-echo "Local dependencies installed"
+echo "=== Installing Newman and Dependencies ==="
+# Install Newman globally if not already available
+if ! command -v newman >/dev/null 2>&1; then
+  echo "Newman not found, installing globally..."
+  npm install -g newman newman-reporter-html newman-reporter-json --no-fund --silent
+fi
 
-echo "=== Checking Pre-installed Dependencies ==="
+# Install local dependencies for OpenAPI validation
+npm install --no-fund --silent 2>/dev/null || true
+echo "Dependencies installed"
+
+echo "=== Checking Dependencies ==="
 echo "Newman version:" && newman --version
 echo "Node.js version:" && node --version
-echo "Global modules:" && ls -la /usr/local/lib/node_modules/ | grep -E "(newman|js-yaml|ajv)" | head -3 || echo "Dependencies ready"
 
 echo "=== Checking OpenAPI Validator ==="
 if [ -f "scripts/newman-openapi-validator.mjs" ]; then
@@ -28,8 +34,9 @@ wget -q --spider http://host.docker.internal:8000/api/v2/stamps?limit=1 && echo 
 wget -q --spider https://stampchain.io/api/v2/stamps?limit=1 && echo "Production server is reachable" || echo "Production server is NOT reachable"
 
 echo "=== Preparing Reports Directory ==="
-mkdir -p reports/newman
-chmod 755 reports/newman
+REPORT_DIR="reports/${REPORT_PREFIX:-newman}"
+mkdir -p "$REPORT_DIR"
+chmod 755 "$REPORT_DIR"
 
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 echo "Using timestamp: $TIMESTAMP"
@@ -43,7 +50,7 @@ if [ "$USE_OPENAPI_VALIDATOR" = "true" ] && [ -f "./static/swagger/openapi.yml" 
   node scripts/newman-openapi-validator.mjs \
     ./static/swagger/openapi.yml \
     "${NEWMAN_COLLECTION:-tests/postman/collections/comprehensive.json}" \
-    "${NEWMAN_ENVIRONMENT:-postman-environment.json}" > reports/newman/$TIMESTAMP-openapi-validation.log 2>&1
+    "${NEWMAN_ENVIRONMENT:-postman-environment.json}" > $REPORT_DIR/$TIMESTAMP-openapi-validation.log 2>&1
   
   OPENAPI_EXIT_CODE=$?
   
@@ -55,7 +62,7 @@ if [ "$USE_OPENAPI_VALIDATOR" = "true" ] && [ -f "./static/swagger/openapi.yml" 
   
   # Also generate standard Newman reports using global newman
   # Build Newman command with proper parameter handling
-  NEWMAN_CMD="newman run '${NEWMAN_COLLECTION:-tests/postman/collections/comprehensive.json}' --environment '${NEWMAN_ENVIRONMENT:-postman-environment.json}' --reporters cli,html,json --reporter-html-export reports/newman/$TIMESTAMP-report.html --reporter-json-export reports/newman/$TIMESTAMP-results.json"
+  NEWMAN_CMD="newman run '${NEWMAN_COLLECTION:-tests/postman/collections/comprehensive.json}' --environment '${NEWMAN_ENVIRONMENT:-postman-environment.json}' --reporters cli,html,json --reporter-html-export $REPORT_DIR/$TIMESTAMP-report.html --reporter-json-export $REPORT_DIR/$TIMESTAMP-results.json"
   
   [ -n "$NEWMAN_FOLDER" ] && NEWMAN_CMD="$NEWMAN_CMD --folder '$NEWMAN_FOLDER'"
   [ -n "$NEWMAN_ITERATIONS" ] && [ "$NEWMAN_ITERATIONS" -gt 0 ] && NEWMAN_CMD="$NEWMAN_CMD --iteration-count $NEWMAN_ITERATIONS"
@@ -65,34 +72,34 @@ if [ "$USE_OPENAPI_VALIDATOR" = "true" ] && [ -f "./static/swagger/openapi.yml" 
   [ "$NEWMAN_VERBOSE" = "true" ] && NEWMAN_CMD="$NEWMAN_CMD --verbose"
   
   eval $NEWMAN_CMD
+  NEWMAN_EXIT_CODE=$?
 
 else
   echo "=== Running Standard Newman Tests ==="
   echo "⚠️  OpenAPI validation will depend on server-side headers only"
-  
+
   # Build Newman command with proper parameter handling
-  NEWMAN_CMD="newman run '${NEWMAN_COLLECTION:-tests/postman/collections/comprehensive.json}' --environment '${NEWMAN_ENVIRONMENT:-postman-environment.json}' --reporters cli,html,json --reporter-html-export reports/newman/$TIMESTAMP-report.html --reporter-json-export reports/newman/$TIMESTAMP-results.json"
-  
+  NEWMAN_CMD="newman run '${NEWMAN_COLLECTION:-tests/postman/collections/comprehensive.json}' --environment '${NEWMAN_ENVIRONMENT:-postman-environment.json}' --reporters cli,html,json --reporter-html-export $REPORT_DIR/$TIMESTAMP-report.html --reporter-json-export $REPORT_DIR/$TIMESTAMP-results.json"
+
   [ -n "$NEWMAN_FOLDER" ] && NEWMAN_CMD="$NEWMAN_CMD --folder '$NEWMAN_FOLDER'"
   [ -n "$NEWMAN_ITERATIONS" ] && [ "$NEWMAN_ITERATIONS" -gt 0 ] && NEWMAN_CMD="$NEWMAN_CMD --iteration-count $NEWMAN_ITERATIONS"
   [ -n "$NEWMAN_DELAY_REQUEST" ] && [ "$NEWMAN_DELAY_REQUEST" -gt 0 ] && NEWMAN_CMD="$NEWMAN_CMD --delay-request $NEWMAN_DELAY_REQUEST"
   [ -n "$NEWMAN_TIMEOUT" ] && [ "$NEWMAN_TIMEOUT" -gt 0 ] && NEWMAN_CMD="$NEWMAN_CMD --timeout $NEWMAN_TIMEOUT"
   [ "$NEWMAN_BAIL" = "true" ] && NEWMAN_CMD="$NEWMAN_CMD --bail"
   [ "$NEWMAN_VERBOSE" = "true" ] && NEWMAN_CMD="$NEWMAN_CMD --verbose"
-  
+
   eval $NEWMAN_CMD
-  
   NEWMAN_EXIT_CODE=$?
 fi
 
 echo "=== Test Execution Complete ==="
 
 # Check for validation headers in responses
-if [ -f "reports/newman/$TIMESTAMP-results.json" ]; then
+if [ -f "$REPORT_DIR/$TIMESTAMP-results.json" ]; then
   echo "=== Checking for OpenAPI Validation Headers ==="
   node -e "
     const fs = require('fs');
-    const results = JSON.parse(fs.readFileSync('reports/newman/$TIMESTAMP-results.json', 'utf8'));
+    const results = JSON.parse(fs.readFileSync('$REPORT_DIR/$TIMESTAMP-results.json', 'utf8'));
     let validatedCount = 0;
     let failedCount = 0;
     
@@ -115,9 +122,9 @@ fi
 
 # Generate summary report
 echo "=== Summary ==="
-echo "📁 Reports saved to: reports/newman/"
-echo "📄 HTML Report: reports/newman/$TIMESTAMP-report.html"
-echo "📊 JSON Results: reports/newman/$TIMESTAMP-results.json"
-[ -f "reports/newman/$TIMESTAMP-openapi-validation.log" ] && echo "🔍 OpenAPI Validation: reports/newman/$TIMESTAMP-openapi-validation.log"
+echo "📁 Reports saved to: $REPORT_DIR/"
+echo "📄 HTML Report: $REPORT_DIR/$TIMESTAMP-report.html"
+echo "📊 JSON Results: $REPORT_DIR/$TIMESTAMP-results.json"
+[ -f "$REPORT_DIR/$TIMESTAMP-openapi-validation.log" ] && echo "🔍 OpenAPI Validation: $REPORT_DIR/$TIMESTAMP-openapi-validation.log"
 
 exit $NEWMAN_EXIT_CODE


### PR DESCRIPTION
## Summary

Companion fix to #941. The Newman CI tests have been failing for 20+ days due to multiple issues:

1. **Newman not installed**: Docker image `node:22-alpine` doesn't have Newman — the script assumed it was pre-installed
2. **Report directory mismatch**: Script wrote to `reports/newman/` but workflow expected `reports/newman-comprehensive/` (the `REPORT_PREFIX` env var was set but never used)
3. **Silent failure**: Exit code bug in OpenAPI validator path meant Newman failures exited 0

## Changes (scripts/run-newman-with-openapi.sh)

- Install Newman globally if not available (`npm install -g newman newman-reporter-html newman-reporter-json`)
- Use `REPORT_PREFIX` env var for report directory (e.g., `reports/newman-comprehensive/`)
- Fix `NEWMAN_EXIT_CODE` capture in OpenAPI validator code path
- Suppress `npm install` errors for local deps (container may not have writable package-lock.json)

## Test plan

- [ ] Merge to dev, trigger Newman workflow manually
- [ ] Verify Newman installs, runs tests, generates reports in correct directory
- [ ] Verify regression analysis finds and analyzes reports
- [ ] Verify "Check for critical issues" passes

Generated with [Claude Code](https://claude.com/claude-code)