### PR TITLE
fix(ci): override Postman env file URLs with container env vars

### DIFF
--- a/scripts/run-newman-with-openapi.sh
+++ b/scripts/run-newman-with-openapi.sh
@@ -70,7 +70,9 @@ if [ "$USE_OPENAPI_VALIDATOR" = "true" ] && [ -f "./static/swagger/openapi.yml" 
   [ -n "$NEWMAN_TIMEOUT" ] && [ "$NEWMAN_TIMEOUT" -gt 0 ] && NEWMAN_CMD="$NEWMAN_CMD --timeout $NEWMAN_TIMEOUT"
   [ "$NEWMAN_BAIL" = "true" ] && NEWMAN_CMD="$NEWMAN_CMD --bail"
   [ "$NEWMAN_VERBOSE" = "true" ] && NEWMAN_CMD="$NEWMAN_CMD --verbose"
-  
+  [ -n "$DEV_BASE_URL" ] && NEWMAN_CMD="$NEWMAN_CMD --env-var 'dev_base_url=$DEV_BASE_URL'"
+  [ -n "$PROD_BASE_URL" ] && NEWMAN_CMD="$NEWMAN_CMD --env-var 'prod_base_url=$PROD_BASE_URL'"
+
   eval $NEWMAN_CMD
   NEWMAN_EXIT_CODE=$?
 
@@ -87,6 +89,8 @@ else
   [ -n "$NEWMAN_TIMEOUT" ] && [ "$NEWMAN_TIMEOUT" -gt 0 ] && NEWMAN_CMD="$NEWMAN_CMD --timeout $NEWMAN_TIMEOUT"
   [ "$NEWMAN_BAIL" = "true" ] && NEWMAN_CMD="$NEWMAN_CMD --bail"
   [ "$NEWMAN_VERBOSE" = "true" ] && NEWMAN_CMD="$NEWMAN_CMD --verbose"
+  [ -n "$DEV_BASE_URL" ] && NEWMAN_CMD="$NEWMAN_CMD --env-var 'dev_base_url=$DEV_BASE_URL'"
+  [ -n "$PROD_BASE_URL" ] && NEWMAN_CMD="$NEWMAN_CMD --env-var 'prod_base_url=$PROD_BASE_URL'"
 
   eval $NEWMAN_CMD
   NEWMAN_EXIT_CODE=$?


### PR DESCRIPTION
## Summary
- Newman `--env-var` flags now override `dev_base_url` and `prod_base_url` from Postman environment file
- Fixes API Performance Benchmarking CI job which fails because `comprehensive.json` hardcodes `dev_base_url` to `http://host.docker.internal:8000`
- Docker container env vars (`DEV_BASE_URL`, `PROD_BASE_URL`) are now properly passed through to Newman

## Context
This is the final fix in a series addressing 20+ days of Newman test failures:
- PR #941: Docker file permissions (EACCES)
- PR #943: Newman installation, report paths, exit code
- PR #944: Regression analysis informational
- PR #945: Newman workflow fully informational
- PR #946: Performance benchmark URL config
- **This PR**: Env var override (Postman file values were overriding Docker env vars)

## Test plan
- [ ] Trigger Newman workflow manually after merge
- [ ] All 3 jobs should pass: Newman Integration, Pagination Validation, Performance Benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)