### PR TITLE
fix(wallet): fix Leather signMessage and remove duplicate CI triggers

### DIFF
--- a/.github/workflows/api-schema-validation.yml
+++ b/.github/workflows/api-schema-validation.yml
@@ -8,15 +8,6 @@ on:
       - 'server/services/**'
       - 'static/swagger/**'
       - '.redocly.yaml'
-  push:
-    branches:
-      - main
-      - dev
-    paths:
-      - 'routes/api/**'
-      - 'server/services/**'
-      - 'static/swagger/**'
-      - '.redocly.yaml'
 
 jobs:
   validate-schema:

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -1,16 +1,6 @@
 name: Lighthouse CI
 
 on:
-  push:
-    branches: [main, dev]
-    paths:
-      - 'client/**'
-      - 'routes/**'
-      - 'islands/**'
-      - 'components/**'
-      - 'static/**'
-      - 'lighthouserc.cjs'
-      - '.github/workflows/lighthouse-ci.yml'
   pull_request:
     branches: [main, dev]
     paths:

--- a/.github/workflows/newman-comprehensive-tests.yml
+++ b/.github/workflows/newman-comprehensive-tests.yml
@@ -2,26 +2,9 @@ name: Newman Comprehensive Tests (Production Validation + Local Dev)
 
 # This workflow includes:
 # 1. Production validation (scheduled) - validates live stampchain.io endpoints
-# 2. Local dev testing (push/PR) - runs Newman tests against local dev server with MySQL+Redis
+# 2. Local dev testing (PR) - runs Newman tests against local dev server with MySQL+Redis
 
 on:
-  push:
-    branches: [main, dev]
-    paths:
-      - 'tests/postman/collections/comprehensive.json'
-      - 'tests/postman/collections/pagination-validation.json'
-      - 'tests/postman/collections/schema-contract-tests.json'
-      - 'tests/postman/environments/comprehensive.json'
-      - 'tests/postman/data/pagination-tests.json'
-      - 'scripts/run-newman-comprehensive.sh'
-      - 'scripts/run-newman-pagination-validation.sh'
-      - 'scripts/analyze-newman-regression.js'
-      - 'scripts/test-schema.sql'
-      - 'scripts/test-seed-data.sql'
-      - 'server/**'
-      - 'routes/**'
-      - 'lib/**'
-      - '.github/workflows/newman-comprehensive-tests.yml'
   pull_request:
     branches: [main, dev]
     paths:

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -1,15 +1,6 @@
 name: API Schema Validation
 
 on:
-  push:
-    branches: [main, dev]
-    paths:
-      - 'routes/api/**'
-      - 'server/**'
-      - 'lib/types/**'
-      - 'schema.yml'
-      - 'tests/postman/collections/schema-validation.json'
-      - '.github/workflows/schema-validation.yml'
   pull_request:
     branches: [main, dev]
     paths:

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,15 +1,6 @@
 name: TypeScript Type Checking
 
 on:
-  push:
-    branches: [main, dev]
-    paths:
-      - "**/*.ts"
-      - "**/*.tsx"
-      - "deno.json"
-      - "globals.d.ts"
-      - "lib/types/**"
-      - ".github/workflows/type-check.yml"
   pull_request:
     branches: [main, dev]
     paths:
@@ -19,6 +10,7 @@ on:
       - "globals.d.ts"
       - "lib/types/**"
       - ".github/workflows/type-check.yml"
+  workflow_dispatch:
 
 jobs:
   type-check:

--- a/.github/workflows/validate-imports.yml
+++ b/.github/workflows/validate-imports.yml
@@ -1,15 +1,7 @@
 name: Import Pattern Validation
 
-# Trigger on pull requests and pushes to main branch
+# Trigger on pull requests to main/dev branches
 on:
-  push:
-    branches: [main, dev]
-    paths:
-      - "**/*.ts"
-      - "**/*.tsx"
-      - "deno.json"
-      - ".github/workflows/validate-imports.yml"
-      - "scripts/validate-import-patterns.ts"
   pull_request:
     branches: [main, dev]
     paths:

--- a/client/wallet/leather.ts
+++ b/client/wallet/leather.ts
@@ -131,14 +131,20 @@ const signMessage = async (message: string) => {
 
   console.log("Leather wallet signing message:", message);
   try {
-    const { signature } = await leatherProvider.request(
+    const response = await leatherProvider.request(
       "signMessage",
       {
         message,
         paymentType: "p2wpkh",
       },
-    );
+    ) as { result?: { signature?: string }; signature?: string };
+    // Leather wraps responses in {result: ...} (same as signPsbt)
+    const signature = response?.result?.signature ?? response?.signature;
     console.log("Leather wallet signature result:", signature);
+    if (!signature) {
+      console.error("Leather signMessage response:", JSON.stringify(response));
+      throw new Error("Leather wallet returned empty signature");
+    }
     return signature;
   } catch (error) {
     console.error("Error signing message with Leather wallet:", error);

--- a/islands/modal/EditCreatorNameModal.tsx
+++ b/islands/modal/EditCreatorNameModal.tsx
@@ -130,7 +130,20 @@ function EditCreatorNameModal({
 
       let signature: string;
       try {
-        signature = await walletContext.signMessage(message);
+        const rawSignature = await walletContext.signMessage(message);
+        console.log(
+          "[EditCreatorName] signMessage returned:",
+          typeof rawSignature,
+          rawSignature
+            ? `(${String(rawSignature).length} chars)`
+            : rawSignature,
+        );
+        if (!rawSignature || typeof rawSignature !== "string") {
+          throw new Error(
+            `Wallet returned invalid signature (got ${typeof rawSignature})`,
+          );
+        }
+        signature = rawSignature;
       } catch (err) {
         const errMsg = err instanceof Error ? err.message : String(err);
         // User cancellation — don't show an error toast


### PR DESCRIPTION
## Summary
- **Fix Leather wallet signMessage**: Response extraction fixed to handle `{result: {signature: ...}}` wrapper (matching signPSBT pattern). This fixes the "missing required field: signature" error when editing creator names with Leather wallet.
- **Add client-side signature validation**: Modal validates signature is non-empty string before API call.
- **Remove duplicate CI triggers**: Removed push triggers from 6 quality check workflows — PRs are required for both dev and main, so push triggers only duplicated checks.

## Test plan
- [ ] Connect Leather wallet on stampchain.io
- [ ] Edit creator name — verify signature captured and update succeeds
- [ ] Verify CI only runs once per PR (no duplicate push-triggered runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)