### PR TITLE
ci: bump the github-actions group with 4 updates

### DIFF
--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -75,7 +75,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Deno
         uses: denoland/setup-deno@v2
@@ -83,7 +83,7 @@ jobs:
           deno-version: v2.6.9
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -197,7 +197,7 @@ jobs:
 
       - name: Upload Lighthouse reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: lighthouse-reports
           path: .lighthouseci/

--- a/.github/workflows/newman-comprehensive-tests.yml
+++ b/.github/workflows/newman-comprehensive-tests.yml
@@ -1030,7 +1030,7 @@ jobs:
 
       - name: Comment on PR with results
         if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const total = '${{ steps.parse-results.outputs.total_tests }}';


### PR DESCRIPTION
## Summary
- actions/checkout v4 → v6
- actions/setup-node v4 → v6
- actions/github-script v7 → v8
- actions/upload-artifact v4 → v6

Applies same changes as dependabot PR #971 via squash-mergeable branch.

Generated with [Claude Code](https://claude.com/claude-code)