### PR TITLE
feat(preview): S3+CloudFront storage for stamp previews (Task 17)

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -158,6 +158,7 @@
     "@std/path": "jsr:/@std/path@^0.219.1",
     "@std/testing": "jsr:/@std/testing@^1.0.6",
     "@std/yaml": "jsr:/@std/yaml@^0.219.1",
+    "@aws-sdk/client-s3": "npm:@aws-sdk/client-s3@^3.600.0",
     "axiod": "https://deno.land/x/axiod@0.26.2/mod.ts",
     "bitcoinjs-lib": "npm:bitcoinjs-lib@7.0.0-rc.0",
     "big": "https://esm.sh/big.js@6.2.1",

--- a/env-templates/production.json
+++ b/env-templates/production.json
@@ -8,5 +8,10 @@
   {"name": "DENO_ENV", "value": "production"},
   {"name": "SKIP_REDIS_CONNECTION", "value": "false"},
   {"name": "ELASTICACHE_ENDPOINT", "value": "memory"},
-  {"name": "SKIP_REDIS", "value": "false"}
+  {"name": "SKIP_REDIS", "value": "false"},
+  {"name": "AWS_S3_BUCKETNAME", "value": "{existing-bucket-name}"},
+  {"name": "AWS_S3_IMAGE_DIR", "value": "stamps/"},
+  {"name": "CLOUDFRONT_PREVIEW_DOMAIN", "value": "stampchain.io"},
+  {"name": "PREVIEW_STORAGE", "value": "s3"},
+  {"name": "AWS_REGION", "value": "us-east-1"}
 ]

--- a/scripts/backfill-preview-images.ts
+++ b/scripts/backfill-preview-images.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env -S deno run --allow-all
+/**
+ * Backfill preview images to S3.
+ *
+ * Iterates through stamps in the database, renders previews for those
+ * missing from S3, and uploads the PNGs.
+ *
+ * Usage:
+ *   deno run --allow-all scripts/backfill-preview-images.ts [options]
+ *
+ * Options:
+ *   --start=<n>       Start at stamp number (default: 0)
+ *   --end=<n>         End at stamp number (default: latest)
+ *   --concurrency=<n> Parallel renders (default: 5)
+ *   --dry-run         Check which stamps are missing without uploading
+ *   --force           Re-render even if S3 object exists
+ */
+
+import { parse } from "@std/flags";
+import { StampController } from "$server/controller/stampController.ts";
+import {
+  getPreviewUrl,
+  previewExists,
+  uploadPreview,
+} from "$server/services/aws/previewStorageService.ts";
+
+// Dynamically import to trigger the env/config loading chain
+await import("$/server/config/env.ts");
+
+interface BackfillStats {
+  total: number;
+  skipped: number;
+  uploaded: number;
+  failed: number;
+  alreadyExists: number;
+}
+
+const flags = parse(Deno.args, {
+  default: {
+    start: 0,
+    concurrency: 5,
+    "dry-run": false,
+    force: false,
+  },
+  string: ["start", "end", "concurrency"],
+  boolean: ["dry-run", "force"],
+});
+
+const startStamp = Number(flags.start) || 0;
+const endStamp = flags.end ? Number(flags.end) : undefined;
+const concurrency = Number(flags.concurrency) || 5;
+const dryRun = flags["dry-run"];
+const force = flags.force;
+
+console.log("=== Preview Image Backfill ===");
+console.log(`  Start: ${startStamp}`);
+console.log(`  End: ${endStamp ?? "latest"}`);
+console.log(`  Concurrency: ${concurrency}`);
+console.log(`  Dry run: ${dryRun}`);
+console.log(`  Force re-render: ${force}`);
+console.log("");
+
+// We need to import the renderPreview + helpers from preview.ts.
+// Since they are not exported, we replicate the core logic here:
+// fetch stamp data → check S3 → render via preview endpoint → upload.
+// The simplest approach is to call the preview endpoint on the running server.
+
+const BASE_URL = Deno.env.get("BACKFILL_BASE_URL") || "http://localhost:8000";
+
+async function processStamp(
+  identifier: string,
+  stats: BackfillStats,
+): Promise<void> {
+  stats.total++;
+
+  // Check if already in S3 (skip if not forcing)
+  if (!force) {
+    try {
+      const exists = await previewExists(identifier);
+      if (exists) {
+        stats.alreadyExists++;
+        return;
+      }
+    } catch {
+      // S3 check failed — try to render anyway
+    }
+  }
+
+  if (dryRun) {
+    console.log(`[DRY RUN] Would render and upload: ${identifier}`);
+    return;
+  }
+
+  // Fetch rendered preview from the local server (it will render on cache miss)
+  try {
+    const resp = await fetch(
+      `${BASE_URL}/api/v2/stamp/${identifier}/preview`,
+      { redirect: "manual" },
+    );
+
+    // If server returns 302 to CloudFront URL → already handled by S3 path
+    if (resp.status === 302) {
+      const location = resp.headers.get("location") || "";
+      if (location.includes("/stamps/previews/")) {
+        stats.uploaded++;
+        console.log(`  [OK] ${identifier} → ${location}`);
+        return;
+      }
+    }
+
+    // If server returns 200 with image → it's in redis mode, upload to S3 ourselves
+    if (resp.status === 200) {
+      const contentType = resp.headers.get("content-type");
+      if (contentType?.includes("image/png")) {
+        const pngBytes = new Uint8Array(await resp.arrayBuffer());
+        const meta: Record<string, string> = {};
+        for (const [k, v] of resp.headers.entries()) {
+          if (k.startsWith("x-")) meta[k] = v;
+        }
+        await uploadPreview(identifier, pngBytes, meta);
+        stats.uploaded++;
+        console.log(
+          `  [UPLOADED] ${identifier} → ${getPreviewUrl(identifier)}`,
+        );
+        return;
+      }
+    }
+
+    // Fallback redirect or error
+    stats.skipped++;
+  } catch (err) {
+    stats.failed++;
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`  [FAIL] ${identifier}: ${msg}`);
+  }
+}
+
+async function runBatch(
+  identifiers: string[],
+  stats: BackfillStats,
+): Promise<void> {
+  const chunks: string[][] = [];
+  for (let i = 0; i < identifiers.length; i += concurrency) {
+    chunks.push(identifiers.slice(i, i + concurrency));
+  }
+
+  for (const chunk of chunks) {
+    await Promise.all(chunk.map((id) => processStamp(id, stats)));
+
+    if (stats.total % 50 === 0) {
+      console.log(
+        `  Progress: ${stats.total} processed, ${stats.uploaded} uploaded, ${stats.alreadyExists} existed, ${stats.failed} failed`,
+      );
+    }
+  }
+}
+
+// Build stamp identifier list. Use numeric range.
+const identifiers: string[] = [];
+const upper = endStamp ?? startStamp + 1000;
+for (let i = startStamp; i <= upper; i++) {
+  identifiers.push(String(i));
+}
+
+const stats: BackfillStats = {
+  total: 0,
+  skipped: 0,
+  uploaded: 0,
+  failed: 0,
+  alreadyExists: 0,
+};
+
+await runBatch(identifiers, stats);
+
+console.log("");
+console.log("=== Backfill Complete ===");
+console.log(`  Total processed: ${stats.total}`);
+console.log(`  Already in S3: ${stats.alreadyExists}`);
+console.log(`  Newly uploaded: ${stats.uploaded}`);
+console.log(`  Skipped (no preview): ${stats.skipped}`);
+console.log(`  Failed: ${stats.failed}`);

