### PR TITLE
fix(tx): pin Counterparty vin[0] in shared PSBT builder (fairmint/detach ARC4)

### DIFF
--- a/server/services/transaction/generalBitcoinTransactionBuilder.ts
+++ b/server/services/transaction/generalBitcoinTransactionBuilder.ts
@@ -12,6 +12,7 @@ import { hex2bin } from "$lib/utils/data/binary/baseUtils.ts";
 import { logger } from "$lib/utils/logger.ts";
 import { estimateMintingTransactionSize } from "$lib/utils/bitcoin/minting/transactionSizes.ts";
 import { extractOutputs } from "$lib/utils/bitcoin/minting/transactionUtils.ts";
+import { opReturnDecodesFromInput } from "$lib/utils/bitcoin/minting/counterpartyInputs.ts";
 import { getScriptTypeInfo } from "$lib/utils/bitcoin/scripts/scriptTypeUtils.ts";
 import { CounterpartyApiManager } from "$server/services/counterpartyApiService.ts";
 import { CommonUTXOService } from "$server/services/utxo/commonUtxoService.ts";
@@ -222,7 +223,45 @@ export class GeneralBitcoinTransactionBuilder {
         }
       );
 
-      const { inputs } = selectionResult;
+      // Pin Counterparty's vin[0] (the ARC4 OP_RETURN key input) at PSBT index 0.
+      // CP encrypts the OP_RETURN against the txid of ITS first input, and the
+      // indexer derives the ARC4 key ONLY from vin[0]. extractOutputs() above
+      // discarded CP's inputs and we re-selected our own, so we must re-attach
+      // CP's vin[0] at index 0 or the issuance is silently dropped by the indexer
+      // (same failure mode as the pre-fix stamp issuance bug). Funding UTXOs are
+      // appended after it.
+      let inputs: UTXO[] = [...selectionResult.inputs];
+      const cpVin0 = (txObj.ins && txObj.ins.length > 0)
+        ? {
+          txid: Buffer.from(txObj.ins[0].hash).reverse().toString("hex"),
+          vout: txObj.ins[0].index,
+        }
+        : undefined;
+      if (cpVin0) {
+        const idx = inputs.findIndex(
+          (i) => i.txid === cpVin0.txid && i.vout === cpVin0.vout,
+        );
+        if (idx > 0) {
+          // Selected but not first — move it to index 0.
+          const [pin] = inputs.splice(idx, 1);
+          inputs = [pin, ...inputs];
+        } else if (idx === -1) {
+          // Not in our selection — fetch its details and prepend (adds funding).
+          const pinUtxo = await this.commonUtxoService.getSpecificUTXO(
+            cpVin0.txid,
+            cpVin0.vout,
+            { includeAncestorDetails: true },
+          );
+          if (!pinUtxo || !pinUtxo.script || pinUtxo.value === undefined) {
+            throw new Error(
+              `Failed to fetch Counterparty vin[0] UTXO ${cpVin0.txid}:${cpVin0.vout} ` +
+                `required for ARC4 key alignment of ${operationType}.`,
+            );
+          }
+          inputs = [pinUtxo, ...inputs];
+        }
+        // idx === 0: already first — nothing to do.
+      }
       const totalInputValue = inputs.reduce((sum: number, input: UTXO) => sum + safeUTXOValue(input), 0);
 
       // Recalculate with actual inputs
@@ -329,6 +368,26 @@ export class GeneralBitcoinTransactionBuilder {
         feeRate: actualFeeRate,
         size: actualEstimatedSize
       });
