### PR TITLE
fix(ci): allow fork PR comment failures without breaking the job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -142,6 +142,10 @@ jobs:
       # Create a summary comment for PR
       - name: Create PR Comment with Quality Results
         if: github.event_name == 'pull_request'
+        # Fork PRs receive a read-only GITHUB_TOKEN; commenting fails with
+        # HttpError 403 "Resource not accessible by integration". Don't fail
+        # the whole job on that — the quality checks above are what matter.
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/newman-comprehensive-tests.yml
+++ b/.github/workflows/newman-comprehensive-tests.yml
@@ -232,6 +232,10 @@ jobs:
 
       - name: Create PR comment with results
         if: github.event_name == 'pull_request' && always()
+        # Fork PRs receive a read-only GITHUB_TOKEN; commenting fails with
+        # HttpError 403 "Resource not accessible by integration". Don't fail
+        # the whole job on that — the Newman tests above are what matter.
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -919,6 +923,10 @@ jobs:
 
       - name: Create PR comment with results
         if: github.event_name == 'pull_request' && always()
+        # Fork PRs receive a read-only GITHUB_TOKEN; commenting fails with
+        # HttpError 403 "Resource not accessible by integration". Don't fail
+        # the whole job on that — the Newman tests above are what matter.
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -1094,6 +1102,10 @@ jobs:
 
       - name: Comment on PR with results
         if: always() && github.event_name == 'pull_request'
+        # Fork PRs receive a read-only GITHUB_TOKEN; commenting fails with
+        # HttpError 403 "Resource not accessible by integration". Don't fail
+        # the whole job on that — the Newman tests above are what matter.
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/schema-validation.yml
+++ b/.github/workflows/schema-validation.yml
@@ -127,6 +127,10 @@ jobs:
 
       - name: Comment PR with Schema Validation Results
         if: github.event_name == 'pull_request' && always()
+        # Fork PRs receive a read-only GITHUB_TOKEN; commenting fails with
+        # HttpError 403 "Resource not accessible by integration". Don't fail
+        # the whole job on that — the validation tests above are what matter.
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
           script: |

--- a/.github/workflows/validate-imports.yml
+++ b/.github/workflows/validate-imports.yml
@@ -135,6 +135,10 @@ jobs:
 
       - name: Comment on PR
         if: github.event_name == 'pull_request' && always()
+        # Fork PRs receive a read-only GITHUB_TOKEN; commenting fails with
+        # HttpError 403 "Resource not accessible by integration". Don't fail
+        # the whole job on that — the validation tests above are what matter.
+        continue-on-error: true
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
## Summary

PR #1125 (a fork PR from h1615766-star) showed 5 "failing" CI checks that were actually all the same root cause: every step **passed**, but the final "comment on PR" step in each workflow hit a 403 because **fork PRs receive a read-only `GITHUB_TOKEN` by design**. The whole job exit-coded as failing on the comment failure, blocking the merge and forcing an admin override.

This PR adds `continue-on-error: true` to every "comment on PR" step so the same situation in the future doesn't block merge.

## Changes

| File | Step | Line |
|---|---|---|
| `.github/workflows/validate-imports.yml` | Comment on PR | 136 |
| `.github/workflows/schema-validation.yml` | Comment PR with Schema Validation Results | 128 |
| `.github/workflows/deploy.yml` | Create PR Comment with Quality Results | 143 |
| `.github/workflows/newman-comprehensive-tests.yml` | Create PR comment with results (Newman Comprehensive) | 233 |
| `.github/workflows/newman-comprehensive-tests.yml` | Create PR comment with results (Newman Local Dev) | 920 |
| `.github/workflows/newman-comprehensive-tests.yml` | Comment on PR with results | 1095 |

Each gains a four-line addition: a brief comment explaining the fork-token rationale and `continue-on-error: true`.

## Behavior change

| PR type | Before | After |
|---|---|---|
| Same-repo PR | Comment posts to PR ✓ | Comment posts to PR ✓ (unchanged) |
| Fork PR | Comment fails with 403 → job fails → merge blocked | Comment fails with 403 → step marked failed → **job stays green** |

## Why `continue-on-error` and not an `if:` guard for fork detection?

`continue-on-error: true` is one line per step. The alternative — `if: github.event.pull_request.head.repo.full_name == github.repository` — would skip the step entirely on fork PRs. Both work; `continue-on-error` is simpler and still lets the failure surface in the logs if a maintainer wants to investigate.

## Test plan

- [ ] After merge, the next fork PR (or a re-run of #1125's checks if you queue one) should show the comment step as "failed" but the job overall as "passed"
- [ ] Same-repo PRs continue to receive auto-comments as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)