--- a/server/config/config.ts
+++ b/server/config/config.ts
@@ -49,6 +49,12 @@ type ServerConfig = {
   readonly CONNECTION_POOL_RESET_TOKEN?: string;
   readonly CF_PREVIEW_WORKER_URL?: string;
   readonly CF_PREVIEW_WORKER_SECRET?: string;
+  // S3 & CloudFront (stamp preview storage)
+  readonly AWS_S3_BUCKETNAME: string;
+  readonly AWS_S3_IMAGE_DIR: string;
+  readonly CLOUDFRONT_PREVIEW_DOMAIN: string;
+  readonly PREVIEW_STORAGE: "s3" | "redis";
+  readonly AWS_REGION: string;
   // Rendering
   readonly PUPPETEER_EXECUTABLE_PATH?: string;
   // Server Role
@@ -180,6 +186,22 @@ const serverConfig: ServerConfig = {
   },
   get CF_PREVIEW_WORKER_SECRET() {
     return Deno.env.get("CF_PREVIEW_WORKER_SECRET") || "";
+  },
+  // S3 & CloudFront (stamp preview storage)
+  get AWS_S3_BUCKETNAME() {
+    return Deno.env.get("AWS_S3_BUCKETNAME") ?? "";
+  },
+  get AWS_S3_IMAGE_DIR() {
+    return Deno.env.get("AWS_S3_IMAGE_DIR") ?? "stamps/";
+  },
+  get CLOUDFRONT_PREVIEW_DOMAIN() {
+    return Deno.env.get("CLOUDFRONT_PREVIEW_DOMAIN") ?? "stampchain.io";
+  },
+  get PREVIEW_STORAGE(): "s3" | "redis" {
+    return (Deno.env.get("PREVIEW_STORAGE") ?? "redis") as "s3" | "redis";
+  },
+  get AWS_REGION() {
+    return Deno.env.get("AWS_REGION") ?? "us-east-1";
   },
   // Rendering
   get PUPPETEER_EXECUTABLE_PATH() {

--- a/server/services/aws/previewStorageService.ts
+++ b/server/services/aws/previewStorageService.ts
@@ -1,0 +1,97 @@
+/**
+ * S3 Preview Storage Service
+ *
+ * Stores rendered stamp preview PNGs in S3 for CloudFront delivery.
+ * Raw binary PNG is stored (no base64 wrapping) — saves ~33% vs JSON+base64.
+ *
+ * S3 key pattern: {IMAGE_DIR}/previews/{identifier}.png
+ * CloudFront URL: https://{DOMAIN}/{IMAGE_DIR}/previews/{identifier}.png
+ */
+import {
+  HeadObjectCommand,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { serverConfig } from "$server/config/config.ts";
+
+let _s3Client: S3Client | null = null;
+
+function getS3Client(): S3Client {
+  if (!_s3Client) {
+    _s3Client = new S3Client({ region: serverConfig.AWS_REGION });
+  }
+  return _s3Client;
+}
+
+function getS3Key(identifier: string): string {
+  const dir = serverConfig.AWS_S3_IMAGE_DIR || "stamps";
+  return `${dir}/previews/${identifier}.png`;
+}
+
+/**
+ * Build the public CloudFront URL for a stored preview.
+ */
+export function getPreviewUrl(identifier: string): string {
+  const domain = serverConfig.CLOUDFRONT_PREVIEW_DOMAIN || "stampchain.io";
+  return `https://${domain}/${getS3Key(identifier)}`;
+}
+
+/**
+ * Check if a preview already exists in S3.
+ */
+export async function previewExists(identifier: string): Promise<boolean> {
+  try {
+    await getS3Client().send(
+      new HeadObjectCommand({
+        Bucket: serverConfig.AWS_S3_BUCKETNAME,
+        Key: getS3Key(identifier),
+      }),
+    );
+    return true;
+  } catch (err: unknown) {
+    if (err instanceof Error && "name" in err && err.name === "NotFound") {
+      return false;
+    }
+    // $metadata.httpStatusCode === 404 for HeadObject
+    if (
+      typeof err === "object" && err !== null &&
+      "$metadata" in err &&
+      (err as any).$metadata?.httpStatusCode === 404
+    ) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Upload a rendered PNG to S3 with CDN-friendly cache headers.
+ * Stamps are immutable — cache forever.
+ */
+export async function uploadPreview(
+  identifier: string,
+  pngBytes: Uint8Array,
+  meta?: Record<string, string>,
+): Promise<string> {
+  const key = getS3Key(identifier);
+  const s3Meta: Record<string, string> = {};
+  if (meta) {
+    for (const [k, v] of Object.entries(meta)) {
+      // S3 metadata keys are lowercased and must be ASCII
+      s3Meta[k.toLowerCase().replace(/[^a-z0-9-]/g, "-")] = v;
+    }
+  }
+
+  await getS3Client().send(
+    new PutObjectCommand({
+      Bucket: serverConfig.AWS_S3_BUCKETNAME,
+      Key: key,
+      Body: pngBytes,
+      ContentType: "image/png",
+      CacheControl: "public, max-age=31536000, immutable",
+      Metadata: s3Meta,
+    }),
+  );
+
+  return getPreviewUrl(identifier);
+}


### PR DESCRIPTION
## Summary
- Add S3+CloudFront preview image storage with feature flag (`PREVIEW_STORAGE=s3|redis`)
- New `previewStorageService.ts` for S3 upload/check/URL generation
- Preview route split into `handleS3Preview()` / `handleRedisPreview()` with env-based routing
- Backfill script for migrating existing previews to S3
- Config fields: `AWS_S3_BUCKETNAME`, `AWS_S3_IMAGE_DIR`, `CLOUDFRONT_PREVIEW_DOMAIN`, `AWS_REGION`, `PREVIEW_STORAGE`

## Test plan
- [ ] CI passes (same code as PR #1004 which passed all 21 checks)
- [ ] Default `PREVIEW_STORAGE=redis` preserves existing behavior (no change)
- [ ] Set `PREVIEW_STORAGE=s3` to enable S3 path after deploy
- [ ] Validate S3 uploads via backfill script with `--dry-run`
- [ ] Post-deploy: Redis preview key cleanup (subtask 17.7)

Cherry-picked from dev commit c498cdd1d (PR #1004, squash-merged to dev).
Clean branch from main to avoid dev history divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)