### PR TITLE
fix(ci): exclude encrypted .env.enc from security validation

### DIFF
--- a/.github/workflows/production-validation.yml
+++ b/.github/workflows/production-validation.yml
@@ -333,7 +333,7 @@ jobs:
       - name: Validate environment security
         run: |
           # Check for .env files in repository
-          if find . -name ".env*" -not -path "./.env.example" -not -path "./.env.template" -not -path "./.env.sample" | grep -q .; then
+          if find . -name ".env*" -not -path "./.env.example" -not -path "./.env.template" -not -path "./.env.sample" -not -name "*.enc" | grep -q .; then
             echo "❌ Environment files found in repository"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Exclude `.env.enc` (encrypted env backup) from the security validation check in `production-validation.yml`
- The check was rejecting all `.env*` files but `.env.enc` is intentionally tracked as an encrypted backup

## Test plan

- [ ] Security Validation step passes (was failing on all recent PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)