+
+      // Fail-closed ARC4 guard: if the Counterparty transaction carries an
+      // (ARC4-encrypted) OP_RETURN, it MUST decode from vin[0]. inputs[0] is
+      // vin[0] (added to the PSBT in array order above, with CP's vin[0] pinned
+      // first). Abort rather than emit an unindexable ${operationType}.
+      if (inputs.length > 0) {
+        const opReturnVout = vouts.find(
+          (v) => v.script instanceof Uint8Array && v.script[0] === 0x6a,
+        );
+        if (opReturnVout && opReturnVout.script instanceof Uint8Array) {
+          const opReturnHex = Buffer.from(opReturnVout.script).toString("hex");
+          if (!opReturnDecodesFromInput(opReturnHex, inputs[0].txid)) {
+            throw new Error(
+              `ARC4 key mismatch for ${operationType}: OP_RETURN does not decode ` +
+                `from vin[0] (${inputs[0].txid}). Aborting to avoid broadcasting an ` +
+                `unindexable Counterparty transaction.`,
+            );
+          }
+        }
+      }
 
       return {
         psbt,

--- a/tests/unit/generalBitcoinTransactionBuilder.test.ts
+++ b/tests/unit/generalBitcoinTransactionBuilder.test.ts
@@ -1,0 +1,108 @@
+import { assert, assertEquals, assertRejects } from "@std/assert";
+import { stub } from "@std/testing@1.0.14/mock";
+import * as bitcoin from "bitcoinjs-lib";
+import { Buffer } from "node:buffer";
+import { arc4 } from "$lib/utils/bitcoin/minting/transactionUtils.ts";
+import { hex2bin } from "$lib/utils/data/binary/baseUtils.ts";
+import { GeneralBitcoinTransactionBuilder } from "$server/services/transaction/generalBitcoinTransactionBuilder.ts";
+import { OptimalUTXOSelection } from "$server/services/utxo/optimalUtxoSelection.ts";
+
+// Synthetic txids (repeat() so no 64-char hex literal trips the secret-leak guard).
+const TXID_A = "a1".repeat(32); // Counterparty's vin[0] = the ARC4 key input
+const TXID_B = "b2".repeat(32); // an unrelated funding UTXO our selector prefers
+const P2WPKH_SCRIPT = "0014" + "11".repeat(20);
+const CHANGE_ADDR = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
+
+/** Build a Counterparty-style raw tx hex: optional input + an OP_RETURN that is
+ *  ARC4-encrypted (CNTRPRTY-prefixed) against `keyTxid`. */
+function buildCpRawHex(keyTxid: string, withInput: boolean): string {
+  const payload = new Uint8Array([
+    ...new TextEncoder().encode("CNTRPRTY"),
+    ...new TextEncoder().encode("fairmint-test-payload"),
+  ]);
+  const enc = arc4(new Uint8Array(hex2bin(keyTxid)), payload);
+  const opReturn = bitcoin.script.compile([bitcoin.opcodes.OP_RETURN, Buffer.from(enc)]);
+  const tx = new bitcoin.Transaction();
+  tx.version = 2;
+  if (withInput) {
+    // CP's vin[0] prev-txid == keyTxid (hash stored internal/LE -> reverse display hex)
+    tx.addInput(Buffer.from(hex2bin(keyTxid)).reverse(), 0);
+  }
+  tx.addOutput(opReturn, BigInt(0));
+  return tx.toHex();
+}
+
+const utxo = (txid: string) => ({
+  txid,
+  vout: 0,
+  value: 50000,
+  script: P2WPKH_SCRIPT,
+  scriptType: "P2WPKH",
+});
+
+function vin0Txid(psbt: bitcoin.Psbt): string {
+  return Buffer.from(psbt.txInputs[0].hash).reverse().toString("hex");
+}
+
+Deno.test("generatePSBT - pins Counterparty vin[0] at PSBT index 0 even when the selector orders it elsewhere", async () => {
+  const cpRawHex = buildCpRawHex(TXID_A, true);
+  // Selector returns CP's vin[0] (utxo A) NOT first — the builder must move it to index 0.
+  const selStub = stub(
+    OptimalUTXOSelection,
+    "selectUTXOs",
+    () => ({ inputs: [utxo(TXID_B), utxo(TXID_A)], change: 0, fee: 1000 }) as any,
+  );
+  const poolStub = stub(
+    GeneralBitcoinTransactionBuilder as any,
+    "getFullUTXOsWithDetails",
+    () => Promise.resolve([utxo(TXID_A), utxo(TXID_B)]),
+  );
+  try {
+    const res = await GeneralBitcoinTransactionBuilder.generatePSBT(cpRawHex, {
+      address: CHANGE_ADDR,
+      satsPerVB: 5,
+      operationType: "fairmint",
+      customOutputs: [],
+    });
+    // vin[0] is CP's ARC4 key input, regardless of selector order...
+    assertEquals(vin0Txid(res.psbt), TXID_A);
+    // ...and the build succeeded (the fail-closed ARC4 guard passed).
+    assert(res.psbt.txInputs.length === 2);
+  } finally {
+    selStub.restore();
+    poolStub.restore();
+  }
+});
+
+Deno.test("generatePSBT - fail-closed ARC4 guard aborts when vin[0] is NOT the OP_RETURN key input", async () => {
+  // CP raw tx has NO input (parse-fallback shape) so there is no CP vin[0] to pin;
+  // the selector's pick (TXID_B) becomes vin[0], but the OP_RETURN is keyed to
+  // TXID_A — the indexer would silently drop it, so the guard MUST throw.
+  const cpRawHex = buildCpRawHex(TXID_A, false);
+  const selStub = stub(
+    OptimalUTXOSelection,
+    "selectUTXOs",
+    () => ({ inputs: [utxo(TXID_B)], change: 0, fee: 1000 }) as any,
+  );
+  const poolStub = stub(
+    GeneralBitcoinTransactionBuilder as any,
+    "getFullUTXOsWithDetails",
+    () => Promise.resolve([utxo(TXID_B)]),
+  );
+  try {
+    await assertRejects(
+      () =>
+        GeneralBitcoinTransactionBuilder.generatePSBT(cpRawHex, {
+          address: CHANGE_ADDR,
+          satsPerVB: 5,
+          operationType: "fairmint",
+          customOutputs: [],
+        }),
+      Error,
+      "ARC4 key mismatch",
+    );
+  } finally {
+    selStub.restore();
+    poolStub.restore();
+  }
+});


### PR DESCRIPTION
## Summary

Follow-up to the stamp ARC4 fix (#1133). An audit of every transaction-construction endpoint found the **same silent-loss bug class** in `GeneralBitcoinTransactionBuilder.generatePSBT`, which backs **fairmint** and **detach**.

## The bug (fairmint + detach)

`generalBitcoinTransactionBuilder.ts` was copied from the *pre-fix* stamp pattern: it keeps only the Counterparty rawtransaction's **outputs** (`extractOutputs`, discarding CP's inputs) and then **re-selects its own value-sorted UTXOs**. Counterparty — and the btc_stamps SRC-20 indexer (verified: `init_arc4(vin.prevout.hash[::-1])`) — derive the ARC4 OP_RETURN key **only from vin[0]**, so a fairmint/detach whose re-selected `vin[0]` differs from CP's key input is **silently dropped by the indexer**. No guard.

## Fix (self-contained in the builder)

- **Pin CP's vin[0]** (the ARC4 key input) at PSBT index 0 — move it to front if already selected, else fetch + prepend (funding UTXOs follow). `vin[0] == CP's vin[0] == ARC4 key` by construction.
- **Fail-closed ARC4 guard**: if an OP_RETURN is present it must decode from vin[0] (reuses `opReturnDecodesFromInput` from #1133); abort rather than broadcast an unindexable tx.
- **2 unit tests**: vin[0] pinned even when the selector orders it elsewhere; guard aborts on misalignment.

## Audit results (full endpoint sweep)

| Endpoint | Verdict |
|---|---|
| **fairmint, detach** | 🔴 was VULNERABLE → **fixed here** |
| send, attach | 🟢 SAFE (use CP's `vin[0]` directly) — 🟡 LATENT multi-input *funding* limit (only first CP input kept), tracked |
| dispense | 🟢 SAFE (iterates all CP inputs in order) |
| SRC-20, SRC-101 | 🟢 SAFE — self-consistent (`arc4(inputs[0].txid)` + inputs added in same order). Consensus rule confirmed against btc_stamps indexer. A *multisig-aware* defensive guard is deferred (they use multisig data outputs, not OP_RETURN). |
| stamp issuance | 🟢 fixed in #1133 |

## Follow-ups (not in this PR)
- Multisig-aware defensive guard for SRC-20/SRC-101 (defense-in-depth; validate vs SRC consensus + BIP construction first).
- LATENT multi-input funding in `send`/`attach` (funding correctness, not silent loss).
- Pre-existing nightly Newman "Database Required" scheduled-regression failure (separate, predates this work).

## Verification plan
Same as the stamp fix: post-deploy, compose a real fairmint (against an open fairminter) without broadcasting and confirm the OP_RETURN decodes from `vin[0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)