### PR TITLE
fix(health): add DB connectivity check to simple health endpoint

### DIFF
--- a/routes/api/v2/health.ts
+++ b/routes/api/v2/health.ts
@@ -15,10 +15,30 @@ export const handler: Handlers = {
    * Returns 200 without checking any services
    */
   async GET(_req, ctx) {
-    // Extract path to check if this is a simple health check
+    // Simple health check for ALB — verifies API + DB connectivity
+    // without the expensive full health scan (XCP, mempool, node versions).
+    // Returns 503 if DB is unreachable so ALB stops routing to this task.
     const url = new URL(ctx.url);
     if (url.searchParams.has("simple")) {
-      return ApiResponseUtil.success({ status: "OK" }, { forceNoCache: true });
+      try {
+        const dbCheck = await SRC20Repository.checkSrc20Deployments();
+        if (dbCheck.isValid) {
+          return ApiResponseUtil.success({ status: "OK", database: true }, {
+            forceNoCache: true,
+          });
+        }
+        return ApiResponseUtil.serviceUnavailable(
+          "Database connection failed",
+          undefined,
+          { forceNoCache: true },
+        );
+      } catch {
+        return ApiResponseUtil.serviceUnavailable(
+          "Database connection failed",
+          undefined,
+          { forceNoCache: true },
+        );
+      }
     }
 
     // Continue with full health check if not simple


### PR DESCRIPTION
The ALB health check hits `/api/v2/health?simple` which returned 200 without checking any services. Tasks with broken DB connections passed health checks and received traffic, causing 500s.

Now runs a lightweight DB query and returns 503 if unreachable. ALB stops routing after 3 failures (90s).

## Test plan
- [x] `deno check main.ts` passes
- [x] Unit tests: 1019 passed (1 pre-existing recentSales perf test failure, unrelated)
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)