### PR TITLE
fix: sync dev with main - S3 error logging from hotfix #1007

### DIFF
--- a/routes/api/v2/stamp/[stamp]/preview.ts
+++ b/routes/api/v2/stamp/[stamp]/preview.ts
@@ -811,7 +811,14 @@ export const handler: Handlers = {
       }
       return await handleRedisPreview(stamp, forceRefresh);
     } catch (error) {
-      console.error("Preview generation error:", error);
+      const errName = error instanceof Error ? error.name : "unknown";
+      const errMsg = error instanceof Error ? error.message : String(error);
+      console.error(
+        "Preview generation error:",
+        errName,
+        errMsg,
+        error instanceof Error ? error.stack : "",
+      );
       return WebResponseUtil.redirect(FALLBACK_LOGO, 302, {
         headers: {
           "X-Fallback": "general-error",


### PR DESCRIPTION
## Summary
- Syncs dev branch content with main after hotfix PR #1007 was merged directly to main
- Brings the improved S3 error logging to dev branch

## Changes
- `preview.ts`: Detailed error logging (name, message, stack trace) instead of raw error object
- `previewStorageService.ts`: S3 client initialization logging + detailed previewExists error diagnostics

## Context
During S3 preview debugging, PR #1007 was merged directly to main (hotfix path). This PR brings those same changes to dev so both branches have identical content.

## Test plan
- [ ] CI passes
- [ ] After merge: `git diff origin/main origin/dev` returns empty (content parity)

🤖 Generated with [Claude Code](https://claude.com/claude-code)