### PR TITLE
fix(ci): restore cd tests prefix for cross-module test runner

### DIFF
--- a/.github/workflows/production-validation.yml
+++ b/.github/workflows/production-validation.yml
@@ -159,7 +159,7 @@ jobs:
         run: deno task validate:dependencies
 
       - name: Run cross-module type compatibility tests
-        run: deno test --allow-all tests/integration/cross-module/ --no-check
+        run: cd tests && deno test --allow-all integration/cross-module/ --no-check
         env:
           DENO_ENV: test
           SKIP_REDIS_CONNECTION: "true"


### PR DESCRIPTION
The `deno.json` exclude list blocks test discovery from project root. Restores `cd tests &&` prefix that was accidentally dropped in #1111.

1-line fix: `deno test --allow-all tests/integration/cross-module/` → `cd tests && deno test --allow-all integration/cross-module/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)