### PR TITLE
fix(api): accept stamp 0 as valid stamp number identifier

### DIFF
--- a/lib/utils/typeGuards.ts
+++ b/lib/utils/typeGuards.ts
@@ -603,11 +603,11 @@ export function isValidStampNumber(num: unknown): num is number | null {
  */
 export function isStampNumber(value: unknown): boolean {
   if (typeof value === "number") {
-    return Number.isInteger(value) && value !== 0;
+    return Number.isInteger(value);
   }
   if (typeof value === "string") {
     const num = Number(value);
-    return !isNaN(num) && Number.isInteger(num) && num !== 0;
+    return !isNaN(num) && Number.isInteger(num);
   }
   return false;
 }

--- a/tests/unit/identifierUtils.test.ts
+++ b/tests/unit/identifierUtils.test.ts
@@ -19,6 +19,11 @@ Deno.test("identifierUtils - isStampNumber", async (t) => {
     assert(isStampNumber("100"));
   });
 
+  await t.step("should validate zero (stamp 0 - genesis stamp)", () => {
+    assert(isStampNumber(0));
+    assert(isStampNumber("0"));
+  });
+
   await t.step("should validate negative integers (cursed stamps)", () => {
     assert(isStampNumber(-1));
     assert(isStampNumber(-100));
@@ -114,6 +119,8 @@ Deno.test("identifierUtils - getIdentifierType", async (t) => {
     assertEquals(getIdentifierType(123), "stamp_number");
     assertEquals(getIdentifierType("456"), "stamp_number");
     assertEquals(getIdentifierType(-789), "stamp_number");
+    assertEquals(getIdentifierType(0), "stamp_number");
+    assertEquals(getIdentifierType("0"), "stamp_number");
   });
 
   await t.step("should identify transaction hashes", () => {


### PR DESCRIPTION
## Summary

- Accept stamp number `0` as a valid identifier in stamp lookup endpoints
- Stamp 0 exists in the Bitcoin Stamps protocol but was rejected by validation logic treating `0` as falsy

Rebased from #1101 (fork PR that can't rebase cleanly). Same code, clean history.

## Test plan

- [x] Unit tests added for stamp 0 identifier validation
- [ ] CI passes

Closes #1101

🤖 Generated with [Claude Code](https://claude.com/claude-code)