### PR TITLE
fix: remove signature guard blocking creator name updates

### DIFF
--- a/routes/api/internal/creatorName.ts
+++ b/routes/api/internal/creatorName.ts
@@ -45,10 +45,6 @@ export const handler: Handlers = {
     );
     if (originError) return originError;
 
-    // Check signature for wallet ownership
-    const signatureError = await InternalRouteGuard.requireSignature(req);
-    if (signatureError) return signatureError;
-
     try {
       const { address, newName, signature, timestamp, csrfToken } = await req
         .json();


### PR DESCRIPTION
## Summary

Hotfix for the creator name edit feature deployed in #1020. The `requireSignature` guard in the POST handler consumed the request body and expected fields the modal doesn't send, causing "Missing signature data" errors.

- Removed redundant `requireSignature` guard (signature verification already handled in `CreatorService.updateCreatorName()`)
- No security regression — CSRF, origin check, BIP-322 verification, and timestamp freshness all remain intact

## Test plan

- [ ] Connect wallet, navigate to wallet profile, click edit, sign — name should update successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)