### PR TITLE
fix(auth): support BIP-322 signature verification for modern wallets

### DIFF
--- a/lib/utils/security/cryptoUtils.ts
+++ b/lib/utils/security/cryptoUtils.ts
@@ -1,12 +1,21 @@
 import { verify } from "https://esm.sh/bitcoinjs-message@2.2.0";
+import { Verifier } from "https://esm.sh/bip322-js@3.0.0";
 
 export function verifySignature(
   message: string,
   signature: string,
   address: string,
 ): boolean {
+  // Try legacy Bitcoin message verification first (most wallets)
   try {
-    return verify(message, address, signature);
+    return verify(message, address, signature, undefined, true);
+  } catch (_legacyError) {
+    // Legacy verification failed — likely BIP-322 format (Leather, etc.)
+  }
+
+  // Try BIP-322 verification (handles modern wallet signature formats)
+  try {
+    return Verifier.verifySignature(address, message, signature);
   } catch (error) {
     console.error("Error verifying signature:", error);
     return false;


### PR DESCRIPTION
## Summary
- Leather wallet (and potentially other modern wallets) returns BIP-322 format signatures for p2wpkh addresses, which are longer than the 65-byte legacy format that `bitcoinjs-message` expects
- Added `bip322-js@3.0.0` as fallback verifier — tries legacy verification first (with `checkSegwitAlways: true` for segwit addresses), then falls back to BIP-322 verification
- This fixes the "Invalid signature length" error when editing creator names with Leather wallet

## Changes
- `lib/utils/security/cryptoUtils.ts` — dual-format signature verification (legacy + BIP-322)

## Test plan
- [ ] Connect Leather wallet on stampchain.io
- [ ] Edit creator name → sign → verify update succeeds
- [ ] Connect other wallet (OKX, UniSat, etc.) → verify edit still works with legacy format

🤖 Generated with [Claude Code](https://claude.com/claude-code)