### PR TITLE
feat: configure S3 as default preview storage

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -21,6 +21,14 @@ MINTING_SERVICE_FEE_ENABLED=0 # 1 or 0
 # Content Configuration
 IMAGES_SRC_PATH=https://stampchain.io/stamps
 
+# S3 Preview Storage (stamp preview PNGs and GIFs)
+# Previews are stored in S3 alongside original stamp files, served via CloudFront.
+# S3 path: s3://{bucket}/{image_dir}/previews/{stamp_number}.png|gif
+AWS_S3_BUCKETNAME=stampchain.io
+AWS_S3_IMAGE_DIR=stamps
+PREVIEW_STORAGE=s3
+CLOUDFRONT_PREVIEW_DOMAIN=stampchain.io
+
 # MySQL TLS (required for MySQL 8.4 caching_sha2_password auth)
 # TLS is enabled by default. Set to "false" only for local Docker MySQL.
 # DB_ENABLE_TLS=true

--- a/env-templates/production.json
+++ b/env-templates/production.json
@@ -7,8 +7,8 @@
   {"name": "SKIP_REDIS_CONNECTION", "value": "false"},
   {"name": "ELASTICACHE_ENDPOINT", "value": "memory"},
   {"name": "SKIP_REDIS", "value": "false"},
-  {"name": "AWS_S3_BUCKETNAME", "value": "{existing-bucket-name}"},
-  {"name": "AWS_S3_IMAGE_DIR", "value": "stamps/"},
+  {"name": "AWS_S3_BUCKETNAME", "value": "stampchain.io"},
+  {"name": "AWS_S3_IMAGE_DIR", "value": "stamps"},
   {"name": "CLOUDFRONT_PREVIEW_DOMAIN", "value": "stampchain.io"},
   {"name": "PREVIEW_STORAGE", "value": "s3"},
   {"name": "AWS_REGION", "value": "us-east-1"}


### PR DESCRIPTION
## Summary
- Fix .env.sample and production.json to use correct S3 bucket name and preview storage config
- Previews stored at `s3://stampchain.io/stamps/previews/` — same bucket as original stamps, separate path
- Zero impact on existing stamp files in `/stamps/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)