### PR TITLE
fix(stamp): pin inputs_set so OP_RETURN ARC4 key matches vin[0]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,6 @@ ssr-safety-report.json
 # tasks.json
 # tasks/
 tests/coverage/
+
+# Local coverage diagnostics (deno test --coverage)
+coverage_diag/

--- a/lib/utils/bitcoin/minting/counterpartyInputs.ts
+++ b/lib/utils/bitcoin/minting/counterpartyInputs.ts
@@ -1,0 +1,112 @@
+// Pure helpers for aligning a Bitcoin Stamp issuance's funding inputs with the
+// Counterparty composer, so the ARC4-encrypted OP_RETURN stays decodable by the
+// Counterparty indexer.
+//
+// Background: the Counterparty indexer derives the ARC4 OP_RETURN key ONLY from
+// vin[0].previous_output.txid and drops any transaction whose decrypted
+// OP_RETURN does not start with the "CNTRPRTY" prefix. When stampchain pins the
+// exact UTXO set via the compose API's `inputs_set`, the Counterparty composer
+// sorts that set by raw value descending (stable, no secondary key) and keys
+// ARC4 off the first entry. To keep our broadcast vin[0] equal to that key we
+// MUST order our inputs the same way and send `inputs_set` in that exact order.
+//
+// These functions are intentionally pure (no I/O) so the ordering, serialization
+// and ARC4 round-trip can be unit-tested in isolation.
+
+import * as bitcoin from "bitcoinjs-lib";
+import { Buffer } from "node:buffer";
+import { arc4 } from "$lib/utils/bitcoin/minting/transactionUtils.ts";
+import { hex2bin } from "$lib/utils/data/binary/baseUtils.ts";
+
+/** Fields needed to order UTXOs the way the Counterparty composer does. */
+export interface OrderableInput {
+  txid: string; // display-order txid hex
+  vout: number;
+  value: number; // satoshis
+}
+
+/** Minimal UTXO shape required to build a Counterparty `inputs_set`. */
+export interface CounterpartyInput extends OrderableInput {
+  script?: string; // scriptPubKey hex (required at serialization time)
+}
+
+export const CNTRPRTY_PREFIX = "CNTRPRTY";
+
+/**
+ * Order UTXOs exactly the way the Counterparty composer does
+ * (composer.py:798 — `sorted(..., key=value, reverse=True)`): raw value
+ * descending. Python's sort is stable with no secondary key, so we add a
+ * deterministic `(txid, vout)` tiebreak and send `inputs_set` in this same
+ * order. The result's first element is the UTXO Counterparty keys ARC4 against,
+ * which the caller pins to input index 0 of the broadcast transaction.
+ */
+export function orderInputsForCounterparty<T extends OrderableInput>(
+  inputs: readonly T[],
+): T[] {
+  return [...inputs].sort(
+    (a, b) =>
+      (b.value - a.value) ||
+      a.txid.localeCompare(b.txid) ||
+      (a.vout - b.vout),
+  );
+}
+
+/**
+ * Serialize ordered UTXOs into a Counterparty `inputs_set` string
+ * (`txid:vout:value:scriptPubKeyHex`, comma-joined). `value` is emitted as an
+ * integer satoshi count — Counterparty runs `int(value)` and rejects a decimal
+ * string with "invalid value" (composer.py:667).
+ */
+export function formatInputsSet(
+  orderedInputs: readonly CounterpartyInput[],
+): string {
+  return orderedInputs
+    .map((u) => {
+      if (!u.script) {
+        throw new Error(
+          `UTXO ${u.txid}:${u.vout} is missing its scriptPubKey; cannot ` +
+            `serialize it into a Counterparty inputs_set.`,
+        );
+      }
+      return `${u.txid}:${u.vout}:${Math.round(u.value)}:${u.script}`;
+    })
+    .join(",");
+}
+
+/**
+ * Extract the data push from an OP_RETURN scriptPubKey. Returns null when the
+ * script is not an OP_RETURN carrying a single data payload.
+ */
+export function extractOpReturnPayload(scriptHex: string): Uint8Array | null {
+  if (!scriptHex) return null;
+  const buf = Buffer.from(scriptHex, "hex");
+  if (buf.length === 0 || buf[0] !== 0x6a) return null; // 0x6a = OP_RETURN
+  const decompiled = bitcoin.script.decompile(buf);
+  if (!decompiled || decompiled.length < 2) return null;
+  const last = decompiled[decompiled.length - 1];
+  return Buffer.isBuffer(last) ? new Uint8Array(last) : null;
+}
+
+/**
+ * Fail-closed guard mirroring the Counterparty indexer: decrypt the OP_RETURN
+ * payload with the ARC4 key derived from `vin0Txid` (display byte order, which
+ * is what the indexer uses) and report whether the plaintext carries the
+ * CNTRPRTY prefix. Returns false (rather than throwing) for malformed scripts so
+ * callers can decide how to surface the failure.
+ *
+ * @param opReturnScriptHex scriptPubKey hex of the OP_RETURN output
+ * @param vin0Txid          display-order txid hex of input index 0
+ */
+export function opReturnDecodesFromInput(
+  opReturnScriptHex: string,
+  vin0Txid: string,
+): boolean {
+  const payload = extractOpReturnPayload(opReturnScriptHex);
+  if (!payload || payload.length < CNTRPRTY_PREFIX.length) return false;
+  const key = new Uint8Array(hex2bin(vin0Txid));
+  if (key.length === 0) return false;
+  const decrypted = arc4(key, payload);
+  return Buffer.from(decrypted.subarray(0, CNTRPRTY_PREFIX.length)).toString(
+    "utf8",
+  ) === CNTRPRTY_PREFIX;
+}

