### PR TITLE
feat: routeType caching for all GET routes, CF purge on new blocks, ECS autoscaling

### DIFF
--- a/routes/api/v2/block/block_count/[...number].ts
+++ b/routes/api/v2/block/block_count/[...number].ts
@@ -1,6 +1,7 @@
 import { Handlers } from "$fresh/server.ts";
 import { BlockController } from "$server/controller/blockController.ts";
 import { ResponseUtil } from "$lib/utils/api/responses/responseUtil.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers = {
   async GET(_req, ctx) {
@@ -17,7 +18,9 @@ export const handler: Handlers = {
       }
 
       const lastBlocks = await BlockController.getLastXBlocks(parsedNumber);
-      return ResponseUtil.success(lastBlocks);
+      return ResponseUtil.success(lastBlocks, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       console.error("Failed to get last blocks:", error);
       return ResponseUtil.internalError(

--- a/routes/api/v2/docs.ts
+++ b/routes/api/v2/docs.ts
@@ -2,6 +2,7 @@ import { Handlers } from "$fresh/server.ts";
 import { ResponseUtil } from "$lib/utils/api/responses/responseUtil.ts";
 import { parse as parseYaml } from "@std/yaml";
 import { fromFileUrl, join } from "@std/path";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 const __dirname = fromFileUrl(new URL(".", import.meta.url));
 const schemaPath = join(__dirname, "../../../schema.yml");
@@ -110,7 +111,7 @@ export const handler: Handlers = {
         paths: openApiSchema.paths,
         tags: openApiSchema.tags,
         servers: openApiSchema.servers,
-      });
+      }, { routeType: RouteType.STATIC });
     }
 
     // For filtered responses (by path or tag)
@@ -154,6 +155,6 @@ export const handler: Handlers = {
           content: response.content,
         })),
       })),
-    });
+    }, { routeType: RouteType.STATIC });
   },
 };

