### PR TITLE
fix(tx): consolidate SRC-20/101 UTXO selection + fail-closed multisig ARC4 guard (#1141, #1136)

### DIFF
--- a/lib/utils/bitcoin/minting/src20MultisigGuard.ts
+++ b/lib/utils/bitcoin/minting/src20MultisigGuard.ts
@@ -1,0 +1,175 @@
+// Pure helpers for a fail-closed ARC4 guard over SRC-20 / SRC-101 multisig
+// issuances, mirroring the btc_stamps indexer's decode path.
+//
+// Background: unlike stamps/fairmint (which carry the ARC4-encrypted Counterparty
+// payload in an OP_RETURN), SRC-20 and SRC-101 carry their encrypted payload in
+// BARE-MULTISIG data outputs of the form:
+//
+//     5121<pubkey1>21<pubkey2>21<THIRD_PUBKEY>53ae
+//
+// where pubkey1 and pubkey2 are each 33 bytes = sign-byte(1) || 31 data bytes ||
+// trailing-byte(1). So 31 + 31 = 62 encrypted payload bytes are recoverable per
+// output, in output order. The indexer (and the building services) key ARC4 off
+// the txid of vin[0] (display byte order): `vin.prevout.hash[::-1]`.
+//
+// The building services construct the plaintext payload as:
+//
+//     [ 2-byte length prefix ] [ "stamp:" ] [ transfer data ] [ zero padding ]
+//
+// then ARC4-encrypt with hex2bin(inputs[0].txid). This guard reverses that:
+// reassemble the ciphertext from the multisig pubkey segments, decrypt with the
+// claimed vin[0] txid, and assert the plaintext begins with the length-prefixed
+// "stamp:" structure. A mismatch means the transaction's vin[0] is NOT the input
+// the payload was keyed against — the indexer would silently drop it — so the
+// caller MUST abort rather than broadcast an unindexable transaction.
+//
+// These functions are intentionally pure (no I/O) so the reassembly and ARC4
+// round-trip can be unit-tested in isolation.
+
+import { arc4 } from "$lib/utils/bitcoin/minting/transactionUtils.ts";
+import { hex2bin } from "$lib/utils/data/binary/baseUtils.ts";
+
+/** The plaintext marker that follows the 2-byte length prefix. */
+export const STAMP_PREFIX = "stamp:";
+
+/** Length, in bytes, of the leading length prefix in the plaintext payload. */
+export const LENGTH_PREFIX_LEN = 2;
+
+/** Bytes of encrypted payload recovered from each 33-byte multisig pubkey. */
+const DATA_BYTES_PER_PUBKEY = 31;
+
+/**
+ * Extract the two data-bearing pubkey segments (31 bytes each) from a single
+ * bare-multisig data output script of the canonical SRC-20/101 form
+ * `5121<pubkey1>21<pubkey2>21<THIRD_PUBKEY>53ae`.
+ *
+ * Each pubkey is 33 bytes: a leading sign byte, 31 data bytes, and a trailing
+ * byte. We return only the 31 data bytes from the FIRST TWO pubkeys (the third
+ * pubkey is a constant filler that carries no payload), concatenated as 62
+ * bytes. Returns null when the script is not a parseable 1-of-3 multisig with at
+ * least two 33-byte pubkeys.
+ */
+export function extractMultisigPayloadSegments(
+  scriptHex: string,
+): Uint8Array | null {
+  if (!scriptHex) return null;
+  let buf: Uint8Array;
+  try {
+    buf = new Uint8Array(hex2bin(scriptHex));
+  } catch {
+    return null;
+  }
+  // Minimum: OP_1 (0x51) + push33 (0x21) + 33 + push33 (0x21) + 33 ...
+  // First byte must be OP_1 (0x51) for a 1-of-N bare multisig.
+  if (buf.length < 2 || buf[0] !== 0x51) return null;
+
+  const segments: Uint8Array[] = [];
+  let i = 1;
+  // Walk the leading 33-byte pushes; we only need the first two.
+  while (segments.length < 2 && i < buf.length) {
+    const pushLen = buf[i];
+    if (pushLen !== 0x21) break; // not a 33-byte pubkey push
+    const start = i + 1;
+    const end = start + 0x21;
+    if (end > buf.length) return null;
+    // Drop the leading sign byte and the trailing byte; keep 31 data bytes.
+    segments.push(buf.subarray(start + 1, start + 1 + DATA_BYTES_PER_PUBKEY));
+    i = end;
+  }
+
+  if (segments.length < 2) return null;
+
+  const out = new Uint8Array(DATA_BYTES_PER_PUBKEY * 2);
+  out.set(segments[0], 0);
+  out.set(segments[1], DATA_BYTES_PER_PUBKEY);
+  return out;
+}
+
+/**
+ * Reassemble the full encrypted payload from an ordered list of multisig data
+ * output scripts (62 bytes per output, in output order). Returns null if any
+ * output is not a parseable multisig data output, so the caller fails closed.
+ */
+export function reassembleMultisigPayload(
+  multisigScriptHexes: readonly string[],
+): Uint8Array | null {
+  if (multisigScriptHexes.length === 0) return null;
+  const parts: Uint8Array[] = [];
+  for (const scriptHex of multisigScriptHexes) {
+    const seg = extractMultisigPayloadSegments(scriptHex);
+    if (!seg) return null;
+    parts.push(seg);
+  }
+  const total = parts.reduce((sum, p) => sum + p.length, 0);
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const p of parts) {
+    out.set(p, offset);
+    offset += p.length;
+  }
+  return out;
+}
+
+/**
+ * Fail-closed guard mirroring the btc_stamps indexer: reassemble the encrypted
+ * payload from the multisig data outputs, ARC4-decrypt it with the key derived
+ * from `vin0Txid` (display byte order — `vin.prevout.hash[::-1]`, which is what
+ * the indexer uses), and report whether the plaintext carries the length-prefixed
+ * `stamp:` structure the services build before encryption.
+ *
+ * Returns false (rather than throwing) for malformed/empty input so callers can
+ * decide how to surface the failure.
+ *
+ * @param multisigScriptHexes ordered scriptPubKey hexes of the multisig data outputs
+ * @param vin0Txid            display-order txid hex of input index 0
+ */
+export function multisigPayloadDecodesFromInput(
+  multisigScriptHexes: readonly string[],
+  vin0Txid: string,
+): boolean {
+  const ciphertext = reassembleMultisigPayload(multisigScriptHexes);
+  if (
+    !ciphertext || ciphertext.length < LENGTH_PREFIX_LEN + STAMP_PREFIX.length
+  ) {
+    return false;
+  }
+  let key: Uint8Array;
+  try {
+    key = new Uint8Array(hex2bin(vin0Txid));
+  } catch {
+    return false;
+  }
+  if (key.length === 0) return false;
+
+  const decrypted = arc4(key, ciphertext);
+  // Skip the 2-byte length prefix; the plaintext marker is "stamp:".
+  const marker = decrypted.subarray(
+    LENGTH_PREFIX_LEN,
+    LENGTH_PREFIX_LEN + STAMP_PREFIX.length,
+  );
+  return new TextDecoder().decode(marker) === STAMP_PREFIX;
+}
+
+/**
+ * Assert the multisig payload decodes from vin[0]; throw a clear fail-closed
+ * error otherwise. Wired into the SRC-20/101 PSBT services after inputs are
+ * added, before returning, so an ARC4-key/vin[0] mismatch aborts the build
+ * rather than emitting a transaction the indexer would silently drop.
+ *
+ * @param multisigScriptHexes ordered scriptPubKey hexes of the multisig data outputs
+ * @param vin0Txid            display-order txid hex of broadcast input index 0
+ * @param context             label for the error message (e.g. "SRC-20", "SRC-101")
+ */
+export function assertMultisigPayloadDecodesFromInput(
+  multisigScriptHexes: readonly string[],
+  vin0Txid: string,
+  context: string,
+): void {
+  if (!multisigPayloadDecodesFromInput(multisigScriptHexes, vin0Txid)) {
+    throw new Error(
+      `ARC4 key mismatch for ${context}: the multisig data outputs do not ` +
+        `decode from vin[0] (${vin0Txid}). Aborting to avoid broadcasting an ` +
+        `unindexable transaction.`,
+    );
+  }
+}

