### PR TITLE
fix(ci): point Newman performance benchmark at production URL

### DIFF
--- a/.github/workflows/newman-comprehensive-tests.yml
+++ b/.github/workflows/newman-comprehensive-tests.yml
@@ -442,7 +442,10 @@ jobs:
           echo "- Focus: Critical endpoints only" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
-          # Run performance-focused tests
+          # Run performance-focused tests against production
+          # (no dev server in CI, point both URLs at production)
+          DEV_BASE_URL=https://stampchain.io \
+          PROD_BASE_URL=https://stampchain.io \
           NEWMAN_ITERATIONS=3 \
           NEWMAN_DELAY_REQUEST=100 \
           NEWMAN_FOLDER="Stamps Endpoints" \


### PR DESCRIPTION
## Summary

The performance benchmark job was hitting `localhost:8000` (no dev server in CI), causing connection errors. Points it at production URL to match the main Newman test job.

## Test plan

- [ ] Trigger Newman workflow after merge — all 3 jobs should pass

Generated with [Claude Code](https://claude.com/claude-code)