### PR TITLE
test: update typeGuards test for stamp 0 identifier (#1101)

### DIFF
--- a/tests/unit/typeGuards.consolidated.test.ts
+++ b/tests/unit/typeGuards.consolidated.test.ts
@@ -359,7 +359,7 @@ Deno.test("Stamp Protocol Type Guards", async (t) => {
   await t.step("isStampNumber - enhanced version", () => {
     assertEquals(isStampNumber(1), true);
     assertEquals(isStampNumber(-1), true); // cursed stamps
-    assertEquals(isStampNumber(0), false);
+    assertEquals(isStampNumber(0), true); // stamp 0 exists
   });
 
   await t.step("isStampHash", () => {


### PR DESCRIPTION
Updates `isStampNumber(0)` assertion from `false` to `true` to match the #1101 fix. `isValidStampNumber(0)` correctly remains `false`.

Unit tests: 1019 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)