### PR TITLE
fix(ci): resolve false-positive cron job failures

### DIFF
--- a/.github/workflows/daily-regression-tests.yml
+++ b/.github/workflows/daily-regression-tests.yml
@@ -153,6 +153,12 @@ jobs:
           exit $TEST_EXIT_CODE
         continue-on-error: true
 
+      - name: Fix Docker file permissions
+        if: always()
+        run: |
+          # Docker containers run as root and change file ownership
+          sudo chown -R $(id -u):$(id -g) . || true
+
       - name: Run regression analysis with historical comparison
         id: analysis
         if: always()
@@ -221,9 +227,13 @@ jobs:
             echo "- Historical Trends: Available in artifacts" >> daily_summary.md
           fi
           
-          # Save summary
-          cp daily_summary.md "$REPORT_DIR/"
-          
+          # Save summary to report directory (guard against empty REPORT_DIR)
+          if [ -n "$REPORT_DIR" ] && [ -d "$REPORT_DIR" ]; then
+            cp daily_summary.md "$REPORT_DIR/"
+          else
+            echo "⚠️ REPORT_DIR not set or missing, skipping copy"
+          fi
+
           echo "Daily summary generated"
 
       - name: Check for critical regressions
@@ -358,12 +368,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: daily-regression-reports-${{ env.TIMESTAMP }}
+          name: daily-regression-reports-${{ env.TIMESTAMP || 'unknown' }}
           path: |
-            ${{ env.REPORT_DIR }}/
+            reports/daily-regression/
             reports/expected-changes-validation.json
             reports/trends-analysis.json
             daily_summary.md
+          if-no-files-found: warn
           retention-days: 90
 
       - name: Set workflow status

--- a/.github/workflows/newman-comprehensive-tests.yml
+++ b/.github/workflows/newman-comprehensive-tests.yml
@@ -452,8 +452,33 @@ jobs:
       - name: Fail on scheduled regression
         if: github.event_name == 'schedule' && steps.newman-test.outcome == 'failure'
         run: |
-          echo "❌ Scheduled production validation detected API regressions"
-          echo "   A GitHub issue has been created with details."
+          # Check actual Newman assertion failures from JSON report instead of
+          # relying on Docker container exit code (which can fail for infra reasons
+          # even when all assertions pass).
+          LATEST_REPORT=$(ls -t reports/newman-comprehensive/*.json 2>/dev/null | head -1)
+          if [ -n "$LATEST_REPORT" ]; then
+            ASSERTION_FAILURES=$(node -e "
+              const fs = require('fs');
+              try {
+                const r = JSON.parse(fs.readFileSync('$LATEST_REPORT', 'utf8'));
+                const failed = r.run?.stats?.assertions?.failed ?? 0;
+                console.log(failed);
+              } catch(e) { console.log('-1'); }
+            " 2>/dev/null || echo "-1")
+
+            if [ "$ASSERTION_FAILURES" = "0" ]; then
+              echo "✅ Newman assertions all passed (Docker exit was non-zero but no assertion failures)"
+              echo "   Skipping failure — Docker/infra issue, not an API regression."
+              exit 0
+            elif [ "$ASSERTION_FAILURES" = "-1" ]; then
+              echo "⚠️ Could not parse Newman report — treating as failure"
+            else
+              echo "❌ Scheduled production validation: $ASSERTION_FAILURES assertion failure(s)"
+              echo "   A GitHub issue has been created with details."
+            fi
+          else
+            echo "⚠️ No Newman JSON report found — treating as failure"
+          fi
           exit 1
 
   pagination-validation:


### PR DESCRIPTION
## Summary
- **Newman comprehensive workflow**: Replaced Docker exit code check with actual Newman JSON assertion parsing in the "Fail on scheduled regression" step. Docker can exit non-zero for infrastructure reasons even when all 204 assertions pass, causing false failure reports and spurious issue #963 updates.
- **Daily regression workflow**: Added Docker file permissions fix step (`sudo chown`), guarded `REPORT_DIR` copy against empty env var (was causing `cp: cannot create regular file '/daily_summary.md': Permission denied`), and fixed upload-artifact paths to prevent scanning from filesystem root.

## Test plan
- [ ] Verify PR CI passes (no workflow syntax errors)
- [ ] Next scheduled Newman run (2 AM UTC) should not falsely fail when all assertions pass
- [ ] Next daily regression run should not fail on `cp` permission denied
- [ ] Issue #963 should stop receiving false-positive update comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)