### PR TITLE
Release: CF cache fix, anonymous rate limit tightening, CI matrix cleanup

### DIFF
--- a/.github/workflows/production-validation.yml
+++ b/.github/workflows/production-validation.yml
@@ -139,10 +139,6 @@ jobs:
     needs: production-gates
     continue-on-error: true
 
-    strategy:
-      matrix:
-        typescript-version: ["5.0", "5.1", "5.2", "5.3"]
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -156,8 +152,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cache/deno
-          key: deno-${{ matrix.typescript-version }}-${{ hashFiles('deno.json', 'deno.lock') }}
-          restore-keys: deno-${{ matrix.typescript-version }}-
+          key: deno-cross-module-${{ hashFiles('deno.json', 'deno.lock') }}
+          restore-keys: deno-cross-module-
 
       - name: Run dependency graph analysis
         run: deno task validate:dependencies
@@ -174,7 +170,7 @@ jobs:
       - name: Upload integration test results
         uses: actions/upload-artifact@v6
         with:
-          name: cross-module-integration-ts${{ matrix.typescript-version }}
+          name: cross-module-integration
           path: |
             reports/cross-module-integration-*.json
             reports/dependency-analysis.json

--- a/lib/utils/api/responses/apiResponseUtil.ts
+++ b/lib/utils/api/responses/apiResponseUtil.ts
@@ -31,10 +31,19 @@ export const API_RESPONSE_VERSION = "v2.2.7";
 //  └── api.ts                // Type definitions (client-safe, no Deno dependencies)
 
 export class ApiResponseUtil {
+  /**
+   * Default cache duration (seconds) for API responses that don't specify
+   * a routeType. Conservative 5-minute TTL prevents stale data while still
+   * offloading repetitive identical requests from origin.
+   */
+  private static readonly DEFAULT_API_CACHE_SECONDS = 300;
+
   private static createHeaders(options: ApiResponseOptions = {}): Headers {
+    const shouldCache = !(options.forceNoCache ?? false);
+
     const headers: Record<string, string> = {
       ...getSecurityHeaders({
-        forceNoCache: options.forceNoCache ?? true,
+        forceNoCache: !shouldCache,
         context: "api",
       }),
       "Content-Type": "application/json",
@@ -45,27 +54,52 @@ export class ApiResponseUtil {
       ...(options.headers || {}),
     };
 
-    if (options.routeType && !options.forceNoCache) {
-      const { duration, staleWhileRevalidate, staleIfError } = getCacheConfig(
-        options.routeType,
+    // Skip cache header generation if caller supplied an explicit Cache-Control
+    const hasExplicitCacheControl = options.headers &&
+      Object.keys(options.headers).some((k) =>
+        k.toLowerCase() === "cache-control"
       );
 
-      if (duration > 0) {
-        const cacheControl = [
-          "public",
-          `max-age=${duration}`,
-          staleWhileRevalidate
-            ? `stale-while-revalidate=${staleWhileRevalidate}`
-            : "",
-          staleIfError ? `stale-if-error=${staleIfError}` : "",
-        ].filter(Boolean).join(", ");
+    if (shouldCache && !hasExplicitCacheControl) {
+      let cacheControl: string;
 
+      if (options.routeType) {
+        const { duration, staleWhileRevalidate, staleIfError } = getCacheConfig(
+          options.routeType,
+        );
+
+        if (duration > 0) {
+          cacheControl = [
+            "public",
+            `max-age=${duration}`,
+            staleWhileRevalidate
+              ? `stale-while-revalidate=${staleWhileRevalidate}`
+              : "",
+            staleIfError ? `stale-if-error=${staleIfError}` : "",
+          ].filter(Boolean).join(", ");
+        } else {
+          cacheControl = "";
+        }
+      } else {
+        // No routeType specified: apply conservative default (5 min)
+        // instead of the 1-year immutable from securityHeaders.
+        cacheControl =
+          `public, max-age=${this.DEFAULT_API_CACHE_SECONDS}, stale-while-revalidate=60`;
+      }
+
+      if (cacheControl) {
         Object.assign(headers, {
           "Cache-Control": cacheControl,
           "CDN-Cache-Control": cacheControl,
           "Cloudflare-CDN-Cache-Control": cacheControl,
-          "Surrogate-Control": `max-age=${duration}`,
-          "Edge-Control": `cache-maxage=${duration}`,
+          "Surrogate-Control": `max-age=${
+            cacheControl.match(/max-age=(\d+)/)?.[1] ||
+            this.DEFAULT_API_CACHE_SECONDS
+          }`,
+          "Edge-Control": `cache-maxage=${
+            cacheControl.match(/max-age=(\d+)/)?.[1] ||
+            this.DEFAULT_API_CACHE_SECONDS
+          }`,
         });
       }
     }

--- a/routes/api/v2/create/dispense.ts
+++ b/routes/api/v2/create/dispense.ts
@@ -62,7 +62,7 @@ export const handler: Handlers = {
           },
           is_estimate: true,
           estimation_method: "dryRun_calculation",
-        });
+        }, { forceNoCache: true });
       }
 
       let normalizedFees;
@@ -226,7 +226,7 @@ export const handler: Handlers = {
           estimatedFee: builtPsbtData.estimatedFee,
           estimatedVsize: builtPsbtData.estimatedVsize,
           finalBuyerChange: builtPsbtData.finalBuyerChange,
-        });
+        }, { forceNoCache: true });
       } catch (error: unknown) {
         const errorMessage = error instanceof Error
           ? error.message

--- a/routes/api/v2/create/send.ts
+++ b/routes/api/v2/create/send.ts
@@ -222,7 +222,7 @@ export const handler: Handlers<SendResponse | { error: string }> = {
         });
         return ApiResponseUtil.success({
           estimatedFee: feeFromCp ? Number(feeFromCp) : undefined,
-        });
+        }, { forceNoCache: true });
       }
 
       const finalPsbtHex = psbt.toHex();
