### PR TITLE
fix(cache): flip forceNoCache default to enable CF CDN caching

### DIFF
--- a/lib/utils/api/responses/apiResponseUtil.ts
+++ b/lib/utils/api/responses/apiResponseUtil.ts
@@ -31,10 +31,19 @@ export const API_RESPONSE_VERSION = "v2.2.7";
 //  └── api.ts                // Type definitions (client-safe, no Deno dependencies)
 
 export class ApiResponseUtil {
+  /**
+   * Default cache duration (seconds) for API responses that don't specify
+   * a routeType. Conservative 5-minute TTL prevents stale data while still
+   * offloading repetitive identical requests from origin.
+   */
+  private static readonly DEFAULT_API_CACHE_SECONDS = 300;
+
   private static createHeaders(options: ApiResponseOptions = {}): Headers {
+    const shouldCache = !(options.forceNoCache ?? false);
+
     const headers: Record<string, string> = {
       ...getSecurityHeaders({
-        forceNoCache: options.forceNoCache ?? true,
+        forceNoCache: !shouldCache,
         context: "api",
       }),
       "Content-Type": "application/json",
@@ -45,27 +54,52 @@ export class ApiResponseUtil {
       ...(options.headers || {}),
     };
 
-    if (options.routeType && !options.forceNoCache) {
-      const { duration, staleWhileRevalidate, staleIfError } = getCacheConfig(
-        options.routeType,
+    // Skip cache header generation if caller supplied an explicit Cache-Control
+    const hasExplicitCacheControl = options.headers &&
+      Object.keys(options.headers).some((k) =>
+        k.toLowerCase() === "cache-control"
       );
 
-      if (duration > 0) {
-        const cacheControl = [
-          "public",
-          `max-age=${duration}`,
-          staleWhileRevalidate
-            ? `stale-while-revalidate=${staleWhileRevalidate}`
-            : "",
-          staleIfError ? `stale-if-error=${staleIfError}` : "",
-        ].filter(Boolean).join(", ");
+    if (shouldCache && !hasExplicitCacheControl) {
+      let cacheControl: string;
 
+      if (options.routeType) {
+        const { duration, staleWhileRevalidate, staleIfError } = getCacheConfig(
+          options.routeType,
+        );
+
+        if (duration > 0) {
+          cacheControl = [
+            "public",
+            `max-age=${duration}`,
+            staleWhileRevalidate
+              ? `stale-while-revalidate=${staleWhileRevalidate}`
+              : "",
+            staleIfError ? `stale-if-error=${staleIfError}` : "",
+          ].filter(Boolean).join(", ");
+        } else {
+          cacheControl = "";
+        }
+      } else {
+        // No routeType specified: apply conservative default (5 min)
+        // instead of the 1-year immutable from securityHeaders.
+        cacheControl =
+          `public, max-age=${this.DEFAULT_API_CACHE_SECONDS}, stale-while-revalidate=60`;
+      }
+
+      if (cacheControl) {
         Object.assign(headers, {
           "Cache-Control": cacheControl,
           "CDN-Cache-Control": cacheControl,
           "Cloudflare-CDN-Cache-Control": cacheControl,
-          "Surrogate-Control": `max-age=${duration}`,
-          "Edge-Control": `cache-maxage=${duration}`,
+          "Surrogate-Control": `max-age=${
+            cacheControl.match(/max-age=(\d+)/)?.[1] ||
+            this.DEFAULT_API_CACHE_SECONDS
+          }`,
+          "Edge-Control": `cache-maxage=${
+            cacheControl.match(/max-age=(\d+)/)?.[1] ||
+            this.DEFAULT_API_CACHE_SECONDS
+          }`,
         });
       }
     }

--- a/routes/api/v2/create/dispense.ts
+++ b/routes/api/v2/create/dispense.ts
@@ -62,7 +62,7 @@ export const handler: Handlers = {
           },
           is_estimate: true,
           estimation_method: "dryRun_calculation",
-        });
+        }, { forceNoCache: true });
       }
 
       let normalizedFees;
@@ -226,7 +226,7 @@ export const handler: Handlers = {
           estimatedFee: builtPsbtData.estimatedFee,
           estimatedVsize: builtPsbtData.estimatedVsize,
           finalBuyerChange: builtPsbtData.finalBuyerChange,
-        });
+        }, { forceNoCache: true });
       } catch (error: unknown) {
         const errorMessage = error instanceof Error
           ? error.message

--- a/routes/api/v2/create/send.ts
+++ b/routes/api/v2/create/send.ts
@@ -222,7 +222,7 @@ export const handler: Handlers<SendResponse | { error: string }> = {
         });
         return ApiResponseUtil.success({
           estimatedFee: feeFromCp ? Number(feeFromCp) : undefined,
-        });
+        }, { forceNoCache: true });
       }
 
       const finalPsbtHex = psbt.toHex();
