### PR TITLE
fix(send): satsPerVB fee_per_kb NaN → 500 (#1151)

### DIFF
--- a/routes/api/v2/create/send.ts
+++ b/routes/api/v2/create/send.ts
@@ -1,9 +1,11 @@
 // routes/api/v2/create/send.ts
-import { TX_CONSTANTS } from "$constants";
 import { Handlers } from "$fresh/server.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
 import { logger } from "$lib/utils/logger.ts";
-import { CounterpartyApiManager } from "$server/services/counterpartyApiService.ts";
+import {
+  CounterpartyApiManager,
+  normalizeFeeRate,
+} from "$server/services/counterpartyApiService.ts";
 import { CommonUTXOService } from "$server/services/utxo/commonUtxoService.ts";
 import type { SendRequestBody, SendResponse } from "$types/api.d.ts";
 import { Buffer } from "node:buffer";
@@ -69,9 +71,14 @@ export const handler: Handlers<SendResponse | { error: string }> = {
         verbose: true,
         // Pass fee info if CounterpartyApiManager.createSend expects it for the CP API call
         // Assuming CounterpartyApiManager.createSend handles conversion if CP API needs fee_per_kb
+        // Convert satsPerVB → fee_per_kb (sat/kB) via the canonical helper so
+        // Counterparty's create_send receives a valid integer. The prior code
+        // multiplied by the nonexistent TX_CONSTANTS.APPROX_VBYTES_PER_KB,
+        // yielding NaN and a 500 whenever satsPerVB was used without an
+        // explicit options.fee_per_kb (#1151).
         fee_per_kb: options.fee_per_kb ||
-          (satsPerVB
-            ? satsPerVB * (TX_CONSTANTS as any).APPROX_VBYTES_PER_KB / 1000
+          (satsPerVB && satsPerVB > 0
+            ? normalizeFeeRate({ satsPerVB }).normalizedSatsPerKB
             : undefined),
       };
       if (options.memo !== undefined) xcpCreateSendOptions.memo = options.memo;


### PR DESCRIPTION
## Problem
`routes/api/v2/create/send.ts` computed `fee_per_kb` by multiplying `satsPerVB` by `TX_CONSTANTS.APPROX_VBYTES_PER_KB` — a constant that **does not exist** anywhere in the codebase. The result was `NaN`, which Counterparty's `create_send` floored and rejected, returning **500** for any caller that used the documented `satsPerVB` param without an explicit `options.fee_per_kb`.

Confirmed live: `satsPerVB:5` → 500; `options.fee_per_kb:10000` → 200 + valid PSBT.

## Fix
Route the conversion through the canonical `normalizeFeeRate()` helper (`satsPerVB * SATS_PER_KB_MULTIPLIER` = sat/kB, where the multiplier is 1000), guarded on `satsPerVB > 0`. Removes the dead `TX_CONSTANTS` import.

## Verify
`deno check routes/api/v2/create/send.ts` clean. Post-deploy: prod send with `satsPerVB` (no explicit `fee_per_kb`) should return 200 + valid PSBT.

Fixes #1151

🤖 Generated with [Claude Code](https://claude.com/claude-code)