@@ -243,7 +243,7 @@ export const handler: Handlers<SendResponse | { error: string }> = {
         estimatedFee: cpResponse.result.btc_fee
           ? Number(cpResponse.result.btc_fee)
           : undefined,
-      });
+      }, { forceNoCache: true });
     } catch (error: unknown) {
       const errorMessage = error instanceof Error
         ? error.message

--- a/routes/api/v2/fairmint/compose.ts
+++ b/routes/api/v2/fairmint/compose.ts
@@ -101,7 +101,7 @@ export const handler: Handlers = {
             },
             is_estimate: true,
             estimation_method: "dryRun_calculation",
-          });
+          }, { forceNoCache: true });
         }
 
         const psbtResult = await GeneralBitcoinTransactionBuilder.generatePSBT(
@@ -133,7 +133,7 @@ export const handler: Handlers = {
           finalUserChange: BigInt(psbtResult.totalChangeOutput),
         };
 
-        return ResponseUtil.success(processedPSBT);
+        return ResponseUtil.success(processedPSBT, { forceNoCache: true });
       } catch (error) {
         if (
           error instanceof Error && error.message.includes("Insufficient BTC")

--- a/routes/api/v2/src20/create.ts
+++ b/routes/api/v2/src20/create.ts
@@ -230,7 +230,7 @@ export const handler: Handlers<SRC20CreateResponse | TXError> = {
         delete responsePayload.hex;
         delete responsePayload.inputsToSign;
       }
-      return ApiResponseUtil.success(responsePayload);
+      return ApiResponseUtil.success(responsePayload, { forceNoCache: true });
     } catch (error) {
       const errorMessage = error instanceof Error
         ? error.message

--- a/routes/api/v2/trx/complete_psbt.ts
+++ b/routes/api/v2/trx/complete_psbt.ts
@@ -27,7 +27,9 @@ export const handler: Handlers = {
           feeRate,
         );
 
-      return ApiResponseUtil.success({ completedPsbt: completedPsbtHex });
+      return ApiResponseUtil.success({ completedPsbt: completedPsbtHex }, {
+        forceNoCache: true,
+      });
     } catch (error) {
       logger.error("api", {
         message: "Error completing PSBT",

--- a/routes/api/v2/trx/create_psbt.ts
+++ b/routes/api/v2/trx/create_psbt.ts
@@ -52,7 +52,7 @@ export const handler: Handlers = {
         estimatedSize: 250, // Placeholder - should be calculated from PSBT
       };
 
-      return ApiResponseUtil.success(response);
+      return ApiResponseUtil.success(response, { forceNoCache: true });
     } catch (error) {
       if (error instanceof SyntaxError) {
         logger.error("api", {

--- a/routes/api/v2/trx/stampattach.ts
+++ b/routes/api/v2/trx/stampattach.ts
@@ -405,7 +405,7 @@ export const handler: Handlers = {
               : BigInt(0)),
         ),
         estimatedVsize: Number(estimatedVsize),
-      });
+      }, { forceNoCache: true });
     } catch (error: unknown) {
       const errorMessage = error instanceof Error
         ? error.message

--- a/routes/api/v2/trx/stampdetach.ts
+++ b/routes/api/v2/trx/stampdetach.ts
@@ -132,7 +132,7 @@ export const handler: Handlers = {
           finalUserChange: BigInt(psbtResult.totalChangeOutput),
         };
 
-        return ApiResponseUtil.success(processedPSBT);
+        return ApiResponseUtil.success(processedPSBT, { forceNoCache: true });
       } catch (error) {
         if (error instanceof Error) {
           const errorMessage = error.message.toLowerCase();

--- a/server/middleware/rateLimiter.ts
+++ b/server/middleware/rateLimiter.ts
@@ -27,41 +27,85 @@ interface RateLimitConfig {
  * Rate limit configurations by endpoint pattern
  * More specific patterns checked first
  *
- * Configuration based on research recommendations:
- * - SRC-20: 120 req/min (2/sec) - Known performance bottleneck
- * - Stamps: 180 req/min (3/sec) - Database-intensive queries
- * - Blocks: 240 req/min (4/sec) - Lighter queries
- * - General: 300 req/min (5/sec) - Standard API protection
+ * Anonymous (no API key) rate limits:
+ * - SRC-20: 60 req/min (1/sec) - Heaviest DB queries, known bottleneck
+ * - Stamps: 100 req/min (~2/sec) - Database-intensive metadata lookups
+ * - Blocks: 120 req/min (2/sec) - Block data queries
+ * - General: 150 req/min (~3/sec) - All other v2 endpoints
+ *
+ * Block durations are short (30s) to avoid frustrating legitimate users.
+ * API key holders get higher limits (see apiKeyRateLimitConfigs below).
  */
 const rateLimitConfigs: Record<string, RateLimitConfig> = {
-  // Tier 3: SRC-20 endpoints (strictest - known pain point)
+  // Tier 3: SRC-20 endpoints (strictest - heaviest DB queries)
   "/api/v2/src20": {
     windowMs: 60000, // 1 minute
-    max: 120, // 120 requests = 2 req/sec (updated from 60)
-    message: "SRC-20 API rate limit exceeded. Limit: 120 requests per minute.",
-    blockDuration: 300, // 5 minute block (updated from 10 minutes)
+    max: 60, // 60 requests = 1 req/sec
+    message:
+      "SRC-20 API rate limit exceeded. Limit: 60 requests per minute. Get higher limits with a free API key at stampchain.io/api",
+    blockDuration: 30, // 30 second block
   },
 
   // Tier 2: Expensive endpoints (database-intensive)
   "/api/v2/stamps": {
     windowMs: 60000,
-    max: 180, // 180 requests = 3 req/sec (updated from 120)
-    message: "Stamps API rate limit exceeded. Limit: 180 requests per minute.",
-    blockDuration: 300, // 5 minute block
+    max: 100, // 100 requests = ~2 req/sec
+    message:
+      "Stamps API rate limit exceeded. Limit: 100 requests per minute. Get higher limits with a free API key at stampchain.io/api",
+    blockDuration: 30, // 30 second block
   },
   "/api/v2/blocks": {
     windowMs: 60000,
-    max: 240, // 240 requests = 4 req/sec (updated from 120)
-    message: "Blocks API rate limit exceeded. Limit: 240 requests per minute.",
-    blockDuration: 180, // 3 minute block (updated from 5 minutes)
+    max: 120, // 120 requests = 2 req/sec
+    message:
+      "Blocks API rate limit exceeded. Limit: 120 requests per minute. Get higher limits with a free API key at stampchain.io/api",
+    blockDuration: 30, // 30 second block
   },
 
   // Tier 1: General API protection (default for all other endpoints)
   "/api/v2": {
     windowMs: 60000,
-    max: 300, // 300 requests = 5 req/sec
-    message: "API rate limit exceeded. Limit: 300 requests per minute.",
-    blockDuration: 60, // 1 minute block
+    max: 150, // 150 requests = ~3 req/sec
+    message:
+      "API rate limit exceeded. Limit: 150 requests per minute. Get higher limits with a free API key at stampchain.io/api",
+    blockDuration: 30, // 30 second block
+  },
+};
+
+/**
+ * Rate limits for authenticated API key holders (free tier).
+ * 3-5x higher than anonymous limits, no blocking on exceedance.
+ * These will be used when X-API-Key header matches a registered key.
+ *
+ * NOTE: Currently unused — API key tier detection not yet implemented.
+ * This config is defined now so the values are documented and ready
+ * for the next PR that adds key signup + tier-aware middleware.
+ */
+// @ts-ignore: Reserved for API key tier implementation (next PR)
+const _apiKeyRateLimitConfigs: Record<string, RateLimitConfig> = {
+  "/api/v2/src20": {
+    windowMs: 60000,
+    max: 300, // 5 req/sec (5x anonymous)
+    message: "SRC-20 API rate limit exceeded. Limit: 300 requests per minute.",
+    blockDuration: 0, // No block for key holders
+  },
+  "/api/v2/stamps": {
+    windowMs: 60000,
+    max: 480, // 8 req/sec
+    message: "Stamps API rate limit exceeded. Limit: 480 requests per minute.",
+    blockDuration: 0,
+  },
+  "/api/v2/blocks": {
+    windowMs: 60000,
+    max: 600, // 10 req/sec
+    message: "Blocks API rate limit exceeded. Limit: 600 requests per minute.",
+    blockDuration: 0,
+  },
+  "/api/v2": {
+    windowMs: 60000,
+    max: 600, // 10 req/sec
+    message: "API rate limit exceeded. Limit: 600 requests per minute.",
+    blockDuration: 0,
   },
 };
 
@@ -177,6 +221,10 @@ export async function rateLimitMiddleware(
           retryAfter,
           limit: config.max,
           window: config.windowMs / 1000,
+          upgrade: {
+            message: "Get 3-5x higher limits with a free API key",
+            url: "https://stampchain.io/api",
+          },
         }),
         {
           status: 429,
@@ -220,6 +268,10 @@ export async function rateLimitMiddleware(
           window: config.windowMs / 1000,
           blocked: config.blockDuration ? true : false,
           blockDuration: config.blockDuration || 0,
+          upgrade: {
+            message: "Get 3-5x higher limits with a free API key",
+            url: "https://stampchain.io/api",
+          },
         }),
         {
           status: 429,


### PR DESCRIPTION
## Summary

3 commits, cherry-picked clean onto main (no rebase conflicts):

1. **fix(cache)**: Flip `forceNoCache` default to enable Cloudflare CDN caching
   - Root cause: `apiResponseUtil.ts:37` defaulted `forceNoCache` to `true`, sending `Cache-Control: no-store` on all 66 API routes
   - Fix: Default to `false`, add conservative 5-min default for routes without routeType, explicit `forceNoCache: true` on 9 POST/write endpoints
   - Expected: CF cache hit rate from ~17% to 40-60%

2. **feat(rate-limit)**: Tighten anonymous limits, add upgrade messaging
   - SRC-20: 2→1 RPS, Stamps: 3→2 RPS, Blocks: 4→2 RPS, General: 5→3 RPS
   - Block duration: 1-5 min → 30s (less punitive)
   - 429 responses include upgrade URL for API key signup
   - API key tier configs defined (not yet wired)

3. **fix(ci)**: Remove pointless TS version matrix from cross-module tests
   - Matrix ran same test 4x with labels "5.0"-"5.3" but never switched TS versions (Deno bundles 5.9.2)
   - 3 of 4 entries failed nondeterministically, creating false CI failures
   - Now runs once. Same coverage, no flakiness.

## Replaces

Closes #1103 (had rebase conflicts from the sync commit)

## Test plan

- [x] `deno check main.ts` passes
- [x] Unit tests: 1018 passed
- [x] Clean cherry-pick onto main (no conflicts)
- [ ] CI passes on this PR (cross-module should be 1 run, no matrix)
- [ ] Monitor CF cache hit rate post-deploy
- [ ] Monitor 429 rates post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)