### PR TITLE
fix(health): add DB connectivity check to ALB health endpoint

### DIFF
--- a/.github/workflows/daily-regression-tests.yml
+++ b/.github/workflows/daily-regression-tests.yml
@@ -274,7 +274,7 @@ jobs:
 
       - name: Create GitHub issue for critical regressions
         if: steps.check-regressions.outputs.status == 'critical' && env.SEND_NOTIFICATIONS == 'true'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -365,7 +365,7 @@ jobs:
 
       - name: Upload comprehensive reports
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: daily-regression-reports-${{ env.TIMESTAMP || 'unknown' }}
           path: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,7 +142,7 @@ jobs:
       # Create a summary comment for PR
       - name: Create PR Comment with Quality Results
         if: github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -20,10 +20,10 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           load: true

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -169,7 +169,7 @@ jobs:
           deno coverage coverage/ --lcov > coverage-integration.lcov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: stampchain-io/stampchain.io

--- a/.github/workflows/lighthouse-ci.yml
+++ b/.github/workflows/lighthouse-ci.yml
@@ -188,7 +188,7 @@ jobs:
 
       - name: Upload Lighthouse reports
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: lighthouse-reports
           path: .lighthouseci/

--- a/.github/workflows/newman-comprehensive-tests.yml
+++ b/.github/workflows/newman-comprehensive-tests.yml
@@ -224,7 +224,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: newman-comprehensive-reports-${{ github.run_number }}
           path: reports/newman-comprehensive/
@@ -232,7 +232,7 @@ jobs:
 
       - name: Create PR comment with results
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -345,7 +345,7 @@ jobs:
 
       - name: Create regression issue (scheduled runs only)
         if: github.event_name == 'schedule' && steps.newman-test.outcome == 'failure'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -501,7 +501,7 @@ jobs:
 
       - name: Upload pagination test reports
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: pagination-validation-reports-${{ github.run_number }}
           path: reports/newman-pagination-validation/
@@ -544,7 +544,7 @@ jobs:
 
       - name: Store performance results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: performance-benchmark-${{ github.run_number }}
           path: reports/newman-comprehensive/
@@ -903,7 +903,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: newman-local-dev-reports-${{ github.run_number }}
           path: reports/newman-local-dev/
@@ -911,7 +911,7 @@ jobs:
 
       - name: Upload dev server logs
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: dev-server-logs-${{ github.run_number }}
           path: dev-server.log
@@ -919,7 +919,7 @@ jobs:
 
       - name: Create PR comment with results
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -1086,7 +1086,7 @@ jobs:
 
       - name: Upload test results artifact
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: schema-contract-test-results-${{ github.run_number }}
           path: reports/newman/
@@ -1094,7 +1094,7 @@ jobs:
 
       - name: Comment on PR with results
         if: always() && github.event_name == 'pull_request'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const total = '${{ steps.parse-results.outputs.total_tests }}';

--- a/.github/workflows/production-validation.yml
+++ b/.github/workflows/production-validation.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload validation report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: production-readiness-report
           path: reports/
@@ -88,7 +88,7 @@ jobs:
           DEPLOYMENT_VERSION: ${{ github.sha }}
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: performance-benchmarks
           path: reports/performance-baselines.json
@@ -97,7 +97,7 @@ jobs:
       - name: Comment PR with performance results
         if: github.event_name == 'pull_request'
         continue-on-error: true
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -168,7 +168,7 @@ jobs:
         run: deno task validate:dependencies:mermaid
 
       - name: Upload integration test results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: cross-module-integration
           path: |
@@ -292,7 +292,7 @@ jobs:
 
       - name: Upload rollback test results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: rollback-test-results
           path: reports/rollback-*.json
@@ -360,7 +360,7 @@ jobs:
           deno-version: ${{ env.DENO_VERSION }}
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           path: artifacts/
 
@@ -376,7 +376,7 @@ jobs:
           deno run --allow-all scripts/deployment/generate-comprehensive-report.ts
 
       - name: Upload comprehensive report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: comprehensive-validation-report
           path: reports/comprehensive/

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload Schema Validation Results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: schema-validation-results
           path: reports/schema-validation-results.json
@@ -127,7 +127,7 @@ jobs:
 
       - name: Comment PR with Schema Validation Results
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload type analysis report
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: type-analysis-report
           path: reports/type-error-analysis.md

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -101,7 +101,7 @@ jobs:
           deno coverage coverage/ --lcov > coverage-unit.lcov
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: stampchain-io/stampchain.io

--- a/.github/workflows/validate-imports.yml
+++ b/.github/workflows/validate-imports.yml
@@ -102,7 +102,7 @@ jobs:
         continue-on-error: false
 
       - name: Upload Validation Results
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: import-validation-results
@@ -135,7 +135,7 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && always()
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');
@@ -313,7 +313,7 @@ jobs:
           fi
 
       - name: Archive Compliance Report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: compliance-monitoring-report
           path: compliance-report.json

--- a/routes/api/v2/health.ts
+++ b/routes/api/v2/health.ts
@@ -15,10 +15,30 @@ export const handler: Handlers = {
    * Returns 200 without checking any services
    */
   async GET(_req, ctx) {
-    // Extract path to check if this is a simple health check
+    // Simple health check for ALB — verifies API + DB connectivity
+    // without the expensive full health scan (XCP, mempool, node versions).
+    // Returns 503 if DB is unreachable so ALB stops routing to this task.
     const url = new URL(ctx.url);
     if (url.searchParams.has("simple")) {
-      return ApiResponseUtil.success({ status: "OK" }, { forceNoCache: true });
+      try {
+        const dbCheck = await SRC20Repository.checkSrc20Deployments();
+        if (dbCheck.isValid) {
+          return ApiResponseUtil.success({ status: "OK", database: true }, {
+            forceNoCache: true,
+          });
+        }
+        return ApiResponseUtil.serviceUnavailable(
+          "Database connection failed",
+          undefined,
+          { forceNoCache: true },
+        );
+      } catch {
+        return ApiResponseUtil.serviceUnavailable(
+          "Database connection failed",
+          undefined,
+          { forceNoCache: true },
+        );
+      }
     }
 
     // Continue with full health check if not simple


### PR DESCRIPTION
The ALB health check (/api/v2/health?simple) returned 200 without checking DB connectivity. Tasks with broken MySQL connections passed health checks and received traffic, causing 500s.

Now runs a lightweight DB query and returns 503 if unreachable. ALB stops routing after 3 consecutive failures (90s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)