### PR TITLE
fix: add schema-contract-tests.json to Newman workflow triggers

### DIFF
--- a/.github/workflows/newman-comprehensive-tests.yml
+++ b/.github/workflows/newman-comprehensive-tests.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'tests/postman/collections/comprehensive.json'
       - 'tests/postman/collections/pagination-validation.json'
+      - 'tests/postman/collections/schema-contract-tests.json'
       - 'tests/postman/environments/comprehensive.json'
       - 'tests/postman/data/pagination-tests.json'
       - 'scripts/run-newman-comprehensive.sh'
@@ -26,6 +27,7 @@ on:
     paths:
       - 'tests/postman/collections/comprehensive.json'
       - 'tests/postman/collections/pagination-validation.json'
+      - 'tests/postman/collections/schema-contract-tests.json'
       - 'tests/postman/environments/comprehensive.json'
       - 'tests/postman/data/pagination-tests.json'
       - 'scripts/run-newman-comprehensive.sh'


### PR DESCRIPTION
## Summary
- Add `tests/postman/collections/schema-contract-tests.json` to workflow path triggers
- Without this, changes to the schema contract collection don't trigger the Newman CI job
- Also includes the schema contract assertion fixes from PR #986

## Test plan
- [ ] Newman comprehensive tests trigger and pass with schema contract step

Generated with [Claude Code](https://claude.com/claude-code)