### PR TITLE
ci: add Dependabot config targeting dev branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+# Dependabot configuration - targets dev branch
+# PRs flow: dependabot -> dev (CI validation) -> main (production deploy)
+version: 2
+updates:
+  # GitHub Actions - keep workflows up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # npm dependencies (Newman, test tooling)
+  - package-ecosystem: "npm"
+    directory: "/"
+    target-branch: "dev"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+    open-pull-requests-limit: 5
+    groups:
+      newman-testing:
+        patterns:
+          - "newman*"
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` targeting `dev` branch
- GitHub Actions updates grouped weekly (Mondays)
- npm dependency updates with 5 PR limit, grouped by type
- PRs flow through dev CI validation before being synced to main

## Notification volume
Expect an initial burst of PRs as Dependabot catches up on outdated dependencies. After that, grouped weekly updates should keep noise manageable. The `open-pull-requests-limit: 5` caps the npm PRs.

## Test plan
- [ ] Dependabot creates PRs against `dev` (not `main`)
- [ ] PR labels applied correctly
- [ ] Grouped PRs reduce individual PR count

🤖 Generated with [Claude Code](https://claude.com/claude-code)