### PR TITLE
feat(fees): dynamic mempool fee default for send/mint when no rate supplied

### DIFF
--- a/routes/api/v2/create/send.ts
+++ b/routes/api/v2/create/send.ts
@@ -6,6 +6,7 @@ import {
   CounterpartyApiManager,
   normalizeFeeRate,
 } from "$server/services/counterpartyApiService.ts";
+import { getProductionFeeService } from "$server/services/fee/feeServiceFactory.ts";
 import { CommonUTXOService } from "$server/services/utxo/commonUtxoService.ts";
 import type { SendRequestBody, SendResponse } from "$types/api.d.ts";
 import { Buffer } from "node:buffer";
@@ -61,6 +62,46 @@ export const handler: Handlers<SendResponse | { error: string }> = {
         });
       }
 
+      // Resolve fee_per_kb (sat/kB) with a clear precedence:
+      //   1. explicit options.fee_per_kb (caller-supplied, already sat/kB)
+      //   2. explicit satsPerVB (what the frontend sends after its own fee
+      //      selection) — converted via the canonical normalizeFeeRate helper.
+      //      The prior code multiplied by the nonexistent
+      //      TX_CONSTANTS.APPROX_VBYTES_PER_KB, yielding NaN → 500 (#1151).
+      //   3. neither supplied → fetch the live mempool recommended rate as a
+      //      dynamic default so direct API callers (not just the website, which
+      //      always sends an explicit rate) build at a current network fee
+      //      instead of relying on Counterparty's internal default.
+      let resolvedFeePerKb: number | undefined = options.fee_per_kb;
+      if (resolvedFeePerKb === undefined) {
+        if (satsPerVB && satsPerVB > 0) {
+          resolvedFeePerKb =
+            normalizeFeeRate({ satsPerVB }).normalizedSatsPerKB;
+        } else {
+          try {
+            const feeData = await getProductionFeeService().getFeeData();
+            if (feeData?.recommendedFee && feeData.recommendedFee > 0) {
+              resolvedFeePerKb = normalizeFeeRate({
+                satsPerVB: feeData.recommendedFee,
+              }).normalizedSatsPerKB;
+              logger.info("api", {
+                message: "send: applied dynamic mempool fee default",
+                recommendedFee: feeData.recommendedFee,
+                source: feeData.source,
+              });
+            }
+          } catch (feeErr) {
+            // Mempool/FeeService unavailable — leave fee_per_kb undefined and let
+            // Counterparty fall back to its own default (prior behaviour).
+            logger.warn("api", {
+              message:
+                "send: dynamic mempool fee default unavailable, deferring to Counterparty default",
+              error: feeErr instanceof Error ? feeErr.message : String(feeErr),
+            });
+          }
+        }
+      }
+
       // Options for CounterpartyApiManager.createSend to get the raw transaction
       // Counterparty's create_send might require a fee parameter.
       // We pass satsPerVB (converted to fee_per_kb if needed by createSend options) so CP can build its tx.
@@ -69,17 +110,7 @@ export const handler: Handlers<SendResponse | { error: string }> = {
         encoding: options.encoding || "opreturn",
         return_psbt: false, // Explicitly ask for raw tx, not PSBT from CP
         verbose: true,
-        // Pass fee info if CounterpartyApiManager.createSend expects it for the CP API call
-        // Assuming CounterpartyApiManager.createSend handles conversion if CP API needs fee_per_kb
-        // Convert satsPerVB → fee_per_kb (sat/kB) via the canonical helper so
-        // Counterparty's create_send receives a valid integer. The prior code
-        // multiplied by the nonexistent TX_CONSTANTS.APPROX_VBYTES_PER_KB,
-        // yielding NaN and a 500 whenever satsPerVB was used without an
-        // explicit options.fee_per_kb (#1151).
-        fee_per_kb: options.fee_per_kb ||
-          (satsPerVB && satsPerVB > 0
-            ? normalizeFeeRate({ satsPerVB }).normalizedSatsPerKB
-            : undefined),
+        fee_per_kb: resolvedFeePerKb,
       };
       if (options.memo !== undefined) xcpCreateSendOptions.memo = options.memo;
       if (options.memo_is_hex !== undefined) {

--- a/routes/api/v2/olga/mint.ts
+++ b/routes/api/v2/olga/mint.ts
@@ -12,6 +12,7 @@ import {
   CounterpartyApiManager,
   normalizeFeeRate,
 } from "$server/services/counterpartyApiService.ts";
+import { getProductionFeeService } from "$server/services/fee/feeServiceFactory.ts";
 import type {
   CreateStampIssuanceParams,
   NormalizedMintResponse,
@@ -92,6 +93,35 @@ export const handler: Handlers<NormalizedMintResponse | { error: string }> = {
           ? parseFloat(body.feeRate)
           : body.feeRate;
       }
+
+      // No fee rate supplied by the caller — fetch the live mempool recommended
+      // rate as a dynamic default. The website always sends an explicit rate
+      // (from its own fee selection), so this only affects direct API callers,
+      // who previously got a 400 here. FeeService has its own static fallbacks,
+      // so this rarely throws; if it does, normalizeFeeRate below still raises a
+      // clear 400.
+      if (
+        feeInputArgs.satsPerKB === undefined &&
+        feeInputArgs.satsPerVB === undefined
+      ) {
+        try {
+          const feeData = await getProductionFeeService().getFeeData();
+          if (feeData?.recommendedFee && feeData.recommendedFee > 0) {
+            feeInputArgs.satsPerVB = feeData.recommendedFee;
+            logger.info("api", {
+              message: "olga/mint: applied dynamic mempool fee default",
+              recommendedFee: feeData.recommendedFee,
+              source: feeData.source,
+            });
+          }
+        } catch (feeErr) {
+          logger.warn("api", {
+            message: "olga/mint: dynamic mempool fee default unavailable",
+            error: feeErr instanceof Error ? feeErr.message : String(feeErr),
+          });
+        }
+      }
+
       normalizedFees = normalizeFeeRate(feeInputArgs);
 
       // Override with MARA fee rate if in MARA mode and rate provided


### PR DESCRIPTION
## What
When `POST /api/v2/create/send` or `/api/v2/olga/mint` is called **without** a fee rate, the endpoint now fetches the live mempool recommended rate as a default, instead of falling back to Counterparty's internal default (`send`) or returning a 400 (`mint`).

## Why
This is the **API-call (server) side** only. The website is unaffected — it always sends an explicit `satsPerVB` from its own fee selection (sourced from `/api/internal/fees`), which still takes precedence. Direct API consumers who omit the fee previously never got our live mempool recommendation; now they do.

## Precedence
`explicit fee_per_kb` > `explicit satsPerVB` > **mempool default (new)**

## Source
Uses `getProductionFeeService().getFeeData()` directly (the same `FeeService` that backs `/api/internal/fees`: mempool.space → quicknode → cached, with static fallbacks). Called in-process — no HTTP round-trip, no origin-guard issue. The service is cached, so the hot path stays cheap; a mempool outage degrades gracefully (send → CP default; mint → existing 400 via normalizeFeeRate).

## Verify (post-deploy)
- `send`/`mint` with no fee → 200, logs `applied dynamic mempool fee default`.
- `send`/`mint` with explicit `satsPerVB` → unchanged (explicit wins).

Implements the enhancement discussed under #1151's fee investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)