### PR TITLE
fix(ci): gate post-deploy rollback on app health only (#1143)

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -411,56 +411,63 @@ jobs:
 
     steps:
       - name: Wait for new tasks to start serving
-        run: sleep 15
+        # Allow time for ALB target registration + MySQL pool warmup before
+        # probing. The previous 15s sat inside the ALB cutover window, so the
+        # smoke test saw transient ALB-level 503/000 and false-rolled-back a
+        # healthy build (#1143).
+        run: sleep 45
 
-      - name: Health check
+      - name: Health gate (authoritative — gates rollback)
         id: health
+        # The website deploy's health gate depends ONLY on the app's own
+        # /api/v2/health. That route returns 200 whenever the app process is up
+        # and serving (it reports internal-check failures in the JSON body but
+        # still 200s; only ?simple returns 503, which we deliberately do NOT
+        # use). A persistent non-200 across all retries means the app/ALB target
+        # is genuinely down -> legitimate rollback. Backend-data-plane
+        # availability (indexer MySQL) is checked separately, advisory-only.
         run: |
-          STATUS=$(curl -s -o /tmp/health.json -w "%{http_code}" \
-            --max-time 15 \
-            "${{ env.PROD_URL }}/api/v2/health" || echo "000")
+          ATTEMPTS=6
+          SLEEP=15
+          for i in $(seq 1 "$ATTEMPTS"); do
+            STATUS=$(curl -s -o /tmp/health.json -w "%{http_code}" \
+              --max-time 15 \
+              "${{ env.PROD_URL }}/api/v2/health" || echo "000")
+            echo "Health attempt ${i}/${ATTEMPTS}: ${STATUS}"
+            if [ "$STATUS" = "200" ]; then
+              echo "Health gate PASSED on attempt ${i}"
+              cat /tmp/health.json
+              exit 0
+            fi
+            if [ "$i" -lt "$ATTEMPTS" ]; then
+              echo "Health not ready (${STATUS}); retrying in ${SLEEP}s..."
+              sleep "$SLEEP"
+            fi
+          done
+          echo "::error::/api/v2/health did not return 200 after ${ATTEMPTS} attempts — app appears down, triggering rollback"
+          exit 1
 
-          echo "Health endpoint returned: ${STATUS}"
-
-          if [ "$STATUS" = "200" ]; then
-            echo "Health check PASSED"
-            cat /tmp/health.json
-          else
-            echo "::warning::Health check returned ${STATUS} (may still be starting)"
-          fi
-
-      - name: API smoke test
+      - name: Data-plane smoke test (advisory — never fails the deploy)
+        # These endpoints read the SEPARATE backend-indexer MySQL DB. Their
+        # 503/000 during an ALB cutover or an indexer hiccup is NOT a website
+        # build failure, so they emit ::warning:: only and never exit non-zero.
+        # (App-level DB errors surface as 500 via apiResponseUtil; a 503 here is
+        # ALB "no healthy target", not the app.)
         run: |
-          # Test key endpoints
           ENDPOINTS=(
-            "/api/v2/health"
             "/api/v2/stamps?limit=1"
             "/api/v2/src20?limit=1"
           )
-
-          PASS=0
-          FAIL=0
-
           for endpoint in "${ENDPOINTS[@]}"; do
             STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
               --max-time 10 \
               "${{ env.PROD_URL }}${endpoint}" || echo "000")
-
             if [ "$STATUS" = "200" ]; then
               echo "PASS: ${endpoint} (${STATUS})"
-              PASS=$((PASS + 1))
             else
-              echo "WARN: ${endpoint} (${STATUS})"
-              FAIL=$((FAIL + 1))
+              echo "::warning::Data endpoint ${endpoint} returned ${STATUS} (backend indexer/ALB — advisory, not gating the deploy)"
             fi
           done
-
-          echo "Smoke test: ${PASS} passed, ${FAIL} warnings"
-
-          if [ "$FAIL" -gt 1 ]; then
-            echo "::error::Multiple API endpoints failing"
-            exit 1
-          fi
 
       - name: Create deployment summary
         if: always()


### PR DESCRIPTION
## Summary
Fixes the post-deploy smoke test that **false-rolled-back a healthy production build** (run 27800311576 / #1142-#1140) on transient ALB-cutover 503/000s. Closes #1143.

## Root cause
The `validate` job waited only `sleep 15`, then curled `/api/v2/health`, `/api/v2/stamps?limit=1`, `/api/v2/src20?limit=1` once each and failed the job (→ `rollback`) if `>1` returned non-200. But the two data endpoints read the **separate backend-indexer MySQL DB**; their 503s during ALB target cutover are **ALB-generated** ("no healthy target"), not website-build failures. Verified in code:
- Plain `/api/v2/health` returns `ApiResponseUtil.success(...)` = **200** whenever the app process is up — it reports internal-check failures in the JSON body but still 200s (`routes/api/v2/health.ts:156-162`). Only `?simple` returns 503, which the smoke test never called.
- App-level DB errors surface as **500** via `apiResponseUtil`, not 503.

So the gate conflated website app-health with backend data-plane availability, and second-guessed the ECS deployment circuit-breaker the `deploy` job already validated.

## Fix (`production-deploy.yml`, validate job)
1. **Health gate (authoritative):** retry `/api/v2/health` 6× with 15s backoff; rollback only if it never returns 200 (app/ALB target genuinely down).
2. **Data-plane smoke test (advisory):** `/api/v2/stamps` + `/api/v2/src20` emit `::warning::` only, never exit non-zero.
3. **Warmup:** bump pre-probe `sleep 15 → 45` to clear ALB registration + MySQL pool warmup.

## Verification
- `actionlint` clean (exit 0)
- New `run:` blocks produce **zero** shellcheck findings (the only shellcheck infos are on a pre-existing legacy step at line 52)
- YAML parses

🤖 Generated with [Claude Code](https://claude.com/claude-code)