### PR TITLE
fix(api): remove signature guard that blocked creator name updates

### DIFF
--- a/routes/api/internal/creatorName.ts
+++ b/routes/api/internal/creatorName.ts
@@ -45,10 +45,6 @@ export const handler: Handlers = {
     );
     if (originError) return originError;
 
-    // Check signature for wallet ownership
-    const signatureError = await InternalRouteGuard.requireSignature(req);
-    if (signatureError) return signatureError;
-
     try {
       const { address, newName, signature, timestamp, csrfToken } = await req
         .json();


### PR DESCRIPTION
## Summary

- Removes `InternalRouteGuard.requireSignature(req)` from the creator name POST handler

## Root Cause

The `requireSignature` guard had three compounding bugs:
1. **Field mismatch**: Expected `{signature, message, address}` but the modal sends `{address, newName, signature, timestamp, csrfToken}` — `message` was always undefined
2. **Body stream consumed**: `req.json()` in the guard consumed the request body, so the handler's `req.json()` call would also fail
3. **Redundant**: `CreatorService.updateCreatorName()` already performs proper BIP-322 signature verification with message reconstruction and 5-min timestamp freshness check

## Security

No security regression — the remaining guards provide full coverage:
- CSRF token validation (header-based, doesn't consume body)
- Origin/referer check via `InternalApiFrontendGuard`
- BIP-322 signature verification inside `CreatorService.updateCreatorName()`
- Timestamp freshness check (5-min window)
- Input validation (length, pattern, type)

## Test plan

- [ ] Connect wallet on stampchain.io
- [ ] Navigate to wallet profile page
- [ ] Click pencil icon, enter new name, sign with wallet
- [ ] Verify name updates successfully (no "Missing signature data" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)