### PR TITLE
fix(preview): improve S3 error logging for UnknownError diagnosis

### DIFF
--- a/routes/api/v2/stamp/[stamp]/preview.ts
+++ b/routes/api/v2/stamp/[stamp]/preview.ts
@@ -811,7 +811,14 @@ export const handler: Handlers = {
       }
       return await handleRedisPreview(stamp, forceRefresh);
     } catch (error) {
-      console.error("Preview generation error:", error);
+      const errName = error instanceof Error ? error.name : "unknown";
+      const errMsg = error instanceof Error ? error.message : String(error);
+      console.error(
+        "Preview generation error:",
+        errName,
+        errMsg,
+        error instanceof Error ? error.stack : "",
+      );
       return WebResponseUtil.redirect(FALLBACK_LOGO, 302, {
         headers: {
           "X-Fallback": "general-error",


### PR DESCRIPTION
## Summary
- Add structured error logging (name, message, stack) to preview route catch block
- Add S3 client initialization logging with bucket/region details
- Add previewExists error detail logging for credential debugging

## Context
After enabling `PREVIEW_STORAGE=s3` in ECS, preview endpoint returns `general-error` fallback with `Unknown: UnknownError` in CloudWatch. This logging improvement captures the full error chain to diagnose the AWS SDK credential resolution in Deno npm compat + ECS Fargate.

## Test plan
- [ ] CI passes
- [ ] Deploy to production
- [ ] Hit preview endpoint to trigger S3 error
- [ ] Read CloudWatch logs for full error details

🤖 Generated with [Claude Code](https://claude.com/claude-code)