### PR TITLE
fix: resolve POST endpoint 500s and Docker Newman 33 failures

### DIFF
--- a/routes/api/v2/trx/stampattach.ts
+++ b/routes/api/v2/trx/stampattach.ts
@@ -391,18 +391,8 @@ export const handler: Handlers = {
           `Insufficient funds after all calculations for attach. Deficit: ${-finalUserChangeValue}`,
         );
       }
-      try {
-        psbt.finalizeAllInputs();
-      } catch (finalizeError: any) {
-        logger.error("api", {
-          message: "Error finalizing inputs for stampattach PSBT",
-          error: finalizeError.message,
-          psbtInputs: psbt.data.inputs,
-        });
-        throw new Error(
-          `Failed to finalize PSBT inputs: ${finalizeError.message}`,
-        );
-      }
+      // Return unsigned PSBT for the wallet to sign (do NOT finalize —
+      // finalizeAllInputs() requires signatures which the wallet provides)
       const finalPsbtHex = psbt.toHex();
       return ApiResponseUtil.success({
         psbtHex: finalPsbtHex,

--- a/scripts/mock-external-apis.ts
+++ b/scripts/mock-external-apis.ts
@@ -266,6 +266,25 @@ function handleCounterpartyApi(
     });
   }
 
+  // Compose issuance: /addresses/{address}/compose/issuance - SUCCESS path
+  const issuanceMatch = path.match(
+    /^\/addresses\/([^/]+)\/compose\/issuance$/,
+  );
+  if (issuanceMatch) {
+    return jsonResponse({
+      result: {
+        rawtransaction: COUNTERPARTY_RAW_TX,
+        params: {
+          source: issuanceMatch[1],
+          asset: "A12345678901234567",
+          quantity: 1,
+          divisible: false,
+          description: "Mock issuance for CI testing",
+        },
+      },
+    });
+  }
+
   // Get balances: /addresses/{address}/balances
   const balancesMatch = path.match(/^\/addresses\/([^/]+)\/balances/);
   if (balancesMatch) {

--- a/scripts/run-newman-with-openapi.sh
+++ b/scripts/run-newman-with-openapi.sh
@@ -72,6 +72,7 @@ if [ "$USE_OPENAPI_VALIDATOR" = "true" ] && [ -f "./static/swagger/openapi.yml" 
   [ "$NEWMAN_VERBOSE" = "true" ] && NEWMAN_CMD="$NEWMAN_CMD --verbose"
   [ -n "$DEV_BASE_URL" ] && NEWMAN_CMD="$NEWMAN_CMD --env-var 'dev_base_url=$DEV_BASE_URL'"
   [ -n "$PROD_BASE_URL" ] && NEWMAN_CMD="$NEWMAN_CMD --env-var 'prod_base_url=$PROD_BASE_URL'"
+  [ -n "$DEV_BASE_URL" ] && NEWMAN_CMD="$NEWMAN_CMD --env-var 'baseUrl=$DEV_BASE_URL' --env-var 'base_url=$DEV_BASE_URL'"
 
   eval $NEWMAN_CMD
   NEWMAN_EXIT_CODE=$?
@@ -91,6 +92,7 @@ else
   [ "$NEWMAN_VERBOSE" = "true" ] && NEWMAN_CMD="$NEWMAN_CMD --verbose"
   [ -n "$DEV_BASE_URL" ] && NEWMAN_CMD="$NEWMAN_CMD --env-var 'dev_base_url=$DEV_BASE_URL'"
   [ -n "$PROD_BASE_URL" ] && NEWMAN_CMD="$NEWMAN_CMD --env-var 'prod_base_url=$PROD_BASE_URL'"
+  [ -n "$DEV_BASE_URL" ] && NEWMAN_CMD="$NEWMAN_CMD --env-var 'baseUrl=$DEV_BASE_URL' --env-var 'base_url=$DEV_BASE_URL'"
 
   eval $NEWMAN_CMD
   NEWMAN_EXIT_CODE=$?


### PR DESCRIPTION
## Summary

- **stampattach 500 fix**: Removed erroneous `psbt.finalizeAllInputs()` call that caused every stampattach request to 500. The PSBT must be returned unsigned for the wallet to sign — this matches the pattern used by stampsend and stampdetach.
- **olga/mint 500 fix**: Added `/compose/issuance` endpoint to the mock external API server. The mint flow calls Counterparty's compose/issuance API, which was returning 404 from the mock, causing a 500.
- **Docker Newman 33 failures fix**: Added `baseUrl` and `base_url` `--env-var` overrides to `run-newman-with-openapi.sh`. The `src101` folder's 11 requests use `{{baseUrl}}` (not `{{dev_base_url}}`), which resolved to `http://host.docker.internal:8000` where no server was running. 11 requests × 3 collection-level assertions = 33 failures.

## Test plan

- [ ] Newman Local Dev Server job: 475+ assertions, 0 failures
- [ ] Newman Integration Tests (Docker) job: 33 fewer failures from baseUrl resolution
- [ ] POST stampattach returns 200 with unsigned PSBT hex (not 500)
- [ ] POST olga/mint reaches issuance compose step (not 404/500)

🤖 Generated with [Claude Code](https://claude.com/claude-code)