### PR TITLE
fix: tiered-timeout in CF Worker for 100% HTML stamp preview success

### DIFF
--- a/routes/api/v2/stamp/[stamp]/preview.ts
+++ b/routes/api/v2/stamp/[stamp]/preview.ts
@@ -622,12 +622,15 @@ async function renderHtmlPreview(
         timeout: 45000,
       });
     } else {
-      // Simple static HTML: clean Rocket Loader artifacts, render inline
+      // Simple static HTML: clean Rocket Loader artifacts, render inline.
+      // Timeout of 40s accounts for CF Worker tiered fallback (15s networkidle0
+      // timeout + 8s extra delay + render overhead) on complex inline stamps.
       const cleanedHtml = cleanHtmlForRendering(rawHtml);
       cfBuffer = await renderWithCloudflare({
         html: cleanedHtml,
         viewport: { width: 1200, height: 1200 },
         delay,
+        timeout: 40000,
       });
     }
 

--- a/routes/api/v2/stamp/[stamp]/preview.ts
+++ b/routes/api/v2/stamp/[stamp]/preview.ts
@@ -527,6 +527,8 @@ async function renderHtmlPreview(
   }
 
   try {
+    const renderStart = Date.now();
+
     const htmlResponse = await fetch(stamp_url);
     if (!htmlResponse.ok) {
       console.error(
@@ -631,10 +633,16 @@ async function renderHtmlPreview(
 
     // If inline mode produced a suspiciously small image (blank render),
     // retry with URL mode as a fallback before giving up.
+    // Skip retry if not enough time budget remains (handler timeout is 55s).
     const MIN_VALID_PNG_SIZE = 5_000;
-    if (cfBuffer && cfBuffer.length < MIN_VALID_PNG_SIZE && !isRecursive) {
+    const elapsedMs = Date.now() - renderStart;
+    const TIME_BUDGET_FOR_RETRY_MS = 40000; // URL mode needs ~37s worst case
+    if (
+      cfBuffer && cfBuffer.length < MIN_VALID_PNG_SIZE && !isRecursive &&
+      elapsedMs < (HANDLER_TIMEOUT_MS - TIME_BUDGET_FOR_RETRY_MS)
+    ) {
       console.warn(
-        `[HTML Preview] Stamp ${stampNumber} inline render too small (${cfBuffer.length}B) — retrying with URL mode`,
+        `[HTML Preview] Stamp ${stampNumber} inline render too small (${cfBuffer.length}B, ${elapsedMs}ms elapsed) — retrying with URL mode`,
       );
       cfBuffer = await renderWithCloudflare({
         url: contentUrl,
@@ -642,6 +650,12 @@ async function renderHtmlPreview(
         delay: 8000,
         timeout: 45000,
       });
+    } else if (
+      cfBuffer && cfBuffer.length < MIN_VALID_PNG_SIZE && !isRecursive
+    ) {
+      console.warn(
+        `[HTML Preview] Stamp ${stampNumber} inline render too small (${cfBuffer.length}B) — skipping URL retry (${elapsedMs}ms elapsed, not enough time budget)`,
+      );
     }
 
     if (cfBuffer && cfBuffer.length >= MIN_VALID_PNG_SIZE) {

--- a/workers/preview-renderer/src/index.ts
+++ b/workers/preview-renderer/src/index.ts
@@ -70,6 +70,7 @@ export default {
     const delay = body.delay ?? 5000;
 
     let browser;
+    let usedTieredFallback = false;
     try {
       browser = await puppeteer.launch(env.BROWSER);
       const page = await browser.newPage();
@@ -87,13 +88,32 @@ export default {
           timeout: 25000,
         });
       } else if (body.url) {
-        // URL mode: navigate to URL — recursive stamps may load multiple resources,
-        // so allow a longer timeout than inline HTML mode.
-        // CF Browser Rendering allows up to 60s sessions.
-        await page.goto(body.url, {
-          waitUntil: "networkidle2",
-          timeout: 45000,
-        });
+        // URL mode: tiered-timeout approach for maximum reliability.
+        // Some stamps (Append framework, complex recursive) keep network connections
+        // alive indefinitely, causing networkidle2 to hang until timeout.
+        // Strategy: try networkidle2 with 20s timeout first. If it times out,
+        // the page content is already loaded — just wait a bit longer for
+        // rendering to complete, then screenshot anyway.
+        try {
+          await page.goto(body.url, {
+            waitUntil: "networkidle2",
+            timeout: 20000,
+          });
+        } catch (navError) {
+          const navMsg = navError instanceof Error ? navError.message : String(navError);
+          if (navMsg.includes("timeout") || navMsg.includes("Timeout")) {
+            // Page loaded but network didn't settle — content is likely rendered.
+            // Wait for rendering to complete before screenshot.
+            console.log(
+              `[stamp-preview-renderer] networkidle2 timed out for ${body.url} — proceeding with extended delay`,
+            );
+            await new Promise((resolve) => setTimeout(resolve, 12000));
+            usedTieredFallback = true;
+          } else {
+            // Genuine navigation error (DNS, SSL, 404, etc.) — re-throw
+            throw navError;
+          }
+        }
       }
 
       // Wait for dynamic content (animations, canvas rendering, etc.)
@@ -114,6 +134,7 @@ export default {
         headers: {
           "Content-Type": "image/png",
           "X-Rendering-Engine": "cloudflare-browser",
+          ...(usedTieredFallback && { "X-Tiered-Fallback": "true" }),
           "Cache-Control": "no-store",
         },
       });

--- a/workers/preview-renderer/src/index.ts
+++ b/workers/preview-renderer/src/index.ts
@@ -82,11 +82,28 @@ export default {
       });
 
       if (body.html) {
-        // HTML mode: set content directly (no network needed — keep tight timeout)
-        await page.setContent(body.html, {
-          waitUntil: "networkidle0",
-          timeout: 25000,
-        });
+        // HTML mode: set content directly. Use tiered timeout like URL mode —
+        // some stamps with CSS animations and embedded fonts prevent networkidle0
+        // from resolving even though no real network requests are made.
+        try {
+          await page.setContent(body.html, {
+            waitUntil: "networkidle0",
+            timeout: 15000,
+          });
+        } catch (htmlNavError) {
+          const htmlNavMsg = htmlNavError instanceof Error
+            ? htmlNavError.message
+            : String(htmlNavError);
+          if (htmlNavMsg.includes("timeout") || htmlNavMsg.includes("Timeout")) {
+            console.log(
+              `[stamp-preview-renderer] networkidle0 timed out for inline HTML — proceeding with extended delay`,
+            );
+            await new Promise((resolve) => setTimeout(resolve, 8000));
+            usedTieredFallback = true;
+          } else {
+            throw htmlNavError;
+          }
+        }
       } else if (body.url) {
         // URL mode: tiered-timeout approach for maximum reliability.
         // Some stamps (Append framework, complex recursive) keep network connections


### PR DESCRIPTION
## Summary
- Implements tiered-timeout approach in CF Browser Rendering Worker to handle stamps that keep network connections alive indefinitely (Append framework, CSS animations, embedded fonts)
- Applies tiered timeout to both URL mode AND inline HTML mode
- Adds elapsed time check to skip URL retry when not enough time budget remains
- Increases inline HTML fetch timeout from 30s to 40s to accommodate tiered fallback

## How it works
1. Try `networkidle2` (URL mode) or `networkidle0` (inline mode) with 15-20s timeout
2. If timeout fires, page content is already loaded — wait 8-12s more for rendering to complete
3. Screenshot anyway, regardless of network idle state
4. `X-Tiered-Fallback: true` header tracks when fallback was used

## Results
- **Before**: ~7% success rate on 438 HTML stamps
- **Previous session fixes**: ~94% success rate (iframe extraction, abort detection, retry logic)
- **This PR**: **100% success rate** on 100 random samples (zero failures)
- All 6 previously-failing stamps now render successfully
- Stamp 798710 ("The Emerald Brick Of KEK") — 34KB with embedded WOFF fonts + 3D CSS — now renders in 31s

## Files changed
- `workers/preview-renderer/src/index.ts` — tiered timeout for both URL and HTML modes
- `routes/api/v2/stamp/[stamp]/preview.ts` — elapsed time check, increased inline timeout

## Test plan
- [x] Deployed CF Worker via `wrangler deploy`
- [x] Deployed ECS handler via `deploy.sh local`
- [x] Force-refreshed all 6 previously-failing stamps — all render successfully
- [x] Validation: 30/30 random stamps = 100% success
- [x] Validation: 100/100 random stamps = 100% success

🤖 Generated with [Claude Code](https://claude.com/claude-code)