### PR TITLE
fix(tx): use ALL Counterparty inputs in send/attach, not just vin[0] (#1137)

### DIFF
--- a/lib/utils/bitcoin/psbt/cpRawTxInputs.ts
+++ b/lib/utils/bitcoin/psbt/cpRawTxInputs.ts
@@ -1,0 +1,157 @@
+// Shared helper for reconstructing PSBT inputs from a Counterparty-composed
+// rawtransaction, used by the send and stamp-attach routes.
+//
+// Background (#1137): both routes previously processed ONLY `cpTx.ins[0]` and
+// logged a warning that dropped any remaining inputs. If Counterparty funds the
+// source address from several UTXOs (small-UTXO wallets), the resulting
+// single-input PSBT is underfunded and the broadcast fails. This helper
+// iterates ALL of the rawtransaction's inputs IN ORDER.
+//
+// Order preservation is REQUIRED: the Counterparty payload (OP_RETURN / bare
+// multisig) is ARC4-keyed against `vin[0]`, so vin[0] must stay the input
+// Counterparty composed first. We never sort or drop inputs.
+//
+// The fetcher is typed structurally (not as the concrete CommonUTXOService) so
+// this lib/ helper stays decoupled from server/ and is trivially mockable in
+// unit tests.
+
+import { Buffer } from "node:buffer";
+import { hex2bin } from "$lib/utils/binary/baseUtils.ts";
+import { getScriptTypeInfo } from "$lib/utils/scriptTypeUtils.ts";
+
+/** Minimal UTXO-detail shape the input builder needs. */
+export interface CpInputUtxoDetails {
+  script?: string;
+  value?: number | bigint;
+  rawTxHex?: string;
+  redeemScript?: string;
+}
+
+/**
+ * Structural fetcher interface. CommonUTXOService satisfies this; tests pass a
+ * lightweight mock. Keeps lib/ from importing server/.
+ */
+export interface CpUtxoFetcher {
+  getSpecificUTXO(
+    txid: string,
+    vout: number,
+  ): Promise<CpInputUtxoDetails | null>;
+  getRawTransactionHex(txid: string): Promise<string | null>;
+}
+
+/** PSBT input payload (the object passed to psbt.addInput) plus its value. */
+export interface BuiltPsbtInput {
+  inputData: {
+    hash: string;
+    index: number;
+    sequence?: number;
+    witnessUtxo?: { script: Buffer; value: bigint };
+    nonWitnessUtxo?: Buffer;
+    redeemScript?: Buffer;
+  };
+  value: bigint;
+}
+
+/** A previous-output reference plus the sequence to use for it. */
+export interface CpPrevout {
+  txid: string;
+  vout: number;
+  sequence?: number;
+}
+
+export interface InputToSign {
+  index: number;
+  address: string;
+  sighashTypes?: number[];
+}
+
+/**
+ * Build PSBT input data for a single previous output, fetching its script
+ * details. Fails closed (throws) if the UTXO cannot be resolved — silently
+ * dropping an input would underfund the transaction.
+ */
+export async function buildCpPsbtInput(
+  fetcher: CpUtxoFetcher,
+  prevout: CpPrevout,
+): Promise<BuiltPsbtInput> {
+  const { txid, vout, sequence } = prevout;
+  const utxo = await fetcher.getSpecificUTXO(txid, vout);
+  if (!utxo || !utxo.script || utxo.value === undefined) {
+    throw new Error(
+      `Failed to fetch UTXO details for input ${txid}:${vout} from CP raw tx.`,
+    );
+  }
+
+  const scriptTypeInfo = getScriptTypeInfo(utxo.script);
+  const inputData: BuiltPsbtInput["inputData"] = {
+    hash: txid,
+    index: vout,
+    ...(sequence !== undefined ? { sequence } : {}),
+  };
+
+  if (scriptTypeInfo.isWitness) {
+    inputData.witnessUtxo = {
+      script: Buffer.from(hex2bin(utxo.script)),
+      value: BigInt(utxo.value),
+    };
+  } else {
+    // Non-witness inputs require the full previous transaction.
+    const rawTxHex = utxo.rawTxHex ?? await fetcher.getRawTransactionHex(txid);
+    if (!rawTxHex) {
+      throw new Error(
+        `Failed to get raw tx hex for non-witness input ${txid}.`,
+      );
+    }
+    inputData.nonWitnessUtxo = Buffer.from(hex2bin(rawTxHex));
+  }
+
+  // Attach the redeem script for any P2SH input that carries one (covers
+  // P2SH-P2WPKH / P2SH-P2WSH and bare P2SH). Harmless when absent.
+  if (scriptTypeInfo.type === "P2SH" && utxo.redeemScript) {
+    inputData.redeemScript = Buffer.from(hex2bin(utxo.redeemScript));
+  }
+
+  return { inputData, value: BigInt(utxo.value) };
+}
+
+/**
+ * Build PSBT inputs for ALL inputs of a Counterparty-composed rawtransaction,
+ * in their original order (vin[0] stays the ARC4 key — see file header).
+ *
+ * Returns the input payloads (for psbt.addInput, in order), the inputsToSign
+ * descriptors (index i per input), and the summed input value (for fee/change
+ * accounting by callers that fund their own change).
+ */
+export async function buildCpPsbtInputsFromRawTx(
+  fetcher: CpUtxoFetcher,
+  cpTxIns: ReadonlyArray<{ hash: Uint8Array; index: number; sequence: number }>,
+  signerAddress: string,
+  sighashTypes: number[],
+): Promise<{
+  builtInputs: BuiltPsbtInput[];
+  inputsToSign: InputToSign[];
+  totalInputValue: bigint;
+}> {
+  if (!cpTxIns || cpTxIns.length === 0) {
+    throw new Error("Counterparty raw transaction has no inputs.");
+  }
+
+  const builtInputs: BuiltPsbtInput[] = [];
+  const inputsToSign: InputToSign[] = [];
+  let totalInputValue = BigInt(0);
+
+  for (let i = 0; i < cpTxIns.length; i++) {
+    const cpIn = cpTxIns[i];
+    const txid = Buffer.from(cpIn.hash).reverse().toString("hex");
+    const built = await buildCpPsbtInput(fetcher, {
+      txid,
+      vout: cpIn.index,
+      sequence: cpIn.sequence,
+    });
+    builtInputs.push(built);
+    totalInputValue += built.value;
+    inputsToSign.push({ index: i, address: signerAddress, sighashTypes });
+  }
+
+  return { builtInputs, inputsToSign, totalInputValue };
+}

--- a/routes/api/v2/create/send.ts
+++ b/routes/api/v2/create/send.ts
@@ -1,12 +1,8 @@
 // routes/api/v2/create/send.ts
 import { TX_CONSTANTS } from "$constants";
 import { Handlers } from "$fresh/server.ts";
-import type { UTXO as DetailedUTXO } from "$lib/types/index.d.ts";
-import type { ScriptTypeInfo } from "$lib/types/transaction.d.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
-import { hex2bin } from "$lib/utils/binary/baseUtils.ts";
 import { logger } from "$lib/utils/logger.ts";
-import { getScriptTypeInfo } from "$lib/utils/scriptTypeUtils.ts";
 import { CounterpartyApiManager } from "$server/services/counterpartyApiService.ts";
 import { CommonUTXOService } from "$server/services/utxo/commonUtxoService.ts";
 import type { SendRequestBody, SendResponse } from "$types/api.d.ts";
@@ -112,96 +108,24 @@ export const handler: Handlers<SendResponse | { error: string }> = {
       const rawCpTxHex = cpResponse.result.rawtransaction;
       const cpTx = Transaction.fromHex(rawCpTxHex);
 
-      if (!cpTx.ins || cpTx.ins.length === 0) {
-        throw new Error("Counterparty raw transaction has no inputs.");
-      }
-      // Assuming CP uses one input from the sourceAddress for simplicity in this model
-      if (cpTx.ins.length > 1) {
-        logger.warn("api", {
-          message:
-            "Counterparty raw tx has multiple inputs, processing only the first for PSBT.",
-          inputCount: cpTx.ins.length,
-        });
-      }
+      // Reconstruct PSBT inputs from ALL of Counterparty's chosen inputs, in
+      // order, so vin[0] stays the input the CP payload is ARC4-keyed against
+      // (#1137). The prior code processed only cpTx.ins[0] and dropped the rest,
+      // underfunding sends whenever CP funded the source from several UTXOs.
+      const { buildCpPsbtInputsFromRawTx } = await import(
+        "$lib/utils/bitcoin/psbt/cpRawTxInputs.ts"
+      );
+      const { builtInputs, inputsToSign } = await buildCpPsbtInputsFromRawTx(
+        commonUtxoService,
+        cpTx.ins,
+        address,
+        [Transaction.SIGHASH_ALL],
+      );
 
       const psbt = new Psbt({ network });
-      const inputsToSign: {
-        index: number;
-        address: string;
-        sighashTypes?: number[];
-      }[] = [];
-
-      // Process the first input (assuming Counterparty picked one from userAddress)
-      const cpInput = cpTx.ins[0];
-      const inputTxid = Buffer.from(cpInput.hash).reverse().toString("hex");
-      const inputVout = cpInput.index;
-
-      // Fetch full UTXO details for this input
-      const rawUtxoDetails = await commonUtxoService
-        .getSpecificUTXO(inputTxid, inputVout);
-      const utxoDetails: DetailedUTXO | null = rawUtxoDetails
-        ? {
-          ...rawUtxoDetails,
-          scriptType: rawUtxoDetails.scriptType as any, // Type cast to handle different ScriptType definitions
-        }
-        : null;
-      if (
-        !utxoDetails || !utxoDetails.script || utxoDetails.value === undefined
-      ) {
-        throw new Error(
-          `Failed to fetch UTXO details for input ${inputTxid}:${inputVout} from CP raw tx.`,
-        );
+      for (const { inputData } of builtInputs) {
+        psbt.addInput(inputData as any);
       }
-
-      const scriptTypeInfo: ScriptTypeInfo = getScriptTypeInfo(
-        utxoDetails.script,
-      );
-      const psbtInputData: any = {
-        hash: inputTxid,
-        index: inputVout,
-        sequence: cpInput.sequence, // Use sequence from CP's transaction
-      };
-
-      if (scriptTypeInfo.isWitness) {
-        psbtInputData.witnessUtxo = {
-          script: Buffer.from(hex2bin(utxoDetails.script)),
-          value: BigInt(utxoDetails.value),
-        };
-      } else {
-        // For non-witness, nonWitnessUtxo is the full previous tx hex
-        // If utxoDetails itself contains the rawTxHex for its parent, use it. Otherwise, fetch again.
-        const nonWitnessRawTxHex = utxoDetails.rawTxHex ||
-          await commonUtxoService.getRawTransactionHex(inputTxid);
-        if (!nonWitnessRawTxHex) {
-          throw new Error(
-            `Failed to get raw tx hex for non-witness input ${inputTxid}`,
-          );
-        }
-        psbtInputData.nonWitnessUtxo = Buffer.from(hex2bin(nonWitnessRawTxHex));
-      }
-      if (
-        scriptTypeInfo.type === "P2SH" &&
-        scriptTypeInfo.redeemScriptType?.isWitness
-      ) {
-        if (utxoDetails.redeemScript) {
-          psbtInputData.redeemScript = Buffer.from(
-            hex2bin(utxoDetails.redeemScript),
-          );
-        } else {
-          // This case implies P2SH-P2WPKH or P2SH-P2WSH where redeemScript is critical
-          // and must be derivable or provided. For now, log a warning if missing.
-          logger.warn("api", {
-            message:
-              `Redeem script missing for P2SH input ${inputTxid}:${inputVout}. PSBT may be incomplete.`,
-          });
-        }
-      }
-      psbt.addInput(psbtInputData);
-      inputsToSign.push({
-        index: 0,
-        address: address,
-        sighashTypes: [Transaction.SIGHASH_ALL],
-      });
 
       // Add all outputs from Counterparty's transaction
       for (const cpOutput of cpTx.outs) {

--- a/routes/api/v2/trx/stampattach.ts
+++ b/routes/api/v2/trx/stampattach.ts
@@ -6,10 +6,13 @@ import type {
   ScriptTypeInfo,
 } from "$lib/types/transaction.d.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
-import { hex2bin } from "$lib/utils/data/binary/baseUtils.ts";
 import { logger } from "$lib/utils/logger.ts";
 import { estimateMintingTransactionSize } from "$lib/utils/bitcoin/minting/transactionSizes.ts";
 import { getScriptTypeInfo } from "$lib/utils/bitcoin/scripts/scriptTypeUtils.ts";
+import {
+  buildCpPsbtInput,
+  buildCpPsbtInputsFromRawTx,
+} from "$lib/utils/bitcoin/psbt/cpRawTxInputs.ts";
 import { serverConfig } from "$server/config/config.ts"; // Import serverConfig
 import { StampController } from "$server/controller/stampController.ts";
 import {
@@ -18,7 +21,6 @@ import {
   normalizeFeeRate,
 } from "$server/services/counterpartyApiService.ts";
 import { CommonUTXOService } from "$server/services/utxo/commonUtxoService.ts";
-import type { UTXO as ServiceUTXO } from "$types/index.d.ts";
 import { Buffer } from "node:buffer";
 
 // Update interface to accept either fee rate type and service fee
@@ -131,108 +133,35 @@ export const handler: Handlers = {
       if (inputs_set) { // User specified the input UTXO
         const [txid, voutStr] = inputs_set.split(":");
         const vout = parseInt(voutStr, 10);
-        const utxoDetails: ServiceUTXO | null = await commonUtxoService
-          .getSpecificUTXO(txid, vout);
-        if (
-          !utxoDetails || !utxoDetails.script || utxoDetails.value === undefined
-        ) {
-          throw new Error(
-            `Specified input UTXO ${inputs_set} not found or invalid.`,
-          );
-        }
-        sumOfUserInputs = BigInt(utxoDetails.value);
-        const scriptTypeInfo: ScriptTypeInfo = getScriptTypeInfo(
-          utxoDetails.script,
-        );
-        const inputData: any = {
-          hash: txid,
-          index: vout,
+        const built = await buildCpPsbtInput(commonUtxoService, {
+          txid,
+          vout,
           sequence,
-        };
-        if (scriptTypeInfo.isWitness) {
-          inputData.witnessUtxo = {
-            script: Buffer.from(hex2bin(utxoDetails.script)),
-            value: BigInt(utxoDetails.value),
-          };
-        } else {
-          const rawTx = (utxoDetails as any).rawTxHex ||
-            await commonUtxoService.getRawTransactionHex(txid);
-          if (!rawTx) {
-            throw new Error(`Raw tx not found for non-witness input ${txid}`);
-          }
-          inputData.nonWitnessUtxo = Buffer.from(hex2bin(rawTx));
-        }
-        if (
-          scriptTypeInfo.type === "P2SH" &&
-          (utxoDetails as any).redeemScript
-        ) {
-          inputData.redeemScript = Buffer.from(
-            hex2bin((utxoDetails as any).redeemScript),
-          );
-        }
-        psbt.addInput(inputData);
+        });
+        sumOfUserInputs = built.value;
+        psbt.addInput(built.inputData as any);
         inputsToSign.push({
           index: 0,
           address: address,
           sighashTypes: [Transaction.SIGHASH_ALL],
         });
-      } else { // Counterparty chose the input(s) - assume one for now from cpTx.ins[0]
-        if (!cpTx.ins || cpTx.ins.length === 0) {
-          throw new Error("CP rawtransaction has no inputs.");
-        }
-        const cpInput = cpTx.ins[0];
-        const inputTxid = Buffer.from(cpInput.hash).reverse().toString("hex");
-        const inputVout = cpInput.index;
-        const utxoDetails: ServiceUTXO | null = await commonUtxoService
-          .getSpecificUTXO(
-            inputTxid,
-            inputVout,
+      } else {
+        // Counterparty chose the input(s) — use ALL of them, in order, so vin[0]
+        // stays the input the CP payload is ARC4-keyed against (#1137). The prior
+        // code processed only cpTx.ins[0] and dropped the rest, underfunding
+        // attaches whenever CP funded the source from several UTXOs.
+        const { builtInputs, inputsToSign: cpInputsToSign, totalInputValue } =
+          await buildCpPsbtInputsFromRawTx(
+            commonUtxoService,
+            cpTx.ins,
+            address,
+            [Transaction.SIGHASH_ALL],
           );
-        if (
-          !utxoDetails || !utxoDetails.script || utxoDetails.value === undefined
-        ) {
-          throw new Error(
-            `Input UTXO ${inputTxid}:${inputVout} from CP raw tx not found or invalid.`,
-          );
+        sumOfUserInputs = totalInputValue;
+        for (const { inputData } of builtInputs) {
+          psbt.addInput(inputData as any);
         }
-        sumOfUserInputs = BigInt(utxoDetails.value);
-        const scriptTypeInfo: ScriptTypeInfo = getScriptTypeInfo(
-          utxoDetails.script,
-        );
-        const inputData: any = {
-          hash: inputTxid,
-          index: inputVout,
-          sequence: cpInput.sequence,
-        };
-        if (scriptTypeInfo.isWitness) {
-          inputData.witnessUtxo = {
-            script: Buffer.from(hex2bin(utxoDetails.script)),
-            value: BigInt(utxoDetails.value),
-          };
-        } else {
-          const rawTx = (utxoDetails as any).rawTxHex ||
-            await commonUtxoService.getRawTransactionHex(inputTxid);
-          if (!rawTx) {
-            throw new Error(
-              `Raw tx not found for non-witness input ${inputTxid}`,
-            );
-          }
-          inputData.nonWitnessUtxo = Buffer.from(hex2bin(rawTx));
-        }
-        if (
-          scriptTypeInfo.type === "P2SH" &&
-          (utxoDetails as any).redeemScript
-        ) {
-          inputData.redeemScript = Buffer.from(
-            hex2bin((utxoDetails as any).redeemScript),
-          );
-        }
-        psbt.addInput(inputData);
-        inputsToSign.push({
-          index: 0,
-          address: address,
-          sighashTypes: [Transaction.SIGHASH_ALL],
-        });
+        inputsToSign.push(...cpInputsToSign);
       }
 
       let cpOutputsTotalValue = BigInt(0);

--- a/tests/unit/cpRawTxInputs.test.ts
+++ b/tests/unit/cpRawTxInputs.test.ts
@@ -1,0 +1,161 @@
+import { assertEquals, assertExists, assertRejects } from "@std/assert";
+import {
+  buildCpPsbtInput,
+  buildCpPsbtInputsFromRawTx,
+  type CpInputUtxoDetails,
+  type CpUtxoFetcher,
+} from "$lib/utils/bitcoin/psbt/cpRawTxInputs.ts";
+
+// Synthetic scriptPubKeys recognised by getScriptTypeInfo (see scriptTypeUtils):
+//   P2WPKH  = 0014 + 20 bytes  -> witness
+//   P2PKH   = 76a914 + 20 bytes + 88ac -> non-witness
+//   P2SH    = a914 + 20 bytes + 87 -> non-witness, may carry a redeemScript
+const P2WPKH = "0014" + "11".repeat(20);
+const P2PKH = "76a914" + "22".repeat(20) + "88ac";
+const P2SH = "a914" + "33".repeat(20) + "87";
+
+function fill32(byte: number): Uint8Array {
+  return new Uint8Array(32).fill(byte);
+}
+function hex32(byte: number): string {
+  return byte.toString(16).padStart(2, "0").repeat(32);
+}
+
+// A fetcher backed by an in-memory map keyed by display txid. Records calls so
+// we can assert getRawTransactionHex is invoked only for non-witness inputs.
+function mockFetcher(
+  utxos: Record<string, CpInputUtxoDetails | null>,
+): CpUtxoFetcher & { rawTxCalls: string[] } {
+  const rawTxCalls: string[] = [];
+  return {
+    rawTxCalls,
+    getSpecificUTXO(txid: string, _vout: number) {
+      return Promise.resolve(txid in utxos ? utxos[txid] : null);
+    },
+    getRawTransactionHex(txid: string) {
+      rawTxCalls.push(txid);
+      return Promise.resolve("0000"); // any truthy even-length hex
+    },
+  };
+}
+
+Deno.test("buildCpPsbtInput - witness input sets witnessUtxo, no rawtx fetch", async () => {
+  const fetcher = mockFetcher({
+    [hex32(0x0a)]: { script: P2WPKH, value: 100000 },
+  });
+  const built = await buildCpPsbtInput(fetcher, {
+    txid: hex32(0x0a),
+    vout: 0,
+    sequence: 0xfffffffd,
+  });
+  assertEquals(built.value, 100000n);
+  assertEquals(built.inputData.hash, hex32(0x0a));
+  assertEquals(built.inputData.index, 0);
+  assertEquals(built.inputData.sequence, 0xfffffffd);
+  assertExists(built.inputData.witnessUtxo);
+  assertEquals(built.inputData.nonWitnessUtxo, undefined);
+  assertEquals(fetcher.rawTxCalls.length, 0); // witness: no parent-tx fetch
+});
+
+Deno.test("buildCpPsbtInput - non-witness input fetches parent tx for nonWitnessUtxo", async () => {
+  const fetcher = mockFetcher({
+    [hex32(0x0b)]: { script: P2PKH, value: 50000 },
+  });
+  const built = await buildCpPsbtInput(fetcher, {
+    txid: hex32(0x0b),
+    vout: 1,
+    sequence: 0xffffffff,
+  });
+  assertExists(built.inputData.nonWitnessUtxo);
+  assertEquals(built.inputData.witnessUtxo, undefined);
+  assertEquals(fetcher.rawTxCalls, [hex32(0x0b)]);
+});
+
+Deno.test("buildCpPsbtInput - P2SH input attaches redeemScript when present", async () => {
+  const fetcher = mockFetcher({
+    [hex32(0x0c)]: { script: P2SH, value: 25000, redeemScript: "abcd" },
+  });
+  const built = await buildCpPsbtInput(fetcher, {
+    txid: hex32(0x0c),
+    vout: 0,
+    sequence: 0xfffffffd,
+  });
+  assertExists(built.inputData.redeemScript);
+});
+
+Deno.test("buildCpPsbtInput - fails closed when UTXO cannot be resolved", async () => {
+  const fetcher = mockFetcher({ [hex32(0x0a)]: null });
+  await assertRejects(
+    () =>
+      buildCpPsbtInput(fetcher, {
+        txid: hex32(0x0a),
+        vout: 0,
+        sequence: 0xfffffffd,
+      }),
+    Error,
+    "Failed to fetch UTXO details",
+  );
+});
+
+Deno.test("buildCpPsbtInputsFromRawTx - includes ALL inputs in order (the #1137 fix)", async () => {
+  const fetcher = mockFetcher({
+    [hex32(0x0a)]: { script: P2WPKH, value: 100000 },
+    [hex32(0x0b)]: { script: P2PKH, value: 50000 },
+    [hex32(0x0c)]: { script: P2SH, value: 25000, redeemScript: "abcd" },
+  });
+  const cpTxIns = [
+    { hash: fill32(0x0a), index: 0, sequence: 0xfffffffd },
+    { hash: fill32(0x0b), index: 1, sequence: 0xfffffffd },
+    { hash: fill32(0x0c), index: 2, sequence: 0xfffffffd },
+  ];
+
+  const { builtInputs, inputsToSign, totalInputValue } =
+    await buildCpPsbtInputsFromRawTx(
+      fetcher,
+      cpTxIns,
+      "bc1qexampleaddress",
+      [1],
+    );
+
+  // ALL three inputs present (prior code dropped inputs 2 and 3).
+  assertEquals(builtInputs.length, 3);
+  // Order preserved: vin[0] stays the first CP input (the ARC4 key input).
+  assertEquals(builtInputs[0].inputData.hash, hex32(0x0a));
+  assertEquals(builtInputs[1].inputData.hash, hex32(0x0b));
+  assertEquals(builtInputs[2].inputData.hash, hex32(0x0c));
+  // inputsToSign indices increment with input position.
+  assertEquals(inputsToSign.map((i) => i.index), [0, 1, 2]);
+  assertEquals(inputsToSign.every((i) => i.address === "bc1qexampleaddress"), true);
+  // Summed value across ALL inputs (drives correct change in stampattach).
+  assertEquals(totalInputValue, 175000n);
+});
+
+Deno.test("buildCpPsbtInputsFromRawTx - reverses internal hash to display txid order", async () => {
+  // Asymmetric hash proves the byte-reversal (internal -> display) is applied.
+  const internal = new Uint8Array(
+    Array.from({ length: 32 }, (_, i) => i),
+  );
+  const expectedDisplay = Array.from(internal)
+    .reverse()
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  const fetcher = mockFetcher({
+    [expectedDisplay]: { script: P2WPKH, value: 10000 },
+  });
+  const { builtInputs } = await buildCpPsbtInputsFromRawTx(
+    fetcher,
+    [{ hash: internal, index: 0, sequence: 0xfffffffd }],
+    "bc1qexampleaddress",
+    [1],
+  );
+  assertEquals(builtInputs[0].inputData.hash, expectedDisplay);
+});
+
+Deno.test("buildCpPsbtInputsFromRawTx - throws on an empty input set", async () => {
+  const fetcher = mockFetcher({});
+  await assertRejects(
+    () => buildCpPsbtInputsFromRawTx(fetcher, [], "bc1qexampleaddress", [1]),
+    Error,
+    "no inputs",
+  );
+});


### PR DESCRIPTION
## Summary
`send.ts` and `stampattach.ts` rebuilt the PSBT from only `cpTx.ins[0]`, warning-and-dropping any other inputs. If Counterparty funds the source address from several UTXOs, the single-input PSBT is **underfunded** → broadcast fails. Closes #1137.

## Fix
New shared helper `lib/utils/bitcoin/psbt/cpRawTxInputs.ts`:
- `buildCpPsbtInputsFromRawTx` iterates **all** of the CP rawtransaction's inputs **in order** — vin[0] stays the input the CP payload is ARC4-keyed against (no reordering/sort).
- `buildCpPsbtInput` builds a single input (used by the user-specified `inputs_set` branch).
- **Fails closed** (throws) on an unresolvable UTXO rather than silently dropping it.
- Fetcher typed structurally → `lib/` stays decoupled from `server/`, trivially mockable.

`send.ts` and `stampattach.ts` now loop over all inputs. In `stampattach.ts`, `sumOfUserInputs` accumulates across **all** inputs (it feeds the change calc — previously only the first input's value counted).

## Verification
- **7 unit tests** (`tests/unit/cpRawTxInputs.test.ts`, all pass): all-inputs-included + order preserved (the fix), witness / non-witness / P2SH-redeemScript input data, summed value, internal→display hash reversal, fail-closed on missing UTXO + empty set.
- **Live e2e**: real CP `createSend` rawtx (BLUEBEAM + XCP) from a funded wallet run through the new helper with the **real** `CommonUTXOService` → PSBT reconstructed with vin[0] intact (single-input; CP didn't need multiple this run — multi-input is covered by the unit test).
- `deno check` + `deno lint` clean on all changed files.

## Note
Both routes are ARC4-safe (order preserved). This is funding-correctness, not a silent-loss bug — it only triggers when CP composes a multi-input send/attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)