### PR TITLE
fix(tx): consolidate builder UTXO selection + free-fairminter quantity (fairmint/detach were broken)

### DIFF
--- a/routes/api/v2/fairmint/compose.ts
+++ b/routes/api/v2/fairmint/compose.ts
@@ -23,9 +23,12 @@ export const handler: Handlers = {
         dryRun,
       } = body;
 
-      if (!address || !asset || !quantity) {
+      // `quantity` is required for PAID fairminters but must be OMITTED for free
+      // ones (CP rejects it with "quantity is not allowed for free fairminters").
+      // It is validated conditionally below, after we know the fairminter's price.
+      if (!address || !asset) {
         return ResponseUtil.badRequest(
-          "Missing required fields: address, asset, quantity",
+          "Missing required fields: address, asset",
         );
       }
 
@@ -45,11 +48,29 @@ export const handler: Handlers = {
         delete xcpApiOptions.service_fee; // Not for XCP API call
         delete xcpApiOptions.service_fee_address; // Not for XCP API call
 
+        // Free fairminters reject `quantity`; paid ones require it. Decide based
+        // on the fairminter's price.
+        const fairminter = await CounterpartyApiManager.getAssetFairminter(
+          asset,
+        );
+        const isFreeFairminter = fairminter !== null && fairminter.price === 0;
+        if (
+          !isFreeFairminter &&
+          (quantity === undefined || quantity === null || quantity === "")
+        ) {
+          return ResponseUtil.badRequest(
+            "quantity is required for paid fairminters",
+          );
+        }
+        const effectiveQuantity = isFreeFairminter
+          ? undefined
+          : Number(quantity);
+
         // ✅ NEW CLEAN PATTERN: Get raw hex instead of PSBT
         const response = await CounterpartyApiManager.composeFairmint(
           address,
           asset,
-          quantity,
+          effectiveQuantity,
           {
             ...xcpApiOptions,
             return_psbt: false, // ✅ CHANGED: Get raw hex, not PSBT

--- a/server/services/counterpartyApiService.ts
+++ b/server/services/counterpartyApiService.ts
@@ -1553,7 +1553,10 @@ export class CounterpartyApiManager {
   static async composeFairmint(
     address: string,
     asset: string,
-    quantity: number,
+    // Optional: free fairminters REJECT quantity ("quantity is not allowed for
+    // free fairminters"); paid fairminters REQUIRE it. Callers pass undefined
+    // for free fairminters.
+    quantity: number | undefined,
     options: {
       encoding?: string;
       fee_per_kb?: number;
@@ -1584,7 +1587,9 @@ export class CounterpartyApiManager {
     const queryParams = new URLSearchParams();
 
     queryParams.append("asset", asset);
-    queryParams.append("quantity", quantity.toString());
+    if (quantity !== undefined && quantity !== null) {
+      queryParams.append("quantity", quantity.toString());
+    }
 
     // Set default options
     options.allow_unconfirmed_inputs = options.allow_unconfirmed_inputs ?? true;
@@ -1621,6 +1626,34 @@ export class CounterpartyApiManager {
     }
 
     throw new Error("All nodes failed to compose fairmint transaction.");
+  }
+
+  /**
+   * Look up the open fairminter for a single asset. The `price` field determines
+   * whether `compose/fairmint` must include `quantity` (free => omit, paid =>
+   * require). Returns null if none is open or all nodes are unreachable.
+   */
+  static async getAssetFairminter(
+    asset: string,
+  ): Promise<{ price: number; status: string } | null> {
+    const endpoint = `/assets/${encodeURIComponent(asset)}/fairminters`;
+    const queryParams = new URLSearchParams({ verbose: "true", status: "open" });
+    for (const node of XCP_V2_NODES) {
+      try {
+        const response = await httpClient.get(
+          `${node.url}${endpoint}?${queryParams.toString()}`,
+        );
+        if (response.ok) {
+          const fm = response.data?.result?.[0];
+          return fm
+            ? { price: Number(fm.price ?? 0), status: String(fm.status ?? "") }
+            : null;
+        }
+      } catch (_error) {
+        // try the next node
+      }
+    }
+    return null;
   }
 
   static async getFairminters(): Promise<Fairminter[]> {

--- a/server/services/transaction/generalBitcoinTransactionBuilder.ts
+++ b/server/services/transaction/generalBitcoinTransactionBuilder.ts
@@ -14,11 +14,10 @@ import { estimateMintingTransactionSize } from "$lib/utils/bitcoin/minting/trans
 import { extractOutputs } from "$lib/utils/bitcoin/minting/transactionUtils.ts";
 import { opReturnDecodesFromInput } from "$lib/utils/bitcoin/minting/counterpartyInputs.ts";
 import { getScriptTypeInfo } from "$lib/utils/bitcoin/scripts/scriptTypeUtils.ts";
-import { CounterpartyApiManager } from "$server/services/counterpartyApiService.ts";
 import { CommonUTXOService } from "$server/services/utxo/commonUtxoService.ts";
-import { OptimalUTXOSelection } from "$server/services/utxo/optimalUtxoSelection.ts";
+import { BitcoinUtxoManager } from "$server/services/transaction/bitcoinUtxoManager.ts";
 import type { ScriptType, UTXO } from "$types/base.d.ts";
-import { toBasicUTXOs, safeUTXOValue } from "$lib/utils/bitcoin/utxo/utxoTypeUtils.ts";
+import { safeUTXOValue } from "$lib/utils/bitcoin/utxo/utxoTypeUtils.ts";
 import * as bitcoin from "bitcoinjs-lib";
 import { Buffer } from "node:buffer";
 
@@ -48,6 +47,9 @@ export interface BitcoinTransactionGenerationResult {
 
 export class GeneralBitcoinTransactionBuilder {
   private static commonUtxoService = new CommonUTXOService();
+  // Canonical UTXO selector (same path stamp issuance uses). Selects on basic
+  // UTXOs then batch-fetches scripts ONLY for the selected ones.
+  private static utxoService = new BitcoinUtxoManager();
 
   /**
    * Universal PSBT generator for all Counterparty operations
@@ -170,58 +172,28 @@ export class GeneralBitcoinTransactionBuilder {
         });
       }
 
-      // Get UTXOs for funding
-      const fullUTXOs = await this.getFullUTXOsWithDetails(address, true, []);
-
-      if (fullUTXOs.length === 0) {
-        throw new Error(`No UTXOs available for ${operationType} operation`);
-      }
-
-      // Convert vouts for UTXO selection
-      const outputsForSelection = vouts.map(vout => ({
+      // Select funding UTXOs via the canonical BitcoinUtxoManager — the same
+      // path stamp issuance uses. It selects on basic UTXOs then batch-fetches
+      // scripts ONLY for the selected inputs (and hard-errors if a script is
+      // missing). The previous getFullUTXOsWithDetails fetched every UTXO's
+      // script up front AND then discarded them (script: undefined) before
+      // selection, so selected inputs were always scriptless -> "missing script"
+      // at addInput, which broke fairmint/detach entirely.
+      const outputsForSelection = vouts.map((vout) => ({
         value: vout.value,
-        script: vout.script ? Buffer.from(vout.script).toString('hex') : "",
-        ...(vout.address && { address: vout.address })
+        script: vout.script ? Buffer.from(vout.script).toString("hex") : "",
+        ...(vout.address && { address: vout.address }),
       }));
 
-      // Convert UTXOs to BasicUTXOs for the selection algorithm
-      const importedBasicUTXOs = toBasicUTXOs(fullUTXOs);
-
-      if (importedBasicUTXOs.length === 0) {
-        throw new Error(`No valid UTXOs available for ${operationType} operation`);
-      }
-
-      // Convert to the local BasicUTXO interface expected by OptimalUTXOSelection
-      const basicUTXOs = importedBasicUTXOs.map(utxo => {
-        const localBasicUTXO: any = {
-          txid: utxo.txid,
-          vout: utxo.vout,
-          value: utxo.value,
-          script: undefined,
-          scriptType: undefined,
-          scriptDesc: undefined,
-          confirmations: undefined
-        };
-        
-        // Only include address if it exists and is not undefined
-        if (utxo.address !== undefined) {
-          localBasicUTXO.address = utxo.address;
-        }
-        
-        return localBasicUTXO;
-      });
-
-      // Select optimal UTXOs
-      const selectionResult = OptimalUTXOSelection.selectUTXOs(
-        basicUTXOs,
-        outputsForSelection,
-        satsPerVB,
-        {
-          avoidChange: true,
-          consolidationMode: false,
-          dustThreshold: 1000
-        }
-      );
+      const selectionResult = await GeneralBitcoinTransactionBuilder.utxoService
+        .selectUTXOsForTransaction(
+          address,
+          outputsForSelection,
+          satsPerVB,
+          0, // sigops_rate
+          1.5, // rbfBuffer
+          { filterStampUTXOs: true, includeAncestors: true },
+        );
 
       // Pin Counterparty's vin[0] (the ARC4 OP_RETURN key input) at PSBT index 0.
       // CP encrypts the OP_RETURN against the txid of ITS first input, and the
@@ -409,72 +381,5 @@ export class GeneralBitcoinTransactionBuilder {
       });
       throw error;
     }
-  }
-
-  /**
-   * Get full UTXO details (copied from StampCreationService pattern)
-   */
-  private static async getFullUTXOsWithDetails(
-    address: string,
-    filterStampUTXOs: boolean = true,
-    excludeUtxos: Array<{ txid: string; vout: number }> = []
-  ): Promise<UTXO[]> {
-    let basicUtxos = await this.commonUtxoService.getSpendableUTXOs(address, undefined, {
-      includeAncestorDetails: true,
-      confirmedOnly: false
-    });
-
-    // Apply exclusions
-    if (excludeUtxos.length > 0) {
-      const excludeSet = new Set(excludeUtxos.map(u => `${u.txid}:${u.vout}`));
-      basicUtxos = basicUtxos.filter(utxo => !excludeSet.has(`${utxo.txid}:${utxo.vout}`));
-    }
-
-    // Filter stamp UTXOs if requested
-    if (filterStampUTXOs) {
-      try {
-        const stampBalances = await CounterpartyApiManager.getXcpBalancesByAddress(address, undefined, true);
-        const utxosToExcludeFromStamps = new Set<string>();
-        for (const balance of stampBalances.balances) {
-          if (balance.utxo) {
-            utxosToExcludeFromStamps.add(balance.utxo);
-          }
-        }
-        basicUtxos = basicUtxos.filter(
-          (utxo) => !utxosToExcludeFromStamps.has(`${utxo.txid}:${utxo.vout}`),
-        );
-      } catch (error) {
-        logger.error("api", {
-          message: "Error filtering stamp UTXOs",
-          address,
-          error: (error as any).message
-        });
-      }
-    }
-
-    // Get full details for all UTXOs
-    const fullUTXOs: UTXO[] = [];
-    for (const basicUtxo of basicUtxos) {
-      try {
-        const fullUtxo = await this.commonUtxoService.getSpecificUTXO(
-          basicUtxo.txid,
-          basicUtxo.vout,
-          { includeAncestorDetails: true }
-        );
-
-        if (fullUtxo && fullUtxo.script && fullUtxo.value !== undefined && fullUtxo.value > 0) {
-          fullUTXOs.push(fullUtxo);
-        }
-      } catch (error) {
-        logger.warn("api", {
-          message: "Skipping UTXO due to fetch error",
-          txid: basicUtxo.txid,
-          vout: basicUtxo.vout,
-          error: (error as any).message
-        });
-      }
-    }
-
-    return fullUTXOs;
   }
 }

--- a/tests/unit/generalBitcoinTransactionBuilder.test.ts
+++ b/tests/unit/generalBitcoinTransactionBuilder.test.ts
@@ -5,7 +5,6 @@ import { Buffer } from "node:buffer";
 import { arc4 } from "$lib/utils/bitcoin/minting/transactionUtils.ts";
 import { hex2bin } from "$lib/utils/data/binary/baseUtils.ts";
 import { GeneralBitcoinTransactionBuilder } from "$server/services/transaction/generalBitcoinTransactionBuilder.ts";
-import { OptimalUTXOSelection } from "$server/services/utxo/optimalUtxoSelection.ts";
 
 // Synthetic txids (repeat() so no 64-char hex literal trips the secret-leak guard).
 const TXID_A = "a1".repeat(32); // Counterparty's vin[0] = the ARC4 key input
@@ -46,16 +45,11 @@ function vin0Txid(psbt: bitcoin.Psbt): string {
 
 Deno.test("generatePSBT - pins Counterparty vin[0] at PSBT index 0 even when the selector orders it elsewhere", async () => {
   const cpRawHex = buildCpRawHex(TXID_A, true);
-  // Selector returns CP's vin[0] (utxo A) NOT first — the builder must move it to index 0.
+  // Canonical selector returns CP's vin[0] (utxo A) NOT first — builder pins it to index 0.
   const selStub = stub(
-    OptimalUTXOSelection,
-    "selectUTXOs",
-    () => ({ inputs: [utxo(TXID_B), utxo(TXID_A)], change: 0, fee: 1000 }) as any,
-  );
-  const poolStub = stub(
-    GeneralBitcoinTransactionBuilder as any,
-    "getFullUTXOsWithDetails",
-    () => Promise.resolve([utxo(TXID_A), utxo(TXID_B)]),
+    (GeneralBitcoinTransactionBuilder as any).utxoService,
+    "selectUTXOsForTransaction",
+    () => Promise.resolve({ inputs: [utxo(TXID_B), utxo(TXID_A)], change: 0, fee: 1000 }),
   );
   try {
     const res = await GeneralBitcoinTransactionBuilder.generatePSBT(cpRawHex, {
@@ -70,7 +64,6 @@ Deno.test("generatePSBT - pins Counterparty vin[0] at PSBT index 0 even when the
     assert(res.psbt.txInputs.length === 2);
   } finally {
     selStub.restore();
-    poolStub.restore();
   }
 });
 
@@ -80,14 +73,9 @@ Deno.test("generatePSBT - fail-closed ARC4 guard aborts when vin[0] is NOT the O
   // TXID_A — the indexer would silently drop it, so the guard MUST throw.
   const cpRawHex = buildCpRawHex(TXID_A, false);
   const selStub = stub(
-    OptimalUTXOSelection,
-    "selectUTXOs",
-    () => ({ inputs: [utxo(TXID_B)], change: 0, fee: 1000 }) as any,
-  );
-  const poolStub = stub(
-    GeneralBitcoinTransactionBuilder as any,
-    "getFullUTXOsWithDetails",
-    () => Promise.resolve([utxo(TXID_B)]),
+    (GeneralBitcoinTransactionBuilder as any).utxoService,
+    "selectUTXOsForTransaction",
+    () => Promise.resolve({ inputs: [utxo(TXID_B)], change: 0, fee: 1000 }),
   );
   try {
     await assertRejects(
@@ -103,6 +91,5 @@ Deno.test("generatePSBT - fail-closed ARC4 guard aborts when vin[0] is NOT the O
     );
   } finally {
     selStub.restore();
-    poolStub.restore();
   }
 });


### PR DESCRIPTION
## Summary

While verifying the ARC4 fix (#1135) on prod, fairmint/detach compose returned 500s. Investigation (prompted by "do we have duplicate UTXO code?") found **two pre-existing bugs** that have kept fairmint/detach broken — unrelated to the ARC4 work.

## Bug A — duplicate + broken UTXO selection in the shared builder

`GeneralBitcoinTransactionBuilder` had its **own** `getFullUTXOsWithDetails` (one of **3 duplicates** — also in SRC-20 & SRC-101) that:
1. fetched **every** UTXO's script up front (wasteful, one `getSpecificUTXO` per UTXO), then
2. **discarded them** — `script: undefined` (line ~200) — before selection, so
3. every selected input was scriptless → `addInput` always threw `"Input UTXO … is missing script"`.

So fairmint/detach **never worked**. (Stamp issuance works because it uses the canonical `BitcoinUtxoManager`; SRC-20 mint works via its own path — verified live with `punks` → 200.)

**Fix:** replace that path with the canonical `BitcoinUtxoManager.selectUTXOsForTransaction` (select on basic UTXOs, then **batch-fetch scripts only for the selected ones**, hard-erroring if any is missing). Deleted the duplicate `getFullUTXOsWithDetails` and now-dead imports. The ARC4 `vin[0]` pinning + fail-closed guard from #1135 are preserved. Builder: **453 → ~340 lines**.

## Bug B — free fairminters rejected `quantity`

The route always required+sent `quantity`, but CP **rejects** it for free fairminters (`"quantity is not allowed for free fairminters"`) and **requires** it for paid ones. Fix: look up the fairminter price (`CounterpartyApiManager.getAssetFairminter`) and pass `quantity` only for paid fairminters; `composeFairmint`'s `quantity` is now optional.

## Tests
Builder unit tests updated to stub the canonical selector — both pass (vin[0] pinned even when selector reorders; guard aborts on misalignment).

## Follow-up
SRC-20 & SRC-101 still have their own `getFullUTXOsWithDetails` copies. They currently **work**, so consolidating them to `BitcoinUtxoManager` is cleanup/defense-in-depth, not urgent — worth a follow-up issue.

## Post-deploy verification
This should finally make fairmint/detach compose work — verify by composing a free (`TRUDEEPEPE`) and a paid (`THREEIATLAS`) fairmint (no broadcast) and confirming the OP_RETURN decodes from `vin[0]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)