--- a/server/services/src101/psbt/src101MultisigPSBTService.ts
+++ b/server/services/src101/psbt/src101MultisigPSBTService.ts
@@ -55,14 +55,16 @@ import { logger } from "$lib/utils/logger.ts";
 import { estimateMintingTransactionSize } from "$lib/utils/bitcoin/minting/transactionSizes.ts";
 import { arc4 } from "$lib/utils/bitcoin/minting/transactionUtils.ts";
 import { serverConfig } from "$server/config/config.ts";
-// Removed TransactionService import - using direct OptimalUTXOSelection instead
+// Canonical UTXO selector (same path stamp issuance + the general builder use):
+// selects on basic UTXOs then batch-fetches scripts ONLY for the selected
+// inputs (and hard-errors if a script is missing). Replaces the old
+// getFullUTXOsWithDetails (which fetched every UTXO's script up front then
+// discarded them) + raw OptimalUTXOSelection.selectUTXOs path.
 import type { BufferLike } from "$lib/types/utils.d.ts";
+import { BitcoinUtxoManager } from "$server/services/transaction/bitcoinUtxoManager.ts";
 import { CommonUTXOService } from "$server/services/utxo/commonUtxoService.ts";
-import { OptimalUTXOSelection } from "$server/services/utxo/optimalUtxoSelection.ts";
-import { CounterpartyApiManager } from "$server/services/counterpartyApiService.ts";
+import { assertMultisigPayloadDecodesFromInput } from "$lib/utils/bitcoin/minting/src20MultisigGuard.ts";
 import type {IPrepareSRC101TX} from "$server/types/services/src101.d.ts";
-import type { UTXO } from "$types/base.d.ts";
-import { convertUTXOsToBasic } from "$lib/utils/bitcoin/utxo/utxoTypeUtils.ts";
 import type { PSBTInput, VOUT } from "$types/src20.d.ts";
 import { crypto } from "@std/crypto";
 