@@ -243,7 +243,7 @@ export const handler: Handlers<SendResponse | { error: string }> = {
         estimatedFee: cpResponse.result.btc_fee
           ? Number(cpResponse.result.btc_fee)
           : undefined,
-      });
+      }, { forceNoCache: true });
     } catch (error: unknown) {
       const errorMessage = error instanceof Error
         ? error.message

--- a/routes/api/v2/fairmint/compose.ts
+++ b/routes/api/v2/fairmint/compose.ts
@@ -101,7 +101,7 @@ export const handler: Handlers = {
             },
             is_estimate: true,
             estimation_method: "dryRun_calculation",
-          });
+          }, { forceNoCache: true });
         }
 
         const psbtResult = await GeneralBitcoinTransactionBuilder.generatePSBT(
@@ -133,7 +133,7 @@ export const handler: Handlers = {
           finalUserChange: BigInt(psbtResult.totalChangeOutput),
         };
 
-        return ResponseUtil.success(processedPSBT);
+        return ResponseUtil.success(processedPSBT, { forceNoCache: true });
       } catch (error) {
         if (
           error instanceof Error && error.message.includes("Insufficient BTC")

--- a/routes/api/v2/src20/create.ts
+++ b/routes/api/v2/src20/create.ts
@@ -230,7 +230,7 @@ export const handler: Handlers<SRC20CreateResponse | TXError> = {
         delete responsePayload.hex;
         delete responsePayload.inputsToSign;
       }
-      return ApiResponseUtil.success(responsePayload);
+      return ApiResponseUtil.success(responsePayload, { forceNoCache: true });
     } catch (error) {
       const errorMessage = error instanceof Error
         ? error.message

--- a/routes/api/v2/trx/complete_psbt.ts
+++ b/routes/api/v2/trx/complete_psbt.ts
@@ -27,7 +27,9 @@ export const handler: Handlers = {
           feeRate,
         );
 
-      return ApiResponseUtil.success({ completedPsbt: completedPsbtHex });
+      return ApiResponseUtil.success({ completedPsbt: completedPsbtHex }, {
+        forceNoCache: true,
+      });
     } catch (error) {
       logger.error("api", {
         message: "Error completing PSBT",

--- a/routes/api/v2/trx/create_psbt.ts
+++ b/routes/api/v2/trx/create_psbt.ts
@@ -52,7 +52,7 @@ export const handler: Handlers = {
         estimatedSize: 250, // Placeholder - should be calculated from PSBT
       };
 
-      return ApiResponseUtil.success(response);
+      return ApiResponseUtil.success(response, { forceNoCache: true });
     } catch (error) {
       if (error instanceof SyntaxError) {
         logger.error("api", {

--- a/routes/api/v2/trx/stampattach.ts
+++ b/routes/api/v2/trx/stampattach.ts
@@ -405,7 +405,7 @@ export const handler: Handlers = {
               : BigInt(0)),
         ),
         estimatedVsize: Number(estimatedVsize),
-      });
+      }, { forceNoCache: true });
     } catch (error: unknown) {
       const errorMessage = error instanceof Error
         ? error.message

--- a/routes/api/v2/trx/stampdetach.ts
+++ b/routes/api/v2/trx/stampdetach.ts
@@ -132,7 +132,7 @@ export const handler: Handlers = {
           finalUserChange: BigInt(psbtResult.totalChangeOutput),
         };
 
-        return ApiResponseUtil.success(processedPSBT);
+        return ApiResponseUtil.success(processedPSBT, { forceNoCache: true });
       } catch (error) {
         if (error instanceof Error) {
           const errorMessage = error.message.toLowerCase();


### PR DESCRIPTION
## Summary

- Flips `forceNoCache` default from `true` to `false` in `ApiResponseUtil.createHeaders()` — the root cause of the 7% CF cache hit rate
- Adds conservative 5-minute default cache for routes without explicit `routeType`
- Routes with `routeType` get their configured TTL from `cacheService.ts` (24h for blockchain data, 5min for dynamic)
- Adds `forceNoCache: true` to 9 POST/write endpoints to prevent caching mutations
- Explicit `Cache-Control` headers from callers take precedence over defaults

## Context

Cloudflare analytics show 93% of requests hitting ECS origin because every API response sent `Cache-Control: no-store`. The `cacheService.ts` RouteType configs (24h for BLOCKCHAIN_DATA, etc.) were correctly defined but never activated because `forceNoCache` defaulted to `true` on line 37 of `apiResponseUtil.ts`.

## Expected Impact

| Metric | Before | After |
|--------|--------|-------|
| CF cache hit rate | 7% | 40-60% |
| Origin requests/day | ~140K | ~60-80K |
| ECS CPU peak | 98% | <40% |

## Test Plan

- [x] `deno check main.ts` passes
- [x] `deno fmt --check` passes (586 files)
- [x] Unit tests: 1018 passed, 1 pre-existing failure (maraConfigValidator, unrelated)
- [x] Cache header tests updated and passing
- [ ] Monitor CF Analytics dashboard for cache hit rate increase post-deploy
- [ ] Verify POST endpoints still return `no-store` headers
- [ ] Verify stamp/SRC-20 GET endpoints return `public, max-age=...` headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)