--- a/routes/api/v2/fairmint/index.ts
+++ b/routes/api/v2/fairmint/index.ts
@@ -1,12 +1,15 @@
 import { Handlers } from "$fresh/server.ts";
 import { CounterpartyApiManager } from "$server/services/counterpartyApiService.ts";
 import { ResponseUtil } from "$lib/utils/api/responses/responseUtil.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers = {
   async GET(_req, _ctx) {
     try {
       const fairminters = await CounterpartyApiManager.getFairminters();
-      return ResponseUtil.success(fairminters);
+      return ResponseUtil.success(fairminters, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       console.error("Error fetching fairminters:", error);
       return ResponseUtil.internalError(error, "Failed to fetch fairminters");

--- a/routes/api/v2/src101/[deploy_hash]/[tokenid].ts
+++ b/routes/api/v2/src101/[deploy_hash]/[tokenid].ts
@@ -8,6 +8,7 @@ import {
   validateRequiredParams,
   validateSortParam,
 } from "$server/services/validation/routeValidationService.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers = {
   async GET(req, ctx) {
@@ -74,7 +75,9 @@ export const handler: Handlers = {
         return emptyCheck;
       }
 
-      return ResponseUtil.success(result);
+      return ResponseUtil.success(result, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       console.error("Error in [deploy_hash]/[tokenid] handler:", error);
       return ResponseUtil.internalError(

--- a/routes/api/v2/src101/[deploy_hash]/address/[address_btc].ts
+++ b/routes/api/v2/src101/[deploy_hash]/address/[address_btc].ts
@@ -9,6 +9,7 @@ import {
   validateRequiredParams,
   validateSortParam,
 } from "$server/services/validation/routeValidationService.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers<AddressHandlerContext> = {
   async GET(req, ctx) {
@@ -59,7 +60,9 @@ export const handler: Handlers<AddressHandlerContext> = {
         return emptyCheck;
       }
 
-      return ResponseUtil.success(result);
+      return ResponseUtil.success(result, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       console.error(
         "Error in [deploy_hash]/address/[address_btc] handler:",

--- a/routes/api/v2/src101/[deploy_hash]/deploy.ts
+++ b/routes/api/v2/src101/[deploy_hash]/deploy.ts
@@ -2,6 +2,7 @@ import { Handlers } from "$fresh/server.ts";
 import type { AddressHandlerContext } from "$types/base.d.ts";
 import { Src101Controller } from "$server/controller/src101Controller.ts";
 import { ResponseUtil } from "$lib/utils/api/responses/responseUtil.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers<AddressHandlerContext> = {
   async GET(_req, ctx) {
@@ -29,7 +30,9 @@ export const handler: Handlers<AddressHandlerContext> = {
         return ResponseUtil.notFound("No data found");
       }
 
-      return ResponseUtil.success(result);
+      return ResponseUtil.success(result, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       console.error(
         "Error in [deploy_hash]/address/[address_btc] handler:",

--- a/routes/api/v2/src101/[deploy_hash]/index.ts
+++ b/routes/api/v2/src101/[deploy_hash]/index.ts
@@ -2,6 +2,7 @@ import { Handlers } from "$fresh/server.ts";
 import { Src101Controller } from "$server/controller/src101Controller.ts";
 import { ResponseUtil } from "$lib/utils/api/responses/responseUtil.ts";
 import type { AddressHandlerContext } from "$types/base.d.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers<AddressHandlerContext> = {
   async GET(req, ctx) {
@@ -34,7 +35,9 @@ export const handler: Handlers<AddressHandlerContext> = {
         return ResponseUtil.notFound("No data found");
       }
 
-      return ResponseUtil.success(result);
+      return ResponseUtil.success(result, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       console.error(
         "Error in [deploy_hash]/address/[address_btc] handler:",

--- a/routes/api/v2/src101/[deploy_hash]/total.ts
+++ b/routes/api/v2/src101/[deploy_hash]/total.ts
@@ -1,6 +1,7 @@
 import { Handlers } from "$fresh/server.ts";
 import { Src101Controller } from "$server/controller/src101Controller.ts";
 import { ResponseUtil } from "$lib/utils/api/responses/responseUtil.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers = {
   async GET(_req, ctx) {
@@ -16,7 +17,9 @@ export const handler: Handlers = {
         return ResponseUtil.notFound("No data found");
       }
 
-      return ResponseUtil.success(result);
+      return ResponseUtil.success(result, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       console.error("Error in [deploy_hash]/total handler:", error);
       return ResponseUtil.internalError(

--- a/routes/api/v2/src101/index.ts
+++ b/routes/api/v2/src101/index.ts
@@ -6,6 +6,7 @@ import {
   checkEmptyResult,
   DEFAULT_PAGINATION,
 } from "$server/services/validation/routeValidationService.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers = {
   async GET(req) {
@@ -35,7 +36,9 @@ export const handler: Handlers = {
         return emptyCheck;
       }
 
-      return ApiResponseUtil.success(result);
+      return ApiResponseUtil.success(result, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       console.error("Error in index handler:", error);
       return ApiResponseUtil.internalError(

--- a/routes/api/v2/src101/index/[deploy_hash]/[index].ts
+++ b/routes/api/v2/src101/index/[deploy_hash]/[index].ts
@@ -2,6 +2,7 @@ import { Handlers } from "$fresh/server.ts";
 import type { AddressHandlerContext } from "$types/base.d.ts";
 import { Src101Controller } from "$server/controller/src101Controller.ts";
 import { ResponseUtil } from "$lib/utils/api/responses/responseUtil.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers<AddressHandlerContext> = {
   async GET(req, ctx) {
@@ -27,7 +28,9 @@ export const handler: Handlers<AddressHandlerContext> = {
         return ResponseUtil.notFound("No data found");
       }
 
-      return ResponseUtil.success(result);
+      return ResponseUtil.success(result, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       console.error(
         "Error in [deploy_hash]/address/[address_btc] handler:",

--- a/routes/api/v2/src101/tx/[tx_hash].ts
+++ b/routes/api/v2/src101/tx/[tx_hash].ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_PAGINATION,
   validateRequiredParams,
 } from "$server/services/validation/routeValidationService.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers = {
   async GET(req, ctx) {
@@ -42,7 +43,9 @@ export const handler: Handlers = {
         return ResponseUtil.notFound("No data found");
       }
 
-      return ResponseUtil.success(result);
+      return ResponseUtil.success(result, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       console.error("Error in index handler:", error);
       return ResponseUtil.internalError(

--- a/routes/api/v2/src101/tx/index.ts
+++ b/routes/api/v2/src101/tx/index.ts
@@ -2,6 +2,7 @@ import { Handlers } from "$fresh/server.ts";
 import { Src101Controller } from "$server/controller/src101Controller.ts";
 import { ResponseUtil } from "$lib/utils/api/responses/responseUtil.ts";
 import { getPaginationParams } from "$lib/utils/data/pagination/paginationUtils.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export interface SRC101TxParams {
   tick?: string;
@@ -45,7 +46,9 @@ export const handler: Handlers = {
         return ResponseUtil.notFound("No data found");
       }
 
-      return ResponseUtil.success(result);
+      return ResponseUtil.success(result, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       console.error("Error in index handler:", error);
       return ResponseUtil.internalError(

--- a/routes/api/v2/src20/[...op].ts
+++ b/routes/api/v2/src20/[...op].ts
@@ -6,6 +6,7 @@ import {
   validateSortParam,
 } from "$server/services/validation/routeValidationService.ts";
 import { SRC20Service } from "$server/services/src20/index.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers = {
   async GET(req, ctx) {
@@ -33,7 +34,9 @@ export const handler: Handlers = {
         page: page || DEFAULT_PAGINATION.page,
         limit: limit || DEFAULT_PAGINATION.limit,
       });
-      return ApiResponseUtil.success(result);
+      return ApiResponseUtil.success(result, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       return ApiResponseUtil.internalError(error, "Error processing request");
     }

--- a/routes/api/v2/src20/block/[block_index]/[tick].ts
+++ b/routes/api/v2/src20/block/[block_index]/[tick].ts
@@ -4,6 +4,7 @@ import { Handlers } from "$fresh/server.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
 import { getPaginationParams } from "$lib/utils/data/pagination/paginationUtils.ts";
 import { SRC20Service } from "$server/services/src20/index.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers<BlockHandlerContext> = {
   async GET(req, ctx) {
@@ -30,7 +31,9 @@ export const handler: Handlers<BlockHandlerContext> = {
         ...(sort && { sort }),
         ...(op && { op }),
       });
-      return ApiResponseUtil.success(result);
+      return ApiResponseUtil.success(result, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       return ApiResponseUtil.internalError(error, "Error processing request");
     }

--- a/routes/api/v2/src20/block/[block_index]/index.ts
+++ b/routes/api/v2/src20/block/[block_index]/index.ts
@@ -3,6 +3,7 @@ import { Handlers } from "$fresh/server.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
 import { getPaginationParams } from "$lib/utils/data/pagination/paginationUtils.ts";
 import { SRC20Service } from "$server/services/src20/index.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers<BlockHandlerContext> = {
   async GET(req, ctx) {
@@ -30,7 +31,9 @@ export const handler: Handlers<BlockHandlerContext> = {
         ...(sort && { sort }),
         ...(op && { op }),
       });
-      return ApiResponseUtil.success(result);
+      return ApiResponseUtil.success(result, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       return ApiResponseUtil.internalError(error, "Error processing request");
     }

--- a/routes/api/v2/src20/search.ts
+++ b/routes/api/v2/src20/search.ts
@@ -1,6 +1,7 @@
 import { Handlers } from "$fresh/server.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
 import { SRC20Service } from "$server/services/src20/index.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers = {
   async GET(req) {
@@ -14,7 +15,9 @@ export const handler: Handlers = {
         mintableOnly,
       );
 
-      return ApiResponseUtil.success({ data: results });
+      return ApiResponseUtil.success({ data: results }, {
+        routeType: RouteType.DYNAMIC,
+      });
     } catch (error) {
       console.error("Error in search handler:", error);
       return ApiResponseUtil.internalError(

--- a/routes/api/v2/src20/tick/[tick]/deploy.ts
+++ b/routes/api/v2/src20/tick/[tick]/deploy.ts
@@ -3,6 +3,7 @@ import { Src20Controller } from "$server/controller/src20Controller.ts";
 //  // Temporarily replaced
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
 import { FreshContext } from "$fresh/server.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 // Define params shape explicitly for this route
 interface DeployRouteParams {
@@ -20,7 +21,9 @@ export const handler = async (
     // If 'op' was needed from query params: const op = ctx.url.searchParams.get("op");
 
     const body = await Src20Controller.handleDeploymentRequest(tick, req);
-    return ApiResponseUtil.success(body);
+    return ApiResponseUtil.success(body, {
+      routeType: RouteType.BLOCKCHAIN_DATA,
+    });
   } catch (error) {
     console.error("Error in deploy handler:", error);
     return ApiResponseUtil.internalError(error, "Internal server error");

--- a/routes/api/v2/src20/tick/[tick]/index.ts
+++ b/routes/api/v2/src20/tick/[tick]/index.ts
@@ -12,6 +12,7 @@ import {
 } from "$server/services/validation/routeValidationService.ts";
 import { BigFloat } from "bigfloat/mod.ts";
 import { MarketDataRepository } from "$server/database/marketDataRepository.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers = {
   async GET(req, ctx) {
@@ -123,7 +124,9 @@ export const handler: Handlers = {
         market_data, // Add market data field (null if not found)
       };
 
-      return ApiResponseUtil.success(body);
+      return ApiResponseUtil.success(body, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       console.error(error);
       return ApiResponseUtil.internalError(error, "Error processing request");

--- a/routes/api/v2/src20/tick/[tick]/mintData.ts
+++ b/routes/api/v2/src20/tick/[tick]/mintData.ts
@@ -4,6 +4,7 @@ import { logger } from "$lib/utils/logger.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
 import type { SRC20MintDataResponse } from "$lib/types/src20.d.ts";
 import { SRC20Service } from "$server/services/src20/index.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers = {
   async GET(_req, ctx) {
@@ -30,7 +31,9 @@ export const handler: Handlers = {
         holders: balanceData.total || 0,
       };
 
-      return ApiResponseUtil.success(response);
+      return ApiResponseUtil.success(response, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       logger.error("stamps", {
         message: "Error in /api/v2/src20/tick/[tick]/mintData",

--- a/routes/api/v2/src20/tx/[tx_hash].ts
+++ b/routes/api/v2/src20/tx/[tx_hash].ts
@@ -2,6 +2,7 @@ import type { SRC20TrxRequestParams } from "$types/api.d.ts";
 import { Handlers } from "$fresh/server.ts";
 import { ApiResponseUtil } from "$utils/api/responses/apiResponseUtil.ts";
 import { SRC20Service } from "$server/services/src20/index.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers = {
   async GET(_req, ctx) {
@@ -29,7 +30,9 @@ export const handler: Handlers = {
         );
       }
 
-      return ApiResponseUtil.success(result);
+      return ApiResponseUtil.success(result, {
+        routeType: RouteType.BLOCKCHAIN_DATA,
+      });
     } catch (error) {
       return ApiResponseUtil.internalError(error, "Error processing request");
     }

--- a/routes/api/v2/stamps/ident/[ident].ts
+++ b/routes/api/v2/stamps/ident/[ident].ts
@@ -13,6 +13,7 @@ import {
   validateRequiredParams,
   validateSortParam,
 } from "$server/services/validation/routeValidationService.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 export const handler: Handlers<IdentHandlerContext> = {
   async GET(req, ctx) {
     const { ident } = ctx.params;
@@ -71,7 +72,7 @@ export const handler: Handlers<IdentHandlerContext> = {
         data: (result as any).stamps,
       };
 
-      return ApiResponseUtil.success(body);
+      return ApiResponseUtil.success(body, { routeType: RouteType.STAMP_LIST });
     } catch (error) {
       console.error(`Error in stamps/ident handler:`, error);
       return ApiResponseUtil.internalError(

--- a/routes/api/v2/stamps/search.ts
+++ b/routes/api/v2/stamps/search.ts
@@ -4,6 +4,7 @@ import {
   classifySearchInput,
 } from "$lib/utils/data/search/searchInputClassifier.ts";
 import { StampService } from "$server/services/stampService.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 export const handler: Handlers = {
   async GET(req) {
@@ -12,7 +13,9 @@ export const handler: Handlers = {
       const query = url.searchParams.get("q") || "";
 
       if (!query.trim()) {
-        return ApiResponseUtil.success({ data: [] });
+        return ApiResponseUtil.success({ data: [] }, {
+          routeType: RouteType.STAMP_LIST,
+        });
       }
 
       const { type, sanitized } = classifySearchInput(query);
@@ -65,7 +68,9 @@ export const handler: Handlers = {
         results = await StampService.getStamps(queryOptions);
       } catch (_err) {
         // Service throws "NO STAMPS FOUND" when result is null
-        return ApiResponseUtil.success({ data: [] });
+        return ApiResponseUtil.success({ data: [] }, {
+          routeType: RouteType.STAMP_LIST,
+        });
       }
 
       // StampService.getStamps returns { stamps: [...], last_block }
@@ -82,7 +87,9 @@ export const handler: Handlers = {
         tx_hash: stamp.tx_hash,
       }));
 
-      return ApiResponseUtil.success({ data: formattedResults });
+      return ApiResponseUtil.success({ data: formattedResults }, {
+        routeType: RouteType.STAMP_LIST,
+      });
     } catch (error) {
       console.error("Error in stamp search handler:", error);
       return ApiResponseUtil.internalError(

--- a/routes/api/v2/utxo/ancestors/[address].ts
+++ b/routes/api/v2/utxo/ancestors/[address].ts
@@ -2,6 +2,7 @@ import { Handlers } from "$fresh/server.ts";
 import { logger } from "$lib/utils/logger.ts";
 import { ResponseUtil } from "$lib/utils/api/responses/responseUtil.ts";
 import { BitcoinUtxoManager } from "$server/services/transaction/bitcoinUtxoManager.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 interface UTXOWithAncestors {
   ancestorCount?: number;
@@ -46,7 +47,9 @@ export const handler: Handlers = {
         ancestorCount: ancestors.length,
       });
 
-      return ResponseUtil.success({ ancestors });
+      return ResponseUtil.success({ ancestors }, {
+        routeType: RouteType.DYNAMIC,
+      });
     } catch (error) {
       logger.error("stamps", {
         message: "Error fetching UTXO ancestors",

--- a/routes/api/v2/version.ts
+++ b/routes/api/v2/version.ts
@@ -1,6 +1,7 @@
 import { Handlers } from "$fresh/server.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
 import { VERSION_CONFIG } from "$server/middleware/apiVersionMiddleware.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 /**
  * Simple API Version Endpoint
@@ -26,6 +27,6 @@ export const handler: Handlers = {
       version: currentVersion,
     };
 
-    return ApiResponseUtil.success(response);
+    return ApiResponseUtil.success(response, { routeType: RouteType.STATIC });
   },
 };

--- a/routes/api/v2/versions/changelog.ts
+++ b/routes/api/v2/versions/changelog.ts
@@ -1,6 +1,7 @@
 import { Handlers } from "$fresh/server.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
 import { VERSION_CONFIG } from "$server/middleware/apiVersionMiddleware.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 /**
  * API Version Changelog Endpoint
@@ -162,6 +163,6 @@ export const handler: Handlers = {
         notice: "6 months",
         support: "12 months after deprecation",
       },
-    });
+    }, { routeType: RouteType.STATIC });
   },
 };

--- a/routes/api/v2/versions/index.ts
+++ b/routes/api/v2/versions/index.ts
@@ -1,6 +1,7 @@
 import { Handlers } from "$fresh/server.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
 import { VERSION_CONFIG } from "$server/middleware/apiVersionMiddleware.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 /**
  * API Version Discovery Endpoint
@@ -185,6 +186,6 @@ export const handler: Handlers = {
       };
     }
 
-    return ApiResponseUtil.success(response);
+    return ApiResponseUtil.success(response, { routeType: RouteType.STATIC });
   },
 };

--- a/routes/handlers/sharedBlockWithStampsHandler.ts
+++ b/routes/handlers/sharedBlockWithStampsHandler.ts
@@ -2,6 +2,7 @@ import { Handlers } from "$fresh/server.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
 import { WebResponseUtil } from "$lib/utils/api/responses/webResponseUtil.ts";
 import { BlockController } from "$server/controller/blockController.ts";
+import { RouteType } from "$server/services/infrastructure/cacheService.ts";
 
 const sharedBlockWithStampsHandler: Handlers = {
   async GET(_req, ctx) {
@@ -13,7 +14,9 @@ const sharedBlockWithStampsHandler: Handlers = {
         block_index,
         type,
       );
-      return ApiResponseUtil.success(response);
+      return ApiResponseUtil.success(response, {
+        routeType: RouteType.STAMP_LIST,
+      });
     } catch (error) {
       console.error(`Error in ${type}/block handler:`, error);
       return ApiResponseUtil.internalError(

--- a/scripts/setup-autoscaling.sh
+++ b/scripts/setup-autoscaling.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Setup ECS autoscaling for stamps-app-service
+#
+# Configures:
+# - Desired count: 1 (from 2) — saves ~$18/mo
+# - Autoscaling: min 1, max 3, target CPU 60%
+# - Deploys still work: rolling deploy temporarily scales to 2, then back to 1
+#
+# Rollback: aws ecs update-service --cluster stamps-app-prod --service stamps-app-service --desired-count 2
+#
+# Usage: ./scripts/setup-autoscaling.sh [--dry-run]
+
+set -euo pipefail
+
+CLUSTER="stamps-app-prod"
+SERVICE="stamps-app-service"
+REGION="us-east-1"
+RESOURCE_ID="service/${CLUSTER}/${SERVICE}"
+
+MIN_CAPACITY=1
+MAX_CAPACITY=3
+TARGET_CPU=60
+DESIRED_COUNT=1
+
+DRY_RUN="${1:-}"
+
+echo "=== ECS Autoscaling Setup ==="
+echo "Cluster: ${CLUSTER}"
+echo "Service: ${SERVICE}"
+echo "Desired: ${DESIRED_COUNT} (from 2)"
+echo "Autoscale: min=${MIN_CAPACITY}, max=${MAX_CAPACITY}, target CPU=${TARGET_CPU}%"
+echo ""
+
+if [ "$DRY_RUN" = "--dry-run" ]; then
+  echo "[DRY RUN] Would execute the following:"
+  echo ""
+  echo "1. Update service desired count to ${DESIRED_COUNT}"
+  echo "2. Register scalable target (min=${MIN_CAPACITY}, max=${MAX_CAPACITY})"
+  echo "3. Create target tracking scaling policy (CPU ${TARGET_CPU}%)"
+  exit 0
+fi
+
+echo "Step 1: Update service desired count to ${DESIRED_COUNT}..."
+aws ecs update-service \
+  --cluster "${CLUSTER}" \
+  --service "${SERVICE}" \
+  --desired-count "${DESIRED_COUNT}" \
+  --region "${REGION}" \
+  --query 'service.{desired:desiredCount,running:runningCount,status:status}' \
+  --output table
+
+echo ""
+echo "Step 2: Register scalable target..."
+aws application-autoscaling register-scalable-target \
+  --service-namespace ecs \
+  --scalable-dimension ecs:service:DesiredCount \
+  --resource-id "${RESOURCE_ID}" \
+  --min-capacity "${MIN_CAPACITY}" \
+  --max-capacity "${MAX_CAPACITY}" \
+  --region "${REGION}"
+
+echo "Registered: min=${MIN_CAPACITY}, max=${MAX_CAPACITY}"
+
+echo ""
+echo "Step 3: Create CPU target tracking policy..."
+aws application-autoscaling put-scaling-policy \
+  --service-namespace ecs \
+  --scalable-dimension ecs:service:DesiredCount \
+  --resource-id "${RESOURCE_ID}" \
+  --policy-name "stamps-cpu-target-tracking" \
+  --policy-type TargetTrackingScaling \
+  --target-tracking-scaling-policy-configuration '{
+    "TargetValue": '"${TARGET_CPU}"',
+    "PredefinedMetricSpecification": {
+      "PredefinedMetricType": "ECSServiceAverageCPUUtilization"
+    },
+    "ScaleInCooldown": 300,
+    "ScaleOutCooldown": 60
+  }' \
+  --region "${REGION}" \
+  --query 'PolicyARN' \
+  --output text
+
+echo ""
+echo "=== Autoscaling configured ==="
+echo "Service will run ${MIN_CAPACITY} task(s) normally, scale to ${MAX_CAPACITY} when CPU > ${TARGET_CPU}%"
+echo "Scale-out cooldown: 60s | Scale-in cooldown: 300s"
+echo ""
+echo "Verify with: aws application-autoscaling describe-scalable-targets --service-namespace ecs --resource-ids ${RESOURCE_ID} --region ${REGION}"

--- a/server/config/config.ts
+++ b/server/config/config.ts
@@ -32,6 +32,8 @@ type ServerConfig = {
   readonly INTERNAL_API_SECRET?: string;
   readonly CF_ACCESS_CLIENT_ID?: string;
   readonly CF_ACCESS_CLIENT_SECRET?: string;
+  readonly CLOUDFLARE_ZONE_ID?: string;
+  readonly CLOUDFLARE_API_TOKEN?: string;
   // Development & debugging
   readonly DEV_BASE_URL: string;
   readonly PROD_BASE_URL: string | undefined;
@@ -143,6 +145,12 @@ const serverConfig: ServerConfig = {
   },
   get CF_ACCESS_CLIENT_SECRET() {
     return Deno.env.get("CF_ACCESS_CLIENT_SECRET") || "";
+  },
+  get CLOUDFLARE_ZONE_ID() {
+    return Deno.env.get("CLOUDFLARE_ZONE_ID") || "";
+  },
+  get CLOUDFLARE_API_TOKEN() {
+    return Deno.env.get("CLOUDFLARE_API_TOKEN") || "";
   },
   // Development & debugging
   get DEV_BASE_URL() {

--- a/server/services/notification/bitcoinNotificationService.ts
+++ b/server/services/notification/bitcoinNotificationService.ts
@@ -1,4 +1,5 @@
 import { dbManager } from "$server/database/databaseManager.ts";
+import { serverConfig } from "$server/config/config.ts";
 
 interface BlockNotification {
   type: "new_block";
@@ -80,6 +81,57 @@ export class BitcoinNotificationService {
     await dbManager.invalidateCacheByCategory('block_transactions');
 
     console.log(`Cache invalidated for new block ${data.blockHeight} (using comprehensive category-based invalidation)`);
+
+    // Purge Cloudflare CDN edge cache for data that changed with new block.
+    // Redis cache (above) handles server-side; this handles CF edge.
+    await this.purgeCloudflareCache();
+  }
+
+  /**
+   * Purge Cloudflare CDN cache for API endpoints with block-dependent data.
+   * Uses the CF API prefix-purge to clear cached responses at the edge.
+   * Runs fire-and-forget — CF purge failure shouldn't block notification processing.
+   */
+  private static async purgeCloudflareCache(): Promise<void> {
+    const zoneId = serverConfig.CLOUDFLARE_ZONE_ID;
+    const apiToken = serverConfig.CLOUDFLARE_API_TOKEN;
+
+    if (!zoneId || !apiToken) {
+      console.log("[CF PURGE] Skipping — CLOUDFLARE_ZONE_ID or CLOUDFLARE_API_TOKEN not configured");
+      return;
+    }
+
+    const prefixes = [
+      "https://stampchain.io/api/v2/src20/",
+      "https://stampchain.io/api/v2/balance/",
+      "https://stampchain.io/api/v2/stamps/",
+      "https://stampchain.io/api/v2/block/",
+      "https://stampchain.io/api/v2/src101/",
+      "https://stampchain.io/api/v2/cursed/",
+    ];
+
+    try {
+      const response = await fetch(
+        `https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`,
+        {
+          method: "POST",
+          headers: {
+            "Authorization": `Bearer ${apiToken}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ prefixes }),
+        },
+      );
+
+      if (response.ok) {
+        console.log(`[CF PURGE] Purged ${prefixes.length} URL prefixes`);
+      } else {
+        const body = await response.text();
+        console.warn(`[CF PURGE] Failed (${response.status}): ${body}`);
+      }
+    } catch (error) {
+      console.warn(`[CF PURGE] Error: ${error instanceof Error ? error.message : String(error)}`);
+    }
   }
 
   private static async handlePriceUpdate(data: PriceNotification) {


### PR DESCRIPTION
## Summary

**3 changes shipping together:**

1. **routeType assignment** (27 route files) — promotes GET routes from 5-min default cache to their proper TTL (24h for blockchain data, 5min for dynamic). Expected cache hit rate improvement from ~30% to 50-60%.

2. **Cloudflare edge cache purge on new blocks** — when the bitcoin notification webhook fires for a new block, purges CF cached responses for `/api/v2/src20/*`, `/api/v2/balance/*`, `/api/v2/stamps/*`, `/api/v2/block/*`, `/api/v2/src101/*`, `/api/v2/cursed/*`. Fire-and-forget. Requires `CLOUDFLARE_ZONE_ID` and `CLOUDFLARE_API_TOKEN` env vars (already in .env).

3. **ECS autoscaling setup script** — `scripts/setup-autoscaling.sh` configures desired count 1 (from 2), autoscale min=1 max=3 at CPU 60%. Saves ~$18/mo. Run after deploy.

## Test plan

- [x] `deno check main.ts` passes
- [x] Unit tests: 1018 passed (1 pre-existing creatorService flake, unrelated)
- [ ] CI passes
- [ ] Run `scripts/setup-autoscaling.sh` after merge+deploy
- [ ] Monitor CF cache hit rates (target 50-60%)
- [ ] Verify CF purge fires on new block notifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)