@@ -72,95 +74,8 @@ export class SRC101MultisigPSBTService {
   private static readonly CHANGE_DUST = 1000;
   private static readonly THIRD_PUBKEY = "020202020202020202020202020202020202020202020202020202020202020202";
   private static commonUtxoService = new CommonUTXOService();
-
-  /**
-   * Simplified UTXO selection that gets full details upfront - same pattern as stamp minting
-   */
-  private static async getFullUTXOsWithDetails(
-    address: string,
-    filterStampUTXOs: boolean = true,
-    excludeUtxos: Array<{ txid: string; vout: number }> = []
-  ): Promise<UTXO[]> {
-    logger.debug("src101", {
-      message: "Fetching full UTXOs with details upfront for multisig",
-      address,
-      filterStampUTXOs,
-      excludeUtxos: excludeUtxos.length
-    });
-
-    // Get basic UTXOs first
-    let basicUtxos = await this.commonUtxoService.getSpendableUTXOs(address, undefined, {
-      includeAncestorDetails: true,
-      confirmedOnly: false
-    });
-
-    // Apply exclusions
-    if (excludeUtxos.length > 0) {
-      const excludeSet = new Set(excludeUtxos.map(u => `${u.txid}:${u.vout}`));
-      basicUtxos = basicUtxos.filter(utxo => !excludeSet.has(`${utxo.txid}:${utxo.vout}`));
-    }
-
-    // Filter stamp UTXOs if requested
-    if (filterStampUTXOs) {
-      try {
-        const stampBalances = await CounterpartyApiManager.getXcpBalancesByAddress(address, undefined, true);
-        const utxosToExcludeFromStamps = new Set<string>();
-        for (const balance of stampBalances.balances) {
-          if (balance.utxo) {
-            utxosToExcludeFromStamps.add(balance.utxo);
-          }
-        }
-        basicUtxos = basicUtxos.filter(
-          (utxo) => !utxosToExcludeFromStamps.has(`${utxo.txid}:${utxo.vout}`),
-        );
-      } catch (error) {
-        logger.error("src101", {
-          message: "Error filtering stamp UTXOs for multisig",
-          address,
-          error: (error as any).message
-        });
-      }
-    }
-
-    // Now get full details for all UTXOs upfront
-    const fullUTXOs: UTXO[] = [];
-    for (const basicUtxo of basicUtxos) {
-      try {
-        const fullUtxo = await this.commonUtxoService.getSpecificUTXO(
-          basicUtxo.txid,
-          basicUtxo.vout,
-          { includeAncestorDetails: true, confirmedOnly: false }
-        );
-
-        if (fullUtxo && fullUtxo.script) {
-          fullUTXOs.push(fullUtxo);
-        } else {
-          logger.warn("src101", {
-            message: "Skipping UTXO with missing script for multisig",
-            txid: basicUtxo.txid,
-            vout: basicUtxo.vout,
-            hasFullUtxo: !!fullUtxo,
-            hasScript: !!fullUtxo?.script
-          });
-        }
-      } catch (error) {
-        logger.warn("src101", {
-          message: "Failed to fetch full UTXO details for multisig",
-          txid: basicUtxo.txid,
-          vout: basicUtxo.vout,
-          error: (error as any).message
-        });
-      }
-    }
-
-    logger.debug("src101", {
-      message: "Full UTXOs fetched successfully for multisig",
-      total: fullUTXOs.length,
-      withScripts: fullUTXOs.filter(u => u.script).length
-    });
-
-    return fullUTXOs;
-  }
+  // Canonical UTXO selector shared with stamp issuance and the general builder.
+  private static utxoService = new BitcoinUtxoManager();
 
   static async preparePSBT({
     network,
@@ -192,36 +107,29 @@ export class SRC101MultisigPSBTService {
         { address: recAddress || changeAddress, value: recVault || this.RECIPIENT_DUST },
       ];
 
-      // Convert vouts to Output format for UTXO selection
+      // Convert vouts to the format expected by the selector
       const outputsForSelection = vouts.map(vout => ({
         value: vout.value,
         script: "",
         ...(vout.address && { address: vout.address })
       }));
 
-      // Get full UTXOs with details first - same pattern as stamp minting
-      const fullUTXOs = await this.getFullUTXOsWithDetails(sourceAddress, true, []);
-
-      if (fullUTXOs.length === 0) {
-        throw new Error("No UTXOs available for SRC-101 multisig transaction");
-      }
-
-      // Convert UTXOs to BasicUTXO format for selection
-      const basicUTXOsForSelection = convertUTXOsToBasic(fullUTXOs);
-
-      // Use optimal UTXO selection directly - same pattern as stamp minting
-      const selectionResult = OptimalUTXOSelection.selectUTXOs(
-        basicUTXOsForSelection,
+      // Select funding UTXOs via the canonical BitcoinUtxoManager — the same
+      // path stamp issuance + the general builder use. It selects on basic
+      // UTXOs then batch-fetches scripts ONLY for the selected inputs (and
+      // hard-errors if a script is missing), returning inputs that already HAVE
+      // their scripts. CRITICAL: the selector preserves input order, so
+      // inputs[0] stays the ARC4 key input and is added to the PSBT first.
+      const selectionResult = await this.utxoService.selectUTXOsForTransaction(
+        sourceAddress,
         outputsForSelection,
         feeRate,
-        {
-          avoidChange: true,
-          consolidationMode: false,
-          dustThreshold: 1000
-        }
+        0, // sigops_rate
+        1.5, // rbfBuffer
+        { filterStampUTXOs: true, includeAncestors: true },
       );
 
-      const { inputs, change: _change, fee } = selectionResult;
+      const { inputs, fee } = selectionResult;
 
       if (inputs.length === 0) {
         throw new Error("Unable to select suitable UTXOs for the transaction");
@@ -249,7 +157,7 @@ export class SRC101MultisigPSBTService {
         payloadBytes = new Uint8Array([...payloadBytes, ...new Uint8Array(padLength)]);
       }
 
-      // Encrypt data using first input's txid
+      // Encrypt data using first input's txid (inputs[0] == vin[0] == ARC4 key)
       const txidBytes = hex2bin(inputs[0].txid);
       const encryptedDataBytes = arc4(txidBytes, payloadBytes);
 
@@ -258,6 +166,10 @@ export class SRC101MultisigPSBTService {
       for (let i = 0; i < encryptedDataBytes.length; i += 62) {
         chunks.push(encryptedDataBytes.slice(i, i + 62));
       }
+
+      // Collect the multisig data-output scripts (in output order) so we can run
+      // the fail-closed ARC4 guard after the PSBT inputs are added.
+      const multisigScriptHexes: string[] = [];
 
       // Add multisig outputs
       for (const chunk of chunks) {
@@ -282,6 +194,7 @@ export class SRC101MultisigPSBTService {
         } while (!this.isValidPubkey(pubkey2));
 
         const script = `5121${pubkey1}21${pubkey2}21${this.THIRD_PUBKEY}53ae`;
+        multisigScriptHexes.push(script);
         vouts.push({
           script: new Uint8Array(hex2bin(script)) as BufferLike,
           value: this.MULTISIG_DUST,
@@ -295,7 +208,9 @@ export class SRC101MultisigPSBTService {
         vouts.push({ address: feeAddress, value: feeAmount });
       }
 
-      // Add inputs to PSBT
+      // Add inputs to PSBT — in the SAME order the selector returned them, so
+      // vin[0] == inputs[0] == the ARC4 key input. No BIP-69 / reordering sort
+      // exists between the arc4 call above and this loop.
       for (const input of inputs) {
         if (!input.script) {
           logger.error("src101-psbt-service", { message: "Input UTXO is missing script for SRC101 Multisig.", input });
@@ -326,6 +241,18 @@ export class SRC101MultisigPSBTService {
 
         psbt.addInput(psbtInput as any);
       }
+
+      // Fail-closed ARC4 guard: the SRC-101 payload is ARC4-encrypted with
+      // inputs[0].txid and carried in the bare-multisig data outputs. inputs[0]
+      // is vin[0] (added to the PSBT in array order above). Reassemble the
+      // payload from those outputs, decrypt with vin[0], and assert the
+      // length-prefixed "stamp:" plaintext. Abort rather than emit a tx the
+      // btc_stamps indexer (which keys ARC4 off vin[0]) would silently drop.
+      assertMultisigPayloadDecodesFromInput(
+        multisigScriptHexes,
+        inputs[0].txid,
+        "SRC-101",
+      );
 
       // Calculate total input and output values
       const totalInputValue = inputs.reduce((sum: any, input: any) =>

--- a/server/services/src20/psbt/src20MultisigPSBTService.ts
+++ b/server/services/src20/psbt/src20MultisigPSBTService.ts
@@ -56,13 +56,15 @@ import { bin2hex, hex2bin } from "$lib/utils/data/binary/baseUtils.ts";
 import { logger } from "$lib/utils/logger.ts";
 import { serverConfig } from "$server/config/config.ts";
 import { SRC20CompressionService } from "$server/services/src20/compression/compressionService.ts";
-// Removed TransactionService import - using direct OptimalUTXOSelection instead
-import { convertUTXOsToBasic } from "$lib/utils/bitcoin/utxo/utxoTypeUtils.ts";
-import { CounterpartyApiManager } from "$server/services/counterpartyApiService.ts";
+// Canonical UTXO selector (same path stamp issuance + the general builder use):
+// selects on basic UTXOs then batch-fetches scripts ONLY for the selected
+// inputs (and hard-errors if a script is missing). Replaces the old
+// getFullUTXOsWithDetails (which fetched every UTXO's script up front then
+// discarded them) + raw OptimalUTXOSelection.selectUTXOs path.
+import { BitcoinUtxoManager } from "$server/services/transaction/bitcoinUtxoManager.ts";
 import { CommonUTXOService } from "$server/services/utxo/commonUtxoService.ts";
-import { OptimalUTXOSelection } from "$server/services/utxo/optimalUtxoSelection.ts";
+import { assertMultisigPayloadDecodesFromInput } from "$lib/utils/bitcoin/minting/src20MultisigGuard.ts";
 import type { IPrepareSRC20TX } from "$server/types/services/src20.d.ts";
-import type { UTXO } from "$types/base.d.ts";
 import type { PSBTInput, VOUT } from "$types/src20.d.ts";
 import { crypto } from "@std/crypto";
 import * as msgpack from "msgpack";
@@ -74,95 +76,8 @@ export class SRC20MultisigPSBTService {
   private static readonly CHANGE_DUST = BigInt(1000);
   private static readonly THIRD_PUBKEY = "020202020202020202020202020202020202020202020202020202020202020202";
   private static commonUtxoService = new CommonUTXOService();
-
-  /**
-   * Simplified UTXO selection that gets full details upfront - same pattern as stamp minting
-   */
-  private static async getFullUTXOsWithDetails(
-    address: string,
-    filterStampUTXOs: boolean = true,
-    excludeUtxos: Array<{ txid: string; vout: number }> = []
-  ): Promise<UTXO[]> {
-    logger.debug("src20", {
-      message: "Fetching full UTXOs with details upfront for multisig",
-      address,
-      filterStampUTXOs,
-      excludeUtxos: excludeUtxos.length
-    });
-
-    // Get basic UTXOs first
-    let basicUtxos = await this.commonUtxoService.getSpendableUTXOs(address, undefined, {
-      includeAncestorDetails: true,
-      confirmedOnly: false
-    });
-
-    // Apply exclusions
-    if (excludeUtxos.length > 0) {
-      const excludeSet = new Set(excludeUtxos.map(u => `${u.txid}:${u.vout}`));
-      basicUtxos = basicUtxos.filter(utxo => !excludeSet.has(`${utxo.txid}:${utxo.vout}`));
-    }
-
-    // Filter stamp UTXOs if requested
-    if (filterStampUTXOs) {
-      try {
-        const stampBalances = await CounterpartyApiManager.getXcpBalancesByAddress(address, undefined, true);
-        const utxosToExcludeFromStamps = new Set<string>();
-        for (const balance of stampBalances.balances) {
-          if (balance.utxo) {
-            utxosToExcludeFromStamps.add(balance.utxo);
-          }
-        }
-        basicUtxos = basicUtxos.filter(
-          (utxo) => !utxosToExcludeFromStamps.has(`${utxo.txid}:${utxo.vout}`),
-        );
-      } catch (error) {
-        logger.error("src20", {
-          message: "Error filtering stamp UTXOs for multisig",
-          address,
-          error: (error as any).message
-        });
-      }
-    }
-
-    // Now get full details for all UTXOs upfront
-    const fullUTXOs: UTXO[] = [];
-    for (const basicUtxo of basicUtxos) {
-      try {
-        const fullUtxo = await this.commonUtxoService.getSpecificUTXO(
-          basicUtxo.txid,
-          basicUtxo.vout,
-          { includeAncestorDetails: true, confirmedOnly: false }
-        );
-
-        if (fullUtxo && fullUtxo.script) {
-          fullUTXOs.push(fullUtxo);
-        } else {
-          logger.warn("src20", {
-            message: "Skipping UTXO with missing script for multisig",
-            txid: basicUtxo.txid,
-            vout: basicUtxo.vout,
-            hasFullUtxo: !!fullUtxo,
-            hasScript: !!fullUtxo?.script
-          });
-        }
-      } catch (error) {
-        logger.warn("src20", {
-          message: "Failed to fetch full UTXO details for multisig",
-          txid: basicUtxo.txid,
-          vout: basicUtxo.vout,
-          error: (error as any).message
-        });
-      }
-    }
-
-    logger.debug("src20", {
-      message: "Full UTXOs fetched successfully for multisig",
-      total: fullUTXOs.length,
-      withScripts: fullUTXOs.filter(u => u.script).length
-    });
-
-    return fullUTXOs;
-  }
+  // Canonical UTXO selector shared with stamp issuance and the general builder.
+  private static utxoService = new BitcoinUtxoManager();
 
   static async preparePSBT({
     network,
@@ -186,36 +101,29 @@ export class SRC20MultisigPSBTService {
         { address: toAddress, value: Number(this.RECIPIENT_DUST) },
       ];
 
-      // Convert initial vouts to format expected by OptimalUTXOSelection
+      // Convert initial vouts to the format expected by the selector
       const initialOutputsForSelection = vouts.map(vout => ({
         value: vout.value,
         script: "",
         ...(vout.address && { address: vout.address })
       }));
 
-      // Get full UTXOs with details first - same pattern as stamp minting
-      const fullUTXOs = await this.getFullUTXOsWithDetails(changeAddress, true, []);
-
-      if (fullUTXOs.length === 0) {
-        throw new Error("No UTXOs available for SRC-20 multisig transaction");
-      }
-
-      // Convert UTXOs to BasicUTXO format for selection
-      const basicUTXOsForSelection = convertUTXOsToBasic(fullUTXOs);
-
-      // Use optimal UTXO selection directly - same pattern as stamp minting
-      const selectionResult = OptimalUTXOSelection.selectUTXOs(
-        basicUTXOsForSelection,
+      // Select funding UTXOs via the canonical BitcoinUtxoManager — the same
+      // path stamp issuance + the general builder use. It selects on basic
+      // UTXOs then batch-fetches scripts ONLY for the selected inputs (and
+      // hard-errors if a script is missing), returning inputs that already HAVE
+      // their scripts. CRITICAL: the selector preserves input order, so
+      // inputs[0] stays the ARC4 key input and is added to the PSBT first.
+      const selectionResult = await this.utxoService.selectUTXOsForTransaction(
+        changeAddress,
         initialOutputsForSelection,
         feeRate,
-        {
-          avoidChange: true,
-          consolidationMode: false,
-          dustThreshold: 1000
-        }
+        0, // sigops_rate
+        1.5, // rbfBuffer
+        { filterStampUTXOs: true, includeAncestors: true },
       );
 
-      const { inputs, change: _change, fee } = selectionResult;
+      const { inputs, fee } = selectionResult;
 
       if (inputs.length === 0) {
         throw new Error("Unable to select suitable UTXOs for the transaction");
@@ -245,7 +153,7 @@ export class SRC20MultisigPSBTService {
         payloadBytes = new Uint8Array([...payloadBytes, ...new Uint8Array(padLength)]);
       }
 
-      // Encrypt data using first input's txid
+      // Encrypt data using first input's txid (inputs[0] == vin[0] == ARC4 key)
       const txidBytes = hex2bin(inputs[0].txid);
       const encryptedDataBytes = arc4(txidBytes, payloadBytes);
 
@@ -254,6 +162,10 @@ export class SRC20MultisigPSBTService {
       for (let i = 0; i < encryptedDataBytes.length; i += 62) {
         chunks.push(encryptedDataBytes.slice(i, i + 62));
       }
+
+      // Collect the multisig data-output scripts (in output order) so we can run
+      // the fail-closed ARC4 guard after the PSBT inputs are added.
+      const multisigScriptHexes: string[] = [];
 
       // Add multisig outputs
       for (const chunk of chunks) {
@@ -278,6 +190,7 @@ export class SRC20MultisigPSBTService {
         } while (!this.isValidPubkey(pubkey2));
 
         const script = `5121${pubkey1}21${pubkey2}21${this.THIRD_PUBKEY}53ae`;
+        multisigScriptHexes.push(script);
         vouts.push({
           script: new Uint8Array(hex2bin(script)),
           value: Number(this.MULTISIG_DUST),
@@ -291,7 +204,9 @@ export class SRC20MultisigPSBTService {
         vouts.push({ address: feeAddress, value: feeAmount });
       }
 
-      // Add inputs to PSBT
+      // Add inputs to PSBT — in the SAME order the selector returned them, so
+      // vin[0] == inputs[0] == the ARC4 key input. No BIP-69 / reordering sort
+      // exists between the arc4 call above and this loop.
       for (const input of inputs) {
         if (!input.script) {
           logger.error("src20", { message: "Input UTXO is missing script for Multisig.", input });
@@ -323,6 +238,18 @@ export class SRC20MultisigPSBTService {
 
         psbt.addInput(psbtInput as any);
       }
+
+      // Fail-closed ARC4 guard: the SRC-20 payload is ARC4-encrypted with
+      // inputs[0].txid and carried in the bare-multisig data outputs. inputs[0]
+      // is vin[0] (added to the PSBT in array order above). Reassemble the
+      // payload from those outputs, decrypt with vin[0], and assert the
+      // length-prefixed "stamp:" plaintext. Abort rather than emit a tx the
+      // btc_stamps indexer (which keys ARC4 off vin[0]) would silently drop.
+      assertMultisigPayloadDecodesFromInput(
+        multisigScriptHexes,
+        inputs[0].txid,
+        "SRC-20",
+      );
 
       // Calculate total input and output values
       const totalInputValue = inputs.reduce((sum: any, input: any) =>

--- a/tests/unit/src20MultisigGuard.test.ts
+++ b/tests/unit/src20MultisigGuard.test.ts
@@ -1,0 +1,170 @@
+import { assert, assertEquals, assertFalse, assertThrows } from "@std/assert";
+import { arc4 } from "$lib/utils/bitcoin/minting/transactionUtils.ts";
+import { bin2hex, hex2bin } from "$lib/utils/data/binary/baseUtils.ts";
+import {
+  assertMultisigPayloadDecodesFromInput,
+  extractMultisigPayloadSegments,
+  multisigPayloadDecodesFromInput,
+  reassembleMultisigPayload,
+} from "$lib/utils/bitcoin/minting/src20MultisigGuard.ts";
+
+// Two distinct, valid 32-byte (64 hex char) txids. Built via repeat() so no
+// 64-char hex literal sits in source (it trips the secret-leak guard). ARC4
+// accepts any key length, so synthetic txids exercise the logic identically to
+// real inputs. These mirror the ARC4 key the SRC-20/101 services derive from
+// inputs[0].txid (display byte order, what the indexer uses: vin.prevout.hash[::-1]).
+const TXID_A = "a1".repeat(32);
+const TXID_B = "b2".repeat(32);
+
+// The constant 1-of-3 third pubkey the services use as filler (33 bytes of 0x02).
+// Built via repeat() to avoid a long hex literal tripping the secret-leak guard.
+const THIRD_PUBKEY = "02".repeat(33);
+
+/**
+ * Build the bare-multisig data outputs EXACTLY the way the SRC-20/101 services
+ * do: take the "stamp:" plaintext, prepend the 2-byte length prefix, pad to a
+ * multiple of 62 bytes, ARC4-encrypt with the given txid, chunk into 62-byte
+ * segments, and emit one `5121<pk1>21<pk2>21<THIRD>53ae` script per chunk where
+ * pk1/pk2 = sign-byte(1) || 31 data bytes || trailing-byte(1).
+ *
+ * We use deterministic 0x02 sign + 0x00 trailing bytes so the test is stable;
+ * the guard ignores those bytes (it reads only the 31 data bytes of each pubkey).
+ */
+function buildMultisigOutputs(
+  txidHex: string,
+  tail = '{"p":"src-20","op":"mint","tick":"KEVIN","amt":"1"}',
+): string[] {
+  const stampPrefix = new TextEncoder().encode("stamp:");
+  const tailBytes = new TextEncoder().encode(tail);
+  const dataWithPrefix = new Uint8Array([...stampPrefix, ...tailBytes]);
+
+  let dataLength = dataWithPrefix.length;
+  while (dataLength > 0 && dataWithPrefix[dataLength - 1] === 0) dataLength--;
+  const lengthPrefix = new Uint8Array([
+    (dataLength >> 8) & 0xff,
+    dataLength & 0xff,
+  ]);
+
+  let payloadBytes = new Uint8Array([...lengthPrefix, ...dataWithPrefix]);
+  const padLength = (62 - (payloadBytes.length % 62)) % 62;
+  if (padLength > 0) {
+    payloadBytes = new Uint8Array([
+      ...payloadBytes,
+      ...new Uint8Array(padLength),
+    ]);
+  }
+
+  const encrypted = arc4(new Uint8Array(hex2bin(txidHex)), payloadBytes);
+
+  const scripts: string[] = [];
+  for (let i = 0; i < encrypted.length; i += 62) {
+    const chunk = encrypted.slice(i, i + 62);
+    const seg1 = bin2hex(chunk.slice(0, 31));
+    const seg2 = bin2hex(chunk.slice(31, 62));
+    // sign byte 02, 31 data bytes, trailing byte 00 -> 33-byte pubkey
+    const pubkey1 = "02" + seg1 + "00";
+    const pubkey2 = "02" + seg2 + "00";
+    scripts.push(`5121${pubkey1}21${pubkey2}21${THIRD_PUBKEY}53ae`);
+  }
+  return scripts;
+}
+
+// ---------------------------------------------------------------------------
+// extractMultisigPayloadSegments
+// ---------------------------------------------------------------------------
+
+Deno.test("extractMultisigPayloadSegments - returns the 62 data bytes of a multisig output", () => {
+  const seg1 = "11".repeat(31);
+  const seg2 = "22".repeat(31);
+  const script = `5121${"02" + seg1 + "00"}21${
+    "02" + seg2 + "00"
+  }21${THIRD_PUBKEY}53ae`;
+  const out = extractMultisigPayloadSegments(script);
+  assert(out !== null);
+  assertEquals(out!.length, 62);
+  assertEquals(bin2hex(out!.slice(0, 31)), seg1);
+  assertEquals(bin2hex(out!.slice(31, 62)), seg2);
+});
+
+Deno.test("extractMultisigPayloadSegments - returns null for a non-multisig script", () => {
+  // P2WPKH-style scriptPubKey (starts with 0x00, not OP_1 0x51).
+  assertEquals(extractMultisigPayloadSegments("0014" + "ab".repeat(20)), null);
+  assertEquals(extractMultisigPayloadSegments(""), null);
+});
+
+Deno.test("extractMultisigPayloadSegments - returns null when fewer than two pubkeys are present", () => {
+  // OP_1 + a single 33-byte pubkey push, then OP_RETURN-ish garbage.
+  const script = `5121${"02" + "11".repeat(31) + "00"}6a`;
+  assertEquals(extractMultisigPayloadSegments(script), null);
+});
+
+// ---------------------------------------------------------------------------
+// reassembleMultisigPayload
+// ---------------------------------------------------------------------------
+
+Deno.test("reassembleMultisigPayload - concatenates segments across outputs in order", () => {
+  const scripts = buildMultisigOutputs(TXID_A);
+  const reassembled = reassembleMultisigPayload(scripts);
+  assert(reassembled !== null);
+  // Length must be a multiple of 62 (one 62-byte block per output).
+  assertEquals(reassembled!.length % 62, 0);
+  assertEquals(reassembled!.length, scripts.length * 62);
+});
+
+Deno.test("reassembleMultisigPayload - returns null on empty input", () => {
+  assertEquals(reassembleMultisigPayload([]), null);
+});
+
+Deno.test("reassembleMultisigPayload - returns null if any output is malformed", () => {
+  const scripts = buildMultisigOutputs(TXID_A);
+  scripts.push("0014" + "ab".repeat(20)); // a non-multisig output
+  assertEquals(reassembleMultisigPayload(scripts), null);
+});
+
+// ---------------------------------------------------------------------------
+// multisigPayloadDecodesFromInput — the fail-closed ARC4 guard (core invariant)
+// ---------------------------------------------------------------------------
+
+Deno.test("multisigPayloadDecodesFromInput - true when matched to the given vin[0] (round-trip)", () => {
+  const scripts = buildMultisigOutputs(TXID_A);
+  assert(multisigPayloadDecodesFromInput(scripts, TXID_A));
+});
+
+Deno.test("multisigPayloadDecodesFromInput - false when matched to a DIFFERENT vin[0] (the indexer-drop bug)", () => {
+  // Payload encrypted against TXID_A (the input the services derived ARC4 from)
+  // but the transaction's vin[0] ended up being TXID_B — exactly the case the
+  // btc_stamps indexer silently drops.
+  const scripts = buildMultisigOutputs(TXID_A);
+  assertFalse(multisigPayloadDecodesFromInput(scripts, TXID_B));
+});
+
+Deno.test("multisigPayloadDecodesFromInput - false for empty / malformed outputs", () => {
+  assertFalse(multisigPayloadDecodesFromInput([], TXID_A));
+  assertFalse(
+    multisigPayloadDecodesFromInput(["0014" + "ab".repeat(20)], TXID_A),
+  );
+});
+
+Deno.test("multisigPayloadDecodesFromInput - false when vin[0] txid is empty", () => {
+  const scripts = buildMultisigOutputs(TXID_A);
+  assertFalse(multisigPayloadDecodesFromInput(scripts, ""));
+});
+
+// ---------------------------------------------------------------------------
+// assertMultisigPayloadDecodesFromInput — throwing wrapper used by the services
+// ---------------------------------------------------------------------------
+
+Deno.test("assertMultisigPayloadDecodesFromInput - passes silently for a correctly matched payload", () => {
+  const scripts = buildMultisigOutputs(TXID_A);
+  // Should not throw.
+  assertMultisigPayloadDecodesFromInput(scripts, TXID_A, "SRC-20");
+});
+
+Deno.test("assertMultisigPayloadDecodesFromInput - throws a clear fail-closed error for a wrong-vin[0] payload", () => {
+  const scripts = buildMultisigOutputs(TXID_A);
+  assertThrows(
+    () => assertMultisigPayloadDecodesFromInput(scripts, TXID_B, "SRC-101"),
+    Error,
+    "ARC4 key mismatch for SRC-101",
+  );
+});


### PR DESCRIPTION
## Summary
Consolidates the SRC-20 and SRC-101 multisig PSBT services onto the canonical `BitcoinUtxoManager.selectUTXOsForTransaction` (the same select-first / fetch-scripts-only-for-selected path stamp issuance and the general builder already use), removing the duplicate `getFullUTXOsWithDetails` + raw `OptimalUTXOSelection` path. Adds a fail-closed ARC4 guard (`lib/utils/bitcoin/minting/src20MultisigGuard.ts`) wired into both services after inputs are added: it reassembles the bare-multisig payload, decrypts with `vin[0]`'s txid, and aborts the build if the plaintext is not the length-prefixed `stamp:` structure the btc_stamps indexer expects — preventing emission of a transaction the indexer would silently drop.

Closes #1141 (consolidation) and #1136 (multisig ARC4 guard).

## Why
`vin[0]` ordering and the ARC4 key must stay aligned. The selector preserves selection order through enrichment (`originalIndex` sort in `batchFetchFullUTXODetails`), and neither service applies any BIP-69/reorder between `arc4(inputs[0].txid)` and the `addInput` loop, so `vin[0] === inputs[0] === ARC4 key` holds for any input count.

## Verification (live, no broadcast)
- **Unit:** `tests/unit/src20MultisigGuard.test.ts` — 12/12 pass (incl. wrong-`vin[0]` discrimination).
- **Static:** `deno lint` + `deno check` clean on all three changed files.
- **Live compose (mainnet, dryRun/no-broadcast), independent RC4 decode of the serialized PSBT:**
  - SRC-20 mint `punks` from P2PKH `1GrgWZdX…` → 1 input, decode from `vin[0]` = `"stamp:"` ✅
  - SRC-20 mint `punks` from P2WPKH `bc1q20d2c…` → 1 input, decode = `"stamp:"` ✅
  - SRC-101 op from P2WPKH → **4 multisig outputs** reassembled, decode from `vin[0]` = `"stamp:"` ✅
- Build succeeds with selected-only script fetch; fees sane (600–615 sats).

🤖 Generated with [Claude Code](https://claude.com/claude-code)