### PR TITLE
fix(wallet): add xverse case to checkWalletAvailability()

### DIFF
--- a/client/wallet/wallet.ts
+++ b/client/wallet/wallet.ts
@@ -31,6 +31,7 @@ interface WalletProviders {
   tapwallet?: any;
   phantom?: any;
   HorizonWalletProvider?: any;
+  XverseProviders?: { BitcoinProvider?: any };
 }
 
 // Initialize wallet state
@@ -251,6 +252,8 @@ export function checkWalletAvailability(provider: string): boolean {
       return !!wallets.phantom?.bitcoin?.isPhantom;
     case "horizon":
       return !!wallets.HorizonWalletProvider;
+    case "xverse":
+      return !!wallets.XverseProviders?.BitcoinProvider;
     default:
       return false;
   }


### PR DESCRIPTION
## Summary
- Adds `XverseProviders` to the `WalletProviders` interface in `wallet.ts`
- Adds `xverse` case to `checkWalletAvailability()` switch statement
- Without this fix, the centralized detection returns `false` for Xverse even when installed

## Context
Found during Task 9 completion audit (subtask 9.12). All other wallet providers (leather, okx, unisat, tapwallet, phantom, horizon) had cases in the switch — xverse was the only one missing.

## Test plan
- [x] `deno task validate:quick` passes (fmt, lint, type check, imports)
- [ ] CI passes (unit tests, integration, Newman)

🤖 Generated with [Claude Code](https://claude.com/claude-code)