--- a/server/services/counterpartyApiService.ts
+++ b/server/services/counterpartyApiService.ts
@@ -558,6 +558,17 @@ export interface IssuanceOptions {
   show_unconfirmed?: boolean;
   lock?: boolean;
   description?: string;
+  // Pin the exact UTXO set used for composition. Format: comma-separated
+  // `<txid>:<vout>:<value>:<scriptPubKeyHex>`. CP sorts this set by raw value
+  // descending and derives the ARC4 OP_RETURN key from the first (largest) entry.
+  inputs_set?: string;
+  // REQUIRED alongside inputs_set: without it CP consumes only the first input
+  // it needs (growing from 1), so the ARC4 key may be keyed off a single UTXO
+  // that does not match the multi-input transaction we build and broadcast.
+  use_all_inputs_set?: boolean;
+  // Avoid CP-side UTXO locking interfering with re-composition/retries; we sign
+  // and broadcast the transaction ourselves.
+  disable_utxo_locks?: boolean;
 }
 
 export class CounterpartyApiManager {

--- a/server/services/stamp/stampCreationService.ts
+++ b/server/services/stamp/stampCreationService.ts
@@ -4,7 +4,7 @@ import { base64ToHex } from "$lib/utils/data/binary/baseUtils.ts";
 import { FileToAddressUtils } from "$lib/utils/bitcoin/encoding/fileToAddressUtils.ts";
 import { estimateMintingTransactionSize } from "$lib/utils/bitcoin/minting/transactionSizes.ts";
 import { estimateMARATransactionSize } from "$lib/utils/bitcoin/minting/maraTransactionSizeEstimator.ts";
-import { extractOutputs } from "$lib/utils/bitcoin/minting/transactionUtils.ts";
+import { arc4, extractOutputs } from "$lib/utils/bitcoin/minting/transactionUtils.ts";
 import { getScriptTypeInfo, validateWalletAddressForMinting } from "$lib/utils/bitcoin/scripts/scriptTypeUtils.ts";
 import { CounterpartyApiManager } from "$server/services/counterpartyApiService.ts";
 import { formatPsbtForLogging } from "$server/services/transaction/bitcoinTransactionBuilder.ts";
@@ -111,6 +111,41 @@ export class StampCreationService {
       // Convert qty from string to number if needed
       const qtyNumber = typeof qty === 'string' ? parseInt(qty, 10) : qty;
 
+      const hex_file = base64ToHex(file);
+      const cip33Addresses = FileToAddressUtils.fileToAddresses(hex_file) as string[];
+      const fileSize = Math.ceil((file.length * 3) / 4);
+      logger.debug("stamp-create", { message: "File and CIP33 details", fileSize, cip33AddressCount: cip33Addresses.length, hex_length: hex_file.length });
+
+      // Select the funding UTXOs BEFORE composing so the exact set (and its
+      // raw-value-descending order) can be pinned to Counterparty via inputs_set.
+      // CP derives the ARC4 OP_RETURN key from the largest-by-value entry, so
+      // pinning the same set + order here keeps vin[0] aligned with that key.
+      // (Dry runs skip this — they never touch the real CP composer.)
+      let orderedInputs: UTXO[] | undefined;
+      let inputsSet: string | undefined;
+      if (!isDryRun) {
+        const selected = await this.selectIssuanceInputs(
+          sourceWallet,
+          cip33Addresses,
+          dustValue,
+          service_fee,
+          service_fee_address,
+          normalizedSatsPerVB,
+        );
+        // Match CP's sort key exactly: raw value descending, with a deterministic
+        // (txid, vout) tiebreak so equal-value ties resolve identically on both
+        // sides (CP's value sort is stable over the order we send it).
+        orderedInputs = [...selected].sort(
+          (a, b) =>
+            (b.value - a.value) ||
+            a.txid.localeCompare(b.txid) ||
+            (a.vout - b.vout),
+        );
+        inputsSet = orderedInputs
+          .map((u) => `${u.txid}:${u.vout}:${u.value}:${u.script}`)
+          .join(",");
+      }
+
       const result = await this.createIssuanceTransaction({
         sourceWallet,
         assetName: assetName || "", // Provide default empty string for undefined assetName
@@ -123,6 +158,9 @@ export class StampCreationService {
         file, // Pass file data for accurate size calculation
         service_fee,
         outputValue: dustValue, // Pass the dust value for accurate fee estimation
+        ...(inputsSet
+          ? { inputs_set: inputsSet, use_all_inputs_set: true }
+          : {}),
       });
 
       if (!result.tx_hex) {
@@ -130,11 +168,6 @@ export class StampCreationService {
       }
 
       const hex = result.tx_hex;
-      const hex_file = base64ToHex(file);
-      const cip33Addresses = FileToAddressUtils.fileToAddresses(hex_file);
-
-      const fileSize = Math.ceil((file.length * 3) / 4);
-      logger.debug("stamp-create", { message: "File and CIP33 details", fileSize, cip33AddressCount: cip33Addresses.length, hex_length: hex_file.length });
 
       const psbtDetails = await this.generatePSBT(
         hex,
@@ -142,10 +175,11 @@ export class StampCreationService {
         normalizedSatsPerVB,
         service_fee,
         service_fee_address,
-        cip33Addresses as string[],
+        cip33Addresses,
         fileSize,
         isDryRun || false,
-        dustValue
+        dustValue,
+        orderedInputs,
       );
 
       if (isDryRun) {
@@ -178,6 +212,54 @@ export class StampCreationService {
     }
   }
 
+  /**
+   * Select the funding UTXOs for an issuance with full details (script, value)
+   * so the exact set can be pinned to Counterparty via inputs_set. Runs BEFORE
+   * composition; fee sizing uses a max-length OP_RETURN placeholder because the
+   * real Counterparty issuance OP_RETURN is a deterministic length.
+   */
+  private static async selectIssuanceInputs(
+    address: string,
+    cip33Addresses: string[],
+    dustValue: number,
+    service_fee: number,
+    recipient_fee: string,
+    satsPerVB: number,
+  ): Promise<UTXO[]> {
+    // Representative OP_RETURN output for fee sizing: OP_RETURN + OP_PUSHDATA1 +
+    // 80 data bytes (upper bound for a Counterparty issuance message).
+    const placeholderOpReturn = "6a4c50" + "00".repeat(80);
+    const outputsForSelection = [
+      { value: 0, script: placeholderOpReturn },
+      ...cip33Addresses.map((addr) => ({ value: dustValue, script: "", address: addr })),
+      ...(service_fee > 0 && recipient_fee
+        ? [{ value: service_fee, script: "", address: recipient_fee }]
+        : []),
+    ];
+
+    const { inputs } = await this.utxoService.selectUTXOsForTransaction(
+      address,
+      outputsForSelection,
+      satsPerVB,
+      0, // sigops_rate
+      1.5, // rbfBuffer
+      {
+        filterStampUTXOs: true, // Filter out stamp-bearing UTXOs
+        includeAncestors: true, // Fetch full details (script) for selected UTXOs
+      },
+    );
+
+    for (const input of inputs) {
+      if (!input.script) {
+        throw new Error(
+          `Pre-selected UTXO ${input.txid}:${input.vout} is missing its ` +
+            `scriptPubKey; cannot pin it to Counterparty inputs_set.`,
+        );
+      }
+    }
+    return inputs;
+  }
+
   private static async generatePSBT(
     tx: string,
     address: string,
@@ -187,7 +269,12 @@ export class StampCreationService {
     cip33Addresses: string[],
     fileSize: number,
     isDryRun: boolean,
-    dustValue: number = TX_CONSTANTS.DUST_SIZE
+    dustValue: number = TX_CONSTANTS.DUST_SIZE,
+    // Inputs pre-selected by createStampIssuance and pinned to CP via inputs_set,
+    // already ordered raw-value descending (CP's ARC4-key sort order). When
+    // provided, these are used verbatim instead of running an independent
+    // selection here, so vin[0] stays equal to the UTXO CP keyed the OP_RETURN to.
+    preSelectedInputs?: UTXO[]
   ) {
     let totalOutputValue = 0;
     let psbt;
@@ -437,20 +524,35 @@ export class StampCreationService {
         satsPerVB: satsPerVB
       });
 
-      // Use BitcoinUtxoManager for optimal UTXO selection with full details
-      const selectionResult = await this.utxoService.selectUTXOsForTransaction(
-        address,
-        outputsForSelection,
-        satsPerVB,
-        0, // sigops_rate
-        1.5, // rbfBuffer
-        {
-          filterStampUTXOs: true, // Filter out stamp-bearing UTXOs
-          includeAncestors: true,  // Get full details for selected UTXOs only
-        }
-      );
-
-      const { inputs, change: initialChange } = selectionResult;
+      // Use the inputs pre-selected (and pinned to CP via inputs_set) when
+      // available. Re-selecting here would derive an independent set/order and
+      // desynchronize vin[0] from the UTXO CP used to derive the ARC4 OP_RETURN
+      // key — the exact failure mode that makes stamp issuances unindexable.
+      let inputs: UTXO[];
+      let initialChange = 0;
+      if (preSelectedInputs && preSelectedInputs.length > 0) {
+        inputs = preSelectedInputs;
+        logger.debug("stamp-create", {
+          message: "Using pre-selected inputs pinned to CP inputs_set",
+          inputCount: inputs.length,
+          vin0: inputs[0] ? `${inputs[0].txid}:${inputs[0].vout}` : undefined,
+        });
+      } else {
+        // Use BitcoinUtxoManager for optimal UTXO selection with full details
+        const selectionResult = await this.utxoService.selectUTXOsForTransaction(
+          address,
+          outputsForSelection,
+          satsPerVB,
+          0, // sigops_rate
+          1.5, // rbfBuffer
+          {
+            filterStampUTXOs: true, // Filter out stamp-bearing UTXOs
+            includeAncestors: true,  // Get full details for selected UTXOs only
+          }
+        );
+        inputs = selectionResult.inputs;
+        initialChange = selectionResult.change;
+      }
       const totalInputValue = inputs.reduce((sum: number, input: UTXO) => sum + (input.value ?? 0), 0);
 
       logger.debug("stamp-create", {
@@ -653,6 +755,55 @@ export class StampCreationService {
         address: v.address
       })), psbtDetails: formatPsbtForLogging(psbt) });
 
+      // ---------------------------------------------------------------------
+      // Fail-closed ARC4 key guard.
+      // The Counterparty indexer derives the ARC4 key ONLY from
+      // vin[0].previous_output.txid (display byte order) and drops the whole
+      // transaction as "invalid OP_RETURN script" if the decrypted payload does
+      // not start with the CNTRPRTY prefix. inputs[0] is vin[0] because inputs
+      // are added to the PSBT in array order above. Verify here, before the PSBT
+      // ever leaves this service, that the OP_RETURN CP encrypted is recoverable
+      // from vin[0]. If not, abort rather than emit an unindexable issuance.
+      // ---------------------------------------------------------------------
+      if (!isDryRun && inputs.length > 0) {
+        const opReturnVout = vouts.find(
+          (v) => v.script instanceof Uint8Array && v.script[0] === 0x6a,
+        );
+        if (!opReturnVout || !(opReturnVout.script instanceof Uint8Array)) {
+          throw new Error(
+            "ARC4 key guard: no OP_RETURN output found in the composed transaction",
+          );
+        }
+        const decompiled = bitcoin.script.decompile(
+          Buffer.from(opReturnVout.script),
+        );
+        const encryptedPayload = decompiled && decompiled.length > 0
+          ? decompiled[decompiled.length - 1]
+          : null;
+        if (!encryptedPayload || !Buffer.isBuffer(encryptedPayload)) {
+          throw new Error(
+            "ARC4 key guard: OP_RETURN output has no data payload to verify",
+          );
+        }
+        // Indexer key = vin[0].prev_txid in display (big-endian) byte order.
+        // input.txid is already the display-order hex string.
+        const arc4Key = new Uint8Array(hex2bin(inputs[0].txid));
+        const decrypted = arc4(arc4Key, new Uint8Array(encryptedPayload));
+        const prefix = Buffer.from(decrypted.subarray(0, 8)).toString("utf8");
+        if (prefix !== "CNTRPRTY") {
+          throw new Error(
+            `ARC4 key mismatch: OP_RETURN is not decryptable from vin[0] ` +
+              `(${inputs[0].txid}:${inputs[0].vout}). Aborting to avoid ` +
+              `broadcasting an unindexable stamp issuance — the UTXO Counterparty ` +
+              `keyed the OP_RETURN against is not at input index 0.`,
+          );
+        }
+        logger.info("stamp-create", {
+          message: "ARC4 key guard passed: OP_RETURN decodes from vin[0]",
+          vin0: `${inputs[0].txid}:${inputs[0].vout}`,
+        });
+      }
+
       return {
         psbt,
         satsPerVB,
@@ -682,6 +833,8 @@ export class StampCreationService {
     file,
     service_fee,
     outputValue,
+    inputs_set,
+    use_all_inputs_set,
   }: {
     sourceWallet: string;
     assetName: string;
@@ -694,6 +847,11 @@ export class StampCreationService {
     file: string;
     service_fee: number;
     outputValue?: number;
+    // Pin the exact UTXO set CP composes against (see IssuanceOptions.inputs_set).
+    // CP keys the ARC4 OP_RETURN off the largest-by-raw-value entry, so the
+    // caller MUST place that same UTXO at vin[0] of the final transaction.
+    inputs_set?: string;
+    use_all_inputs_set?: boolean;
   }) {
     try {
       // Add wallet validation
@@ -783,7 +941,21 @@ export class StampCreationService {
           allow_unconfirmed_inputs: true,
           return_psbt: false, // Request hex instead of PSBT
           verbose: true,
-          encoding: 'opreturn'
+          encoding: 'opreturn',
+          // Pin the exact UTXO set so CP derives the ARC4 OP_RETURN key from a
+          // UTXO we control. use_all_inputs_set forces CP to consume every entry
+          // (default is "grow from 1"), guaranteeing the largest-by-value UTXO —
+          // which CP sorts to vin[0] and keys ARC4 against — is the one we pin to
+          // index 0 of the broadcast transaction. Without this the OP_RETURN is
+          // keyed off an input that may not be vin[0], and the stamp is dropped
+          // by the Counterparty indexer as an invalid OP_RETURN script.
+          ...(inputs_set
+            ? {
+              inputs_set,
+              use_all_inputs_set: use_all_inputs_set ?? true,
+              disable_utxo_locks: true,
+            }
+            : {}),
         }
       );
 

--- a/server/services/stamp/stampCreationService.ts
+++ b/server/services/stamp/stampCreationService.ts
@@ -23,6 +23,10 @@ import type { UTXO } from "$types/base.d.ts";
 export class StampCreationService {
   private static commonUtxoService = new CommonUTXOService();
   private static utxoService = new BitcoinUtxoManager(); // Add BitcoinUtxoManager instance
+  // Counterparty composer hard limit on inputs_set entries (composer.py:36).
+  // Exceeding it makes CP reject compose with a ComposeError; we guard earlier
+  // with an actionable consolidation message.
+  private static readonly MAX_INPUTS_SET = 100;
 
   /**
    * 🚀 REMOVED: getFullUTXOsWithDetails method - replaced with optimal BitcoinUtxoManager pattern
@@ -141,8 +145,21 @@ export class StampCreationService {
             a.txid.localeCompare(b.txid) ||
             (a.vout - b.vout),
         );
+        // CP hard-rejects inputs_set with more than MAX_INPUTS_SET entries
+        // (composer.py:639). Fail loud with an actionable message instead of a
+        // generic ComposeError; >100 funding inputs for one issuance requires a
+        // UTXO consolidation pass first.
+        if (orderedInputs.length > StampCreationService.MAX_INPUTS_SET) {
+          throw new Error(
+            `Issuance needs ${orderedInputs.length} funding inputs, exceeding ` +
+              `Counterparty's inputs_set limit of ${StampCreationService.MAX_INPUTS_SET}. ` +
+              `Consolidate UTXOs for ${sourceWallet} before minting.`,
+          );
+        }
+        // Field 3 MUST be an integer satoshi count — CP does int(value) and
+        // rejects a decimal string ("invalid value"); field 4 is scriptPubKey hex.
         inputsSet = orderedInputs
-          .map((u) => `${u.txid}:${u.vout}:${u.value}:${u.script}`)
+          .map((u) => `${u.txid}:${u.vout}:${Math.round(u.value)}:${u.script}`)
           .join(",");
       }
 

--- a/server/services/stamp/stampCreationService.ts
+++ b/server/services/stamp/stampCreationService.ts
@@ -125,42 +125,10 @@ export class StampCreationService {
       const fileSize = Math.ceil((file.length * 3) / 4);
       logger.debug("stamp-create", { message: "File and CIP33 details", fileSize, cip33AddressCount: cip33Addresses.length, hex_length: hex_file.length });
 
-      // Select the funding UTXOs BEFORE composing so the exact set (and its
-      // raw-value-descending order) can be pinned to Counterparty via inputs_set.
-      // CP derives the ARC4 OP_RETURN key from the largest-by-value entry, so
-      // pinning the same set + order here keeps vin[0] aligned with that key.
-      // (Dry runs skip this — they never touch the real CP composer.)
-      let orderedInputs: UTXO[] | undefined;
-      let inputsSet: string | undefined;
-      if (!isDryRun) {
-        const selected = await this.selectIssuanceInputs(
-          sourceWallet,
-          cip33Addresses,
-          dustValue,
-          service_fee,
-          service_fee_address,
-          normalizedSatsPerVB,
-        );
-        // Match CP's sort key exactly: raw value descending, with a deterministic
-        // (txid, vout) tiebreak so equal-value ties resolve identically on both
-        // sides (CP's value sort is stable over the order we send it).
-        // Order raw-value descending with a (txid, vout) tiebreak — Counterparty's
-        // exact sort key (composer.py:798) — then send inputs_set in this order.
-        orderedInputs = orderInputsForCounterparty(selected);
-        // CP hard-rejects inputs_set with more than MAX_INPUTS_SET entries
-        // (composer.py:639). Fail loud with an actionable message instead of a
-        // generic ComposeError; >100 funding inputs for one issuance requires a
-        // UTXO consolidation pass first.
-        if (orderedInputs.length > StampCreationService.MAX_INPUTS_SET) {
-          throw new Error(
-            `Issuance needs ${orderedInputs.length} funding inputs, exceeding ` +
-              `Counterparty's inputs_set limit of ${StampCreationService.MAX_INPUTS_SET}. ` +
-              `Consolidate UTXOs for ${sourceWallet} before minting.`,
-          );
-        }
-        inputsSet = formatInputsSet(orderedInputs);
-      }
-
+      // createIssuanceTransaction selects the funding UTXOs, pins them to
+      // Counterparty via inputs_set, and returns that same raw-value-ordered set
+      // (orderedInputs) so generatePSBT can place vin[0] — the UTXO CP keyed the
+      // ARC4 OP_RETURN against — at input index 0 of the broadcast transaction.
       const result = await this.createIssuanceTransaction({
         sourceWallet,
         assetName: assetName || "", // Provide default empty string for undefined assetName
@@ -172,10 +140,9 @@ export class StampCreationService {
         isDryRun: isDryRun || false,
         file, // Pass file data for accurate size calculation
         service_fee,
+        service_fee_address,
         outputValue: dustValue, // Pass the dust value for accurate fee estimation
-        ...(inputsSet
-          ? { inputs_set: inputsSet, use_all_inputs_set: true }
-          : {}),
+        cip33Addresses,
       });
 
       if (!result.tx_hex) {
@@ -194,7 +161,7 @@ export class StampCreationService {
         fileSize,
         isDryRun || false,
         dustValue,
-        orderedInputs,
+        result.orderedInputs,
       );
 
       if (isDryRun) {
@@ -834,9 +801,9 @@ export class StampCreationService {
     isDryRun,
     file,
     service_fee,
+    service_fee_address = "",
     outputValue,
-    inputs_set,
-    use_all_inputs_set,
+    cip33Addresses,
   }: {
     sourceWallet: string;
     assetName: string;
@@ -848,12 +815,12 @@ export class StampCreationService {
     isDryRun?: boolean;
     file: string;
     service_fee: number;
+    service_fee_address?: string;
     outputValue?: number;
-    // Pin the exact UTXO set CP composes against (see IssuanceOptions.inputs_set).
-    // CP keys the ARC4 OP_RETURN off the largest-by-raw-value entry, so the
-    // caller MUST place that same UTXO at vin[0] of the final transaction.
-    inputs_set?: string;
-    use_all_inputs_set?: boolean;
+    // CIP33 P2WSH data-output addresses (used to size coin selection); optional
+    // so existing callers/tests that don't compute them still type-check — when
+    // omitted they're derived from `file`.
+    cip33Addresses?: string[];
   }) {
     try {
       // Add wallet validation
@@ -930,6 +897,36 @@ export class StampCreationService {
         };
       }
 
+      // Select the funding UTXOs and pin them to Counterparty so CP derives the
+      // ARC4 OP_RETURN key from a UTXO we control. Selection + composition live
+      // together: we select precisely in order to compose against that set.
+      const issuanceDustValue = outputValue ?? TX_CONSTANTS.DUST_SIZE;
+      const issuanceCip33Addresses = cip33Addresses ??
+        (FileToAddressUtils.fileToAddresses(base64ToHex(file)) as string[]);
+      const selected = await this.selectIssuanceInputs(
+        sourceWallet,
+        issuanceCip33Addresses,
+        issuanceDustValue,
+        service_fee,
+        service_fee_address,
+        satsPerKB / 1000, // sats/kB -> sats/vB
+      );
+      // Order raw-value descending with a (txid, vout) tiebreak — Counterparty's
+      // exact sort key (composer.py:798) — and send inputs_set in this order so
+      // CP's vin[0] (the ARC4 key) equals the UTXO we pin to PSBT index 0.
+      const orderedInputs = orderInputsForCounterparty(selected);
+      // CP hard-rejects inputs_set with more than MAX_INPUTS_SET entries
+      // (composer.py:639). Fail loud with an actionable message instead of a
+      // generic ComposeError; >100 funding inputs needs a consolidation pass.
+      if (orderedInputs.length > StampCreationService.MAX_INPUTS_SET) {
+        throw new Error(
+          `Issuance needs ${orderedInputs.length} funding inputs, exceeding ` +
+            `Counterparty's inputs_set limit of ${StampCreationService.MAX_INPUTS_SET}. ` +
+            `Consolidate UTXOs for ${sourceWallet} before minting.`,
+        );
+      }
+      const inputsSet = formatInputsSet(orderedInputs);
+
       // Use the new V2 API call
       const response = await CounterpartyApiManager.createIssuance(
         sourceWallet,
@@ -944,20 +941,15 @@ export class StampCreationService {
           return_psbt: false, // Request hex instead of PSBT
           verbose: true,
           encoding: 'opreturn',
-          // Pin the exact UTXO set so CP derives the ARC4 OP_RETURN key from a
-          // UTXO we control. use_all_inputs_set forces CP to consume every entry
+          // use_all_inputs_set forces CP to consume every inputs_set entry
           // (default is "grow from 1"), guaranteeing the largest-by-value UTXO —
           // which CP sorts to vin[0] and keys ARC4 against — is the one we pin to
-          // index 0 of the broadcast transaction. Without this the OP_RETURN is
-          // keyed off an input that may not be vin[0], and the stamp is dropped
-          // by the Counterparty indexer as an invalid OP_RETURN script.
-          ...(inputs_set
-            ? {
-              inputs_set,
-              use_all_inputs_set: use_all_inputs_set ?? true,
-              disable_utxo_locks: true,
-            }
-            : {}),
+          // index 0 of the broadcast transaction. disable_utxo_locks keeps a
+          // re-compose deterministic. Without this the OP_RETURN may be keyed off
+          // an input that isn't vin[0] and the stamp is dropped by the indexer.
+          inputs_set: inputsSet,
+          use_all_inputs_set: true,
+          disable_utxo_locks: true,
         }
       );
 
@@ -976,9 +968,11 @@ export class StampCreationService {
         throw new Error('Transaction creation failed: No transaction data returned from API');
       }
 
-      // Return with tx_hex for compatibility with existing code
+      // Return tx_hex plus the raw-value-ordered inputs so the caller can pin
+      // vin[0] to the UTXO CP keyed the OP_RETURN against.
       return {
-        tx_hex: response.result.rawtransaction
+        tx_hex: response.result.rawtransaction,
+        orderedInputs,
       };
     } catch (error) {
       logger.error("stamp-create", { message: "Detailed createIssuanceTransaction error", error: error instanceof Error ? error.message : String(error) });

--- a/server/services/stamp/stampCreationService.ts
+++ b/server/services/stamp/stampCreationService.ts
@@ -4,7 +4,12 @@ import { base64ToHex } from "$lib/utils/data/binary/baseUtils.ts";
 import { FileToAddressUtils } from "$lib/utils/bitcoin/encoding/fileToAddressUtils.ts";
 import { estimateMintingTransactionSize } from "$lib/utils/bitcoin/minting/transactionSizes.ts";
 import { estimateMARATransactionSize } from "$lib/utils/bitcoin/minting/maraTransactionSizeEstimator.ts";
-import { arc4, extractOutputs } from "$lib/utils/bitcoin/minting/transactionUtils.ts";
+import { extractOutputs } from "$lib/utils/bitcoin/minting/transactionUtils.ts";
+import {
+  formatInputsSet,
+  opReturnDecodesFromInput,
+  orderInputsForCounterparty,
+} from "$lib/utils/bitcoin/minting/counterpartyInputs.ts";
 import { getScriptTypeInfo, validateWalletAddressForMinting } from "$lib/utils/bitcoin/scripts/scriptTypeUtils.ts";
 import { CounterpartyApiManager } from "$server/services/counterpartyApiService.ts";
 import { formatPsbtForLogging } from "$server/services/transaction/bitcoinTransactionBuilder.ts";
@@ -139,12 +144,9 @@ export class StampCreationService {
         // Match CP's sort key exactly: raw value descending, with a deterministic
         // (txid, vout) tiebreak so equal-value ties resolve identically on both
         // sides (CP's value sort is stable over the order we send it).
-        orderedInputs = [...selected].sort(
-          (a, b) =>
-            (b.value - a.value) ||
-            a.txid.localeCompare(b.txid) ||
-            (a.vout - b.vout),
-        );
+        // Order raw-value descending with a (txid, vout) tiebreak — Counterparty's
+        // exact sort key (composer.py:798) — then send inputs_set in this order.
+        orderedInputs = orderInputsForCounterparty(selected);
         // CP hard-rejects inputs_set with more than MAX_INPUTS_SET entries
         // (composer.py:639). Fail loud with an actionable message instead of a
         // generic ComposeError; >100 funding inputs for one issuance requires a
@@ -156,11 +158,7 @@ export class StampCreationService {
               `Consolidate UTXOs for ${sourceWallet} before minting.`,
           );
         }
-        // Field 3 MUST be an integer satoshi count — CP does int(value) and
-        // rejects a decimal string ("invalid value"); field 4 is scriptPubKey hex.
-        inputsSet = orderedInputs
-          .map((u) => `${u.txid}:${u.vout}:${Math.round(u.value)}:${u.script}`)
-          .join(",");
+        inputsSet = formatInputsSet(orderedInputs);
       }
 
       const result = await this.createIssuanceTransaction({
@@ -791,23 +789,10 @@ export class StampCreationService {
             "ARC4 key guard: no OP_RETURN output found in the composed transaction",
           );
         }
-        const decompiled = bitcoin.script.decompile(
-          Buffer.from(opReturnVout.script),
-        );
-        const encryptedPayload = decompiled && decompiled.length > 0
-          ? decompiled[decompiled.length - 1]
-          : null;
-        if (!encryptedPayload || !Buffer.isBuffer(encryptedPayload)) {
-          throw new Error(
-            "ARC4 key guard: OP_RETURN output has no data payload to verify",
-          );
-        }
-        // Indexer key = vin[0].prev_txid in display (big-endian) byte order.
-        // input.txid is already the display-order hex string.
-        const arc4Key = new Uint8Array(hex2bin(inputs[0].txid));
-        const decrypted = arc4(arc4Key, new Uint8Array(encryptedPayload));
-        const prefix = Buffer.from(decrypted.subarray(0, 8)).toString("utf8");
-        if (prefix !== "CNTRPRTY") {
+        const opReturnScriptHex = Buffer.from(opReturnVout.script).toString("hex");
+        // inputs[0] is vin[0] (inputs are added to the PSBT in array order);
+        // input.txid is already display-order hex, matching the indexer's key.
+        if (!opReturnDecodesFromInput(opReturnScriptHex, inputs[0].txid)) {
           throw new Error(
             `ARC4 key mismatch: OP_RETURN is not decryptable from vin[0] ` +
               `(${inputs[0].txid}:${inputs[0].vout}). Aborting to avoid ` +

--- a/tests/unit/counterpartyInputs.test.ts
+++ b/tests/unit/counterpartyInputs.test.ts
@@ -1,0 +1,154 @@
+import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
+import * as bitcoin from "bitcoinjs-lib";
+import { Buffer } from "node:buffer";
+import { arc4 } from "$lib/utils/bitcoin/minting/transactionUtils.ts";
+import { hex2bin } from "$lib/utils/data/binary/baseUtils.ts";
+import {
+  extractOpReturnPayload,
+  formatInputsSet,
+  opReturnDecodesFromInput,
+  orderInputsForCounterparty,
+} from "$lib/utils/bitcoin/minting/counterpartyInputs.ts";
+
+// Two distinct, valid 32-byte (64 hex char) txids. Built via repeat() so no
+// 64-char hex literal sits in source (it trips the secret-leak guard). ARC4
+// accepts any key length, so synthetic txids exercise the logic identically to
+// the real PEPEDENCE-incident inputs.
+const TXID_A = "a1".repeat(32);
+const TXID_B = "b2".repeat(32);
+
+/** Build an OP_RETURN scriptPubKey hex carrying CNTRPRTY+payload, ARC4-encrypted
+ *  with the given txid as key (exactly what the Counterparty composer emits). */
+function buildEncryptedOpReturn(txidHex: string, tail = "stamp:payload"): string {
+  const plaintext = new Uint8Array([
+    ...new TextEncoder().encode("CNTRPRTY"),
+    ...new TextEncoder().encode(tail),
+  ]);
+  const key = new Uint8Array(hex2bin(txidHex));
+  const ciphertext = arc4(key, plaintext);
+  const script = bitcoin.script.compile([
+    bitcoin.opcodes.OP_RETURN,
+    Buffer.from(ciphertext),
+  ]);
+  return Buffer.from(script).toString("hex");
+}
+
+// ---------------------------------------------------------------------------
+// orderInputsForCounterparty — must mirror CP's raw-value-descending sort
+// ---------------------------------------------------------------------------
+
+Deno.test("orderInputsForCounterparty - sorts by raw value descending", () => {
+  const ordered = orderInputsForCounterparty([
+    { txid: "aa", vout: 0, value: 100 },
+    { txid: "bb", vout: 0, value: 5000 },
+    { txid: "cc", vout: 0, value: 750 },
+  ]);
+  assertEquals(ordered.map((u) => u.value), [5000, 750, 100]);
+});
+
+Deno.test("orderInputsForCounterparty - breaks value ties by (txid, vout) deterministically", () => {
+  const ordered = orderInputsForCounterparty([
+    { txid: "ff", vout: 1, value: 1000 },
+    { txid: "aa", vout: 2, value: 1000 },
+    { txid: "aa", vout: 0, value: 1000 },
+    { txid: "aa", vout: 1, value: 1000 },
+  ]);
+  assertEquals(
+    ordered.map((u) => `${u.txid}:${u.vout}`),
+    ["aa:0", "aa:1", "aa:2", "ff:1"],
+  );
+});
+
+Deno.test("orderInputsForCounterparty - does not mutate the input array", () => {
+  const input = [
+    { txid: "aa", vout: 0, value: 1 },
+    { txid: "bb", vout: 0, value: 2 },
+  ];
+  orderInputsForCounterparty(input);
+  assertEquals(input.map((u) => u.value), [1, 2]); // original order preserved
+});
+
+// ---------------------------------------------------------------------------
+// formatInputsSet — CP wire format, integer satoshis
+// ---------------------------------------------------------------------------
+
+Deno.test("formatInputsSet - serializes txid:vout:value:script comma-joined", () => {
+  const out = formatInputsSet([
+    { txid: TXID_A, vout: 1, value: 50000, script: "0014abcd" },
+    { txid: TXID_B, vout: 153, value: 12345, script: "00204455" },
+  ]);
+  assertEquals(
+    out,
+    `${TXID_A}:1:50000:0014abcd,${TXID_B}:153:12345:00204455`,
+  );
+});
+
+Deno.test("formatInputsSet - rounds value to an integer satoshi count", () => {
+  // CP runs int(value) and rejects a decimal string; a float value must not
+  // serialize as "50000.4".
+  const out = formatInputsSet([
+    { txid: TXID_A, vout: 0, value: 50000.4, script: "0014ab" },
+  ]);
+  assertEquals(out, `${TXID_A}:0:50000:0014ab`);
+});
+
+Deno.test("formatInputsSet - throws when a UTXO is missing its scriptPubKey", () => {
+  assertThrows(
+    () => formatInputsSet([{ txid: TXID_A, vout: 0, value: 1000 }]),
+    Error,
+    "missing its scriptPubKey",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// extractOpReturnPayload
+// ---------------------------------------------------------------------------
+
+Deno.test("extractOpReturnPayload - returns the data push of an OP_RETURN", () => {
+  const script = Buffer.from(
+    bitcoin.script.compile([
+      bitcoin.opcodes.OP_RETURN,
+      Buffer.from("deadbeef", "hex"),
+    ]),
+  ).toString("hex");
+  assertEquals(extractOpReturnPayload(script), new Uint8Array([0xde, 0xad, 0xbe, 0xef]));
+});
+
+Deno.test("extractOpReturnPayload - returns null for a non-OP_RETURN script", () => {
+  // A P2WPKH-style scriptPubKey (starts with 0x00, not 0x6a).
+  assertEquals(extractOpReturnPayload("0014" + "ab".repeat(20)), null);
+  assertEquals(extractOpReturnPayload(""), null);
+});
+
+// ---------------------------------------------------------------------------
+// opReturnDecodesFromInput — the fail-closed ARC4 guard (the core invariant)
+// ---------------------------------------------------------------------------
+
+Deno.test("opReturnDecodesFromInput - true when OP_RETURN is keyed to the given input", () => {
+  const script = buildEncryptedOpReturn(TXID_A);
+  assert(opReturnDecodesFromInput(script, TXID_A));
+});
+
+Deno.test("opReturnDecodesFromInput - false when keyed to a DIFFERENT input (the PEPEDENCE bug)", () => {
+  // OP_RETURN encrypted against TXID_A (CP's vin[0]) but the transaction's
+  // vin[0] ended up being TXID_B — exactly the case the indexer drops.
+  const script = buildEncryptedOpReturn(TXID_A);
+  assertFalse(opReturnDecodesFromInput(script, TXID_B));
+});
+
+Deno.test("opReturnDecodesFromInput - false for a plaintext (unencrypted) CNTRPRTY OP_RETURN", () => {
+  // The legacy minimal-tx fallback emits a literal 'CNTRPRTY' OP_RETURN; it must
+  // NOT pass the guard (it is not a valid encrypted issuance payload).
+  const script = Buffer.from(
+    bitcoin.script.compile([
+      bitcoin.opcodes.OP_RETURN,
+      Buffer.from("CNTRPRTY", "utf8"),
+    ]),
+  ).toString("hex");
+  assertFalse(opReturnDecodesFromInput(script, TXID_A));
+});
+
+Deno.test("opReturnDecodesFromInput - false for a malformed / non-OP_RETURN script", () => {
+  assertFalse(opReturnDecodesFromInput("0014" + "ab".repeat(20), TXID_A));
+  assertFalse(opReturnDecodesFromInput("", TXID_A));
+});


### PR DESCRIPTION
## Problem

Bitcoin Stamp issuances are Counterparty issuance transactions whose OP_RETURN is ARC4-encrypted using **vin[0].prev_txid** as the key. The Counterparty indexer **always** derives the ARC4 key from vin[0] only — if vin[0] at broadcast time isn't the input the OP_RETURN was keyed against, the indexer drops the tx as *"Encountered invalid OP_RETURN script"* and the issuance is **silently lost** (e.g. asset PEPEDENCE, tx `24c42d9d…`).

## Root cause

The issuance pipeline ran **two independent UTXO selections that were never reconciled**:

1. `createIssuanceTransaction` called Counterparty `compose/issuance` with **no `inputs_set`** → CP selected its own inputs and ARC4-encrypted the OP_RETURN against **its** vin[0].
2. `generatePSBT` then **discarded CP's inputs entirely** (`extractOutputs` keeps only outputs), ran its **own** `OptimalUTXOSelection`, and ordered inputs **by descending value** — so a different (larger) UTXO could land at vin[0].

Single-input mints worked by coincidence (both selectors converge); multi-input mints (large OLGA payloads with many P2WSH dust outputs) diverged and were lost.

## Fix

One canonical input set, ordered identically on both sides, with a fail-closed guard:

- **Select funding UTXOs before composing** and pin them to CP via `inputs_set` + **`use_all_inputs_set=true`** (without the flag CP grows from a single input and may key ARC4 off one UTXO).
- **Order raw-value descending with a `(txid, vout)` tiebreak** — CP's exact sort key (`composer.py:798`, stable, no secondary key) — on both the `inputs_set` string and the PSBT, so vin[0] == CP's ARC4-key input by construction.
- **`disable_utxo_locks=true`** for deterministic re-compose; integer-satoshi `value` field (CP runs `int(value)`).
- **`MAX_INPUTS_SET=100` guard** — fail loud with a consolidation hint instead of CP's generic `ComposeError` (`composer.py:639`).
- **Fail-closed ARC4 guard** in `generatePSBT`: ARC4-decrypt the final OP_RETURN with `vin[0].prev_txid` and **abort** unless it carries the `CNTRPRTY` prefix — the un-bypassable net for any residual divergence (incl. an old CP node ignoring `inputs_set`, or the legacy plaintext-CNTRPRTY fallback).

All compose params verified against `counterparty-core/.../composer.py` by the CP-index maintainer.

## Tests

New pure module `lib/utils/bitcoin/minting/counterpartyInputs.ts` + 12 unit tests (`tests/unit/counterpartyInputs.test.ts`), incl. the PEPEDENCE failure mode (OP_RETURN keyed to one input, vin[0] another → guard fails) and the legacy plaintext-CNTRPRTY fallback. `deno check` + pre-commit `validate:quick` pass.

## Follow-up (not blocking)

If a single issuance ever needs >100 funding inputs, add a UTXO-consolidation pass before compose (currently fails loud with an actionable message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)