### PR TITLE
fix(docs): rename BTCStampsExplorer path in test docs

### DIFF
--- a/tests/postman/RUN_NEW_TESTS.md
+++ b/tests/postman/RUN_NEW_TESTS.md
@@ -14,7 +14,7 @@ This guide explains how to run the newly added test scripts for the 6 Recent Sal
 ### Run All Tests
 
 ```bash
-cd /home/StampchainWorkspace/BTCStampsExplorer
+cd /home/StampchainWorkspace/stampchain.io
 
 # Using the comprehensive test script
 ./scripts/run-newman-comprehensive.sh


### PR DESCRIPTION
## Summary
- Update `tests/postman/RUN_NEW_TESTS.md` to use `stampchain.io` directory name
- Resolves merge conflict with dev branch (both branches have this rename, main was missed)

## Test plan
- [ ] No code changes, docs-only fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)