### PR TITLE
feat(utxo): Redis caching + multi-provider esplora fallback

### DIFF
--- a/server/services/utxo/commonUtxoService.ts
+++ b/server/services/utxo/commonUtxoService.ts
@@ -1,6 +1,5 @@
 import type { CommonUTXOFetchOptions } from "$types/base.d.ts";
 import type {UTXO} from "$lib/types/base.d.ts";
-import { BLOCKSTREAM_API_BASE_URL, MEMPOOL_API_BASE_URL } from "$constants";
 import { logger } from "$lib/utils/logger.ts";
 import { detectScriptType } from "$lib/utils/bitcoin/scripts/scriptTypeUtils.ts";
 import {
@@ -8,10 +7,22 @@ import {
 } from "$lib/utils/bitcoin/utxo/utxoUtils.ts";
 import { serverConfig } from "$server/config/config.ts";
 import { FetchHttpClient } from "$server/interfaces/httpClient.ts";
+import { dbManager } from "$server/database/databaseManager.ts";
+import { fetchFromEsplora } from "$server/services/utxo/esploraFetch.ts";
 import { UTXOOptions as QuicknodeInternalUTXOOptions, QuicknodeUTXOService } from "$server/services/quicknode/quicknodeUTXOService.ts";
 import type {ICommonUTXOService, UTXOFetchOptions} from "$server/services/utxo/utxoServiceInterface.d.ts";
 
 const httpClient = new FetchHttpClient();
+
+/**
+ * Raw tx hex and a transaction's outputs (value + scriptPubKey) are immutable
+ * for a given txid — the txid is the hash of the serialized transaction — so
+ * these lookups are safe to cache for a long time. A 30-day TTL bounds Redis
+ * growth; a miss after expiry is just one cheap API call. Address UTXO *sets*
+ * are deliberately NOT cached (they change whenever the address transacts and a
+ * stale set could underfund a transaction).
+ */
+const IMMUTABLE_TX_CACHE_TTL = 30 * 24 * 60 * 60; // 30 days, in seconds
 
 
 // Added interface for mempool.space transaction response
@@ -60,14 +71,12 @@ interface MempoolTransaction {
 export class CommonUTXOService implements ICommonUTXOService {
   private static instance: CommonUTXOService;
   protected isQuickNodeConfigured: boolean;
-  protected rawTxHexCache: Map<string, string | null>; // Cache for raw tx hex
 
   constructor() {
     // Initialize QuickNode configuration check
     this.isQuickNodeConfigured = !!(
       serverConfig.QUICKNODE_ENDPOINT && serverConfig.QUICKNODE_API_KEY
     );
-    this.rawTxHexCache = new Map();
     logger.info("common-utxo-service", { message: "CommonUTXOService initialized", isQuickNodeConfigured: this.isQuickNodeConfigured });
   }
 
@@ -79,51 +88,48 @@ export class CommonUTXOService implements ICommonUTXOService {
   }
 
   async getRawTransactionHex(txid: string): Promise<string | null> {
-    if (this.rawTxHexCache.has(txid)) {
-      const cachedHex = this.rawTxHexCache.get(txid);
-      logger.debug("common-utxo-service", { message: "Cache hit for rawTxHex", txid, found: cachedHex !== null });
-      return cachedHex || null;
-    }
-    logger.debug("common-utxo-service", { message: "Cache miss for rawTxHex", txid });
+    // Raw tx hex is immutable for a given txid, so cache it in Redis (shared
+    // across service instances + ECS tasks; handleCache falls back to an
+    // in-memory cache automatically if Redis is unavailable).
+    return await dbManager.handleCache<string | null>(
+      `btc:rawtxhex:${txid}`,
+      () => this.fetchRawTransactionHexUncached(txid),
+      IMMUTABLE_TX_CACHE_TTL,
+    );
+  }
 
-    let hex: string | null = null;
+  private async fetchRawTransactionHexUncached(
+    txid: string,
+  ): Promise<string | null> {
+    // QuickNode first when configured (gated; the QUICKNODE_* env vars are unset
+    // in prod, so this branch is inert there and the public esplora providers
+    // serve all traffic).
     if (this.isQuickNodeConfigured) {
       try {
-        // Call the actual method from QuicknodeUTXOService
         const qnResponse = await QuicknodeUTXOService.getRawTransactionHex(txid);
-
         if (qnResponse.data) {
-          hex = qnResponse.data;
           logger.info("common-utxo-service", { message: "Successfully fetched rawTxHex from QuickNode", txid });
-        } else if (qnResponse.error) {
-          logger.warn("common-utxo-service", { message: "QuickNode returned error for getRawTransactionHex", txid, error: qnResponse.error });
-          // Fall through to public APIs
-        } else {
-          logger.warn("common-utxo-service", { message: "QuickNode did not return data or error for getRawTransactionHex", txid, response: qnResponse });
-          // Fall through to public APIs
+          return qnResponse.data;
         }
+        logger.warn("common-utxo-service", { message: "QuickNode returned no rawTxHex, falling back to public esplora APIs", txid, error: qnResponse.error });
       } catch (error) {
-        logger.error("common-utxo-service", { message: "Error during QuickNode getRawTransactionHex call", txid, error: error instanceof Error ? error.message : String(error), stack: error instanceof Error ? error.stack : undefined });
-        // Fall through to public APIs on error
+        logger.error("common-utxo-service", { message: "Error during QuickNode getRawTransactionHex call, falling back to public esplora APIs", txid, error: error instanceof Error ? error.message : String(error) });
       }
     }
 
-    if (!hex) {
-      logger.debug("common-utxo-service", { message: "Falling back to public APIs for getRawTransactionHex", txid });
-      try {
-        const response = await httpClient.get(`${BLOCKSTREAM_API_BASE_URL}/tx/${txid}/hex`);
-        if (response.ok) {
-          hex = response.data;
-          logger.info("common-utxo-service", { message: "Successfully fetched rawTxHex from public API (Blockstream)", txid });
-        } else {
-          logger.warn("common-utxo-service", { message: `Public API (Blockstream) failed to fetch raw tx hex ${txid}`, status: response.statusText, code: response.status });
-        }
-      } catch (error) {
-        logger.error("common-utxo-service", { message: "Error fetching rawTxHex from public APIs", txid, error: error instanceof Error ? error.message : String(error), stack: error instanceof Error ? error.stack : undefined });
-      }
-    }
-
-    return hex;
+    // Public esplora providers (mempool.space -> blockstream.info). Both expose
+    // GET /tx/:txid/hex returning the raw transaction as a hex string; the
+    // shared helper tries each in order so a single provider outage doesn't
+    // break tx construction.
+    return await fetchFromEsplora<string>(
+      `/tx/${txid}/hex`,
+      httpClient,
+      (data) => {
+        const hex = typeof data === "string" ? data.trim() : "";
+        return hex.length > 0 && /^[0-9a-fA-F]+$/.test(hex) ? hex : null;
+      },
+      { txid, op: "getRawTransactionHex" },
+    );
   }
 
   async getSpendableUTXOs(
@@ -237,85 +243,46 @@ export class CommonUTXOService implements ICommonUTXOService {
       }
     }
 
-    logger.debug("common-utxo-service", {
-        message: (this.isQuickNodeConfigured && options?.forcePublicAPI)
-            ? "FORCING public APIs for getSpecificUTXO due to option"
-            : "Falling back/using public APIs for getSpecificUTXO",
-        txid, vout
-    });
+    // Public esplora providers (mempool.space -> blockstream.info), cached.
+    // A transaction's output (value + scriptPubKey) is immutable for a given
+    // txid:vout (the txid commits to the outputs), so the result is safe to
+    // cache long-term. `forcePublicAPI` only changes which source is queried,
+    // not the resulting output, so it shares the same cache entry.
+    return await dbManager.handleCache<UTXO | null>(
+      `btc:txout:${txid}:${vout}`,
+      () => this.fetchSpecificUTXOFromEsplora(txid, vout),
+      IMMUTABLE_TX_CACHE_TTL,
+    );
+  }
 
-    // Try mempool.space first as it's often faster and more reliable
-    try {
-      logger.debug("common-utxo-service", { message: "Attempting mempool.space for getSpecificUTXO", txid, vout });
-      const response = await httpClient.get(`${MEMPOOL_API_BASE_URL}/tx/${txid}`);
-
-      if (response.ok && response.data) {
-        const txData = response.data as MempoolTransaction;
-
-        if (txData && Array.isArray(txData.vout) && txData.vout[vout]) {
-          const output = txData.vout[vout];
-          if (output.value !== undefined && output.scriptpubkey) {
-            const scriptFromMempool = output.scriptpubkey; // hex string
-            const formattedUtxo: UTXO = {
-              txid: txid,
-              vout: vout,
-              value: output.value,
-              script: scriptFromMempool,
-              vsize: txData.weight ? Math.ceil(txData.weight / 4) : 0,
-              weight: txData.weight,
-              scriptType: detectScriptType(scriptFromMempool),
-            };
-            logger.info("common-utxo-service", { message: "Successfully fetched and formatted specific UTXO from public API (Mempool.space)", txid, vout });
-            return formattedUtxo;
-          } else {
-            logger.warn("common-utxo-service", { message: "Mempool.space output missing value or scriptpubkey", txid, vout, output });
-            // Return null without fallback - if mempool has the tx but output is malformed,
-            // other APIs likely won't have better data
-            return null;
-          }
-        } else {
-          logger.warn("common-utxo-service", { message: "Specific output not found in tx from mempool.space", txid, vout, receivedVoutLength: txData?.vout?.length });
-          // Continue to fallback APIs
+  private async fetchSpecificUTXOFromEsplora(
+    txid: string,
+    vout: number,
+  ): Promise<UTXO | null> {
+    // mempool.space and blockstream.info both return the esplora tx JSON shape
+    // (vout[].value / vout[].scriptpubkey / weight), so one extractor handles
+    // both; the shared helper tries each provider in order.
+    return await fetchFromEsplora<UTXO>(
+      `/tx/${txid}`,
+      httpClient,
+      (data) => {
+        const txData = data as MempoolTransaction;
+        const output = txData?.vout?.[vout];
+        if (!output || output.value === undefined || !output.scriptpubkey) {
+          return null;
         }
-      } else {
-        logger.warn("common-utxo-service", { message: `Mempool.space failed to fetch tx ${txid}`, status: response.statusText, code: response.status });
-      }
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      logger.warn("common-utxo-service", { message: "Error fetching specific UTXO from mempool.space, trying Blockstream", txid, vout, error: errorMessage });
-    }
-
-    // Fallback to Blockstream API
-    try {
-        const response = await httpClient.get(`${BLOCKSTREAM_API_BASE_URL}/tx/${txid}`);
-        if (!response.ok) {
-            logger.warn("common-utxo-service", { message: `Public API (Blockstream) failed to fetch tx ${txid}`, status: response.statusText, code: response.status });
-            return null;
-        }
-        const txData = response.data;
-        if (txData && Array.isArray(txData.vout) && txData.vout[vout]) {
-            const output = txData.vout[vout];
-            if (output.value === undefined || !output.scriptpubkey) {
-                 logger.warn("common-utxo-service", { message: "Blockstream output missing value or scriptpubkey", txid, vout, output });
-                 return null;
-            }
-
-            const scriptFromBlockstream = output.scriptpubkey; // hex string
-            const formattedUtxo: UTXO = {
-                txid: txid, vout: vout, value: output.value, script: scriptFromBlockstream,
-                vsize: txData.weight ? Math.ceil(txData.weight / 4) : 0,
-                weight: txData.weight,
-                scriptType: detectScriptType(scriptFromBlockstream),
-            };
-            logger.info("common-utxo-service", { message: "Successfully fetched and formatted specific UTXO from public API (Blockstream)", txid, vout });
-            return formattedUtxo;
-        } else {
-            logger.warn("common-utxo-service", { message: "Specific output not found in tx from public API (Blockstream)", txid, vout, receivedVoutLength: txData?.vout?.length });
-            return null;
-        }
-    } catch (error) {
-      logger.error("common-utxo-service", { message: "Error fetching specific UTXO from all fallback APIs", txid, vout, error: error instanceof Error ? error.message : String(error), stack: error instanceof Error ? error.stack : undefined });
-      return null;
-    }
+        const script = output.scriptpubkey; // hex string
+        return {
+          txid,
+          vout,
+          value: output.value,
+          script,
+          vsize: txData.weight ? Math.ceil(txData.weight / 4) : 0,
+          weight: txData.weight,
+          scriptType: detectScriptType(script),
+        };
+      },
+      { txid, vout, op: "getSpecificUTXO" },
+    );
   }
 }

--- a/server/services/utxo/esploraFetch.ts
+++ b/server/services/utxo/esploraFetch.ts
@@ -1,0 +1,118 @@
+/**
+ * Shared esplora-provider fetch helper.
+ *
+ * mempool.space and blockstream.info expose the **same** HTTP API (the esplora
+ * API: `GET /tx/:txid`, `/tx/:txid/hex`, `/address/:addr/utxo`, ...), so a
+ * single code path can serve all of them. This module centralises the
+ * provider list and the "try each provider in order until one succeeds" logic
+ * so callers (e.g. CommonUTXOService) don't duplicate per-provider blocks.
+ *
+ * Both base URLs are env-overridable (`MEMPOOL_API_URL` / `BLOCKSTREAM_API_URL`
+ * in `lib/constants/apiUrls.ts`), so a self-hosted esplora instance can be
+ * slotted in as the primary provider without any code change.
+ */
+
+import { BLOCKSTREAM_API_BASE_URL, MEMPOOL_API_BASE_URL } from "$constants";
+import { logger } from "$lib/utils/logger.ts";
+import type { HttpClient } from "$server/interfaces/httpClient.ts";
+
+const LOG_NS = "common-utxo-service" as const;
+
+export interface EsploraProvider {
+  name: string;
+  baseUrl: string;
+}
+
+/**
+ * Ordered esplora providers. First entry is tried first; later entries are
+ * fallbacks. mempool.space is primary (typically lower latency / fresher
+ * mempool), blockstream.info is the fallback.
+ */
+export function getEsploraProviders(): EsploraProvider[] {
+  return [
+    { name: "mempool.space", baseUrl: MEMPOOL_API_BASE_URL },
+    { name: "blockstream.info", baseUrl: BLOCKSTREAM_API_BASE_URL },
+  ];
+}
+
+/**
+ * Fetch `path` from each esplora provider in order, returning the first result
+ * that `extract` maps to a non-null value. Returns `null` if every provider
+ * fails or none yields a usable value.
+ *
+ * `extract` lets the caller validate/transform the raw response (e.g. confirm a
+ * hex string is well-formed, or pull a specific vout out of a tx). Returning
+ * `null` from `extract` is treated as "this provider didn't have what we need"
+ * and moves on to the next provider.
+ *
+ * A network error or non-OK status from one provider is logged and the next
+ * provider is tried — a single provider outage never fails the whole lookup.
+ */
+export async function fetchFromEsplora<T>(
+  path: string,
+  httpClient: HttpClient,
+  extract: (data: unknown, provider: EsploraProvider) => T | null,
+  logContext: Record<string, unknown> = {},
+): Promise<T | null> {
+  const providers = getEsploraProviders();
+
+  for (const provider of providers) {
+    const url = `${provider.baseUrl}${path}`;
+    try {
+      const response = await httpClient.get(url);
+
+      if (
+        !response.ok || response.data === undefined || response.data === null
+      ) {
+        logger.warn(LOG_NS, {
+          message: "esplora provider returned non-OK / empty, trying next",
+          component: "esplora-fetch",
+          provider: provider.name,
+          path,
+          status: response.status,
+          ...logContext,
+        });
+        continue;
+      }
+
+      const value = extract(response.data, provider);
+      if (value !== null && value !== undefined) {
+        logger.info(LOG_NS, {
+          message: "esplora request served by provider",
+          component: "esplora-fetch",
+          provider: provider.name,
+          path,
+          ...logContext,
+        });
+        return value;
+      }
+
+      // extract() rejected this provider's payload (e.g. malformed) — try next.
+      logger.warn(LOG_NS, {
+        message: "esplora provider payload not usable, trying next",
+        component: "esplora-fetch",
+        provider: provider.name,
+        path,
+        ...logContext,
+      });
+    } catch (error) {
+      logger.warn(LOG_NS, {
+        message: "esplora provider request threw, trying next",
+        component: "esplora-fetch",
+        provider: provider.name,
+        path,
+        error: error instanceof Error ? error.message : String(error),
+        ...logContext,
+      });
+    }
+  }
+
+  logger.warn(LOG_NS, {
+    message: "all esplora providers failed",
+    component: "esplora-fetch",
+    path,
+    providers: providers.map((p) => p.name),
+    ...logContext,
+  });
+  return null;
+}

--- a/tests/unit/esploraFetch.test.ts
+++ b/tests/unit/esploraFetch.test.ts
@@ -1,0 +1,109 @@
+import { assertEquals } from "@std/assert";
+import {
+  fetchFromEsplora,
+  getEsploraProviders,
+} from "$server/services/utxo/esploraFetch.ts";
+import type {
+  HttpClient,
+  HttpResponse,
+} from "$server/interfaces/httpClient.ts";
+
+/**
+ * Minimal HttpClient stub: maps a URL substring to a canned response (or throws
+ * if the value is an Error). Records every URL it was asked for so tests can
+ * assert provider ordering / short-circuiting.
+ */
+function makeHttpClient(
+  handler: (url: string) => HttpResponse | Error,
+): { client: HttpClient; calls: string[] } {
+  const calls: string[] = [];
+  const get = (url: string): Promise<HttpResponse> => {
+    calls.push(url);
+    const result = handler(url);
+    if (result instanceof Error) return Promise.reject(result);
+    return Promise.resolve(result);
+  };
+  // Only `get` is exercised by fetchFromEsplora; cast the rest.
+  const client = { get } as unknown as HttpClient;
+  return { client, calls };
+}
+
+function ok(data: unknown): HttpResponse {
+  return { data, status: 200, statusText: "OK", headers: {}, ok: true };
+}
+function notOk(status = 503): HttpResponse {
+  return { data: null, status, statusText: "ERR", headers: {}, ok: false };
+}
+
+const [PRIMARY, FALLBACK] = getEsploraProviders();
+
+Deno.test("fetchFromEsplora: returns primary result and does NOT call fallback", async () => {
+  const { client, calls } = makeHttpClient(() => ok("deadbeef"));
+  const result = await fetchFromEsplora<string>(
+    "/tx/abc/hex",
+    client,
+    (d) => (typeof d === "string" ? d : null),
+  );
+  assertEquals(result, "deadbeef");
+  assertEquals(calls.length, 1);
+  assertEquals(calls[0], `${PRIMARY.baseUrl}/tx/abc/hex`);
+});
+
+Deno.test("fetchFromEsplora: falls back to second provider when primary is non-OK", async () => {
+  const { client, calls } = makeHttpClient((url) =>
+    url.startsWith(PRIMARY.baseUrl) ? notOk() : ok("cafe")
+  );
+  const result = await fetchFromEsplora<string>(
+    "/tx/abc/hex",
+    client,
+    (d) => (typeof d === "string" ? d : null),
+  );
+  assertEquals(result, "cafe");
+  assertEquals(calls.length, 2);
+  assertEquals(calls[1], `${FALLBACK.baseUrl}/tx/abc/hex`);
+});
+
+Deno.test("fetchFromEsplora: falls back when primary THROWS (outage)", async () => {
+  const { client } = makeHttpClient((url) =>
+    url.startsWith(PRIMARY.baseUrl) ? new Error("ECONNRESET") : ok("beef")
+  );
+  const result = await fetchFromEsplora<string>(
+    "/tx/abc/hex",
+    client,
+    (d) => (typeof d === "string" ? d : null),
+  );
+  assertEquals(result, "beef");
+});
+
+Deno.test("fetchFromEsplora: falls back when extract rejects primary payload as malformed", async () => {
+  const { client, calls } = makeHttpClient((url) =>
+    url.startsWith(PRIMARY.baseUrl) ? ok({ malformed: true }) : ok({ value: 5 })
+  );
+  const result = await fetchFromEsplora<number>(
+    "/tx/abc",
+    client,
+    (d) => {
+      const v = (d as { value?: number }).value;
+      return typeof v === "number" ? v : null;
+    },
+  );
+  assertEquals(result, 5);
+  assertEquals(calls.length, 2);
+});
+
+Deno.test("fetchFromEsplora: returns null when ALL providers fail", async () => {
+  const { client, calls } = makeHttpClient(() => notOk(500));
+  const result = await fetchFromEsplora<string>(
+    "/tx/abc/hex",
+    client,
+    (d) => (typeof d === "string" ? d : null),
+  );
+  assertEquals(result, null);
+  assertEquals(calls.length, getEsploraProviders().length);
+});
+
+Deno.test("getEsploraProviders: mempool.space is primary, blockstream.info is fallback", () => {
+  const providers = getEsploraProviders();
+  assertEquals(providers[0].name, "mempool.space");
+  assertEquals(providers[1].name, "blockstream.info");
+});


### PR DESCRIPTION
## Why
Measured prod load is **~341 outbound public-API calls/day with zero rate-limit errors**, so self-hosting ($56/mo) or QuickNode ($75/mo, now cancelled) aren't justified. Instead, harden the free public-API path — the only path in prod (QuickNode is unconfigured) — at no monthly cost.

## Changes
- **New `server/services/utxo/esploraFetch.ts`** (shared, unit-tested): centralizes the esplora provider list (mempool.space → blockstream.info — both env-overridable to a self-hosted node via `MEMPOOL_API_URL`/`BLOCKSTREAM_API_URL`) and a "try each provider until one succeeds" helper. A single provider outage no longer breaks tx construction.
- **`getRawTransactionHex`**: was **Blockstream-only** + a per-instance in-memory `Map`; now **multi-provider** (mempool + blockstream) and **Redis-cached** via `dbManager.handleCache` (shared across instances/ECS tasks, auto in-memory fallback if Redis is down). Raw tx hex is immutable per txid → 30-day TTL.
- **`getSpecificUTXO`**: unified the duplicated mempool/blockstream blocks into the shared helper + Redis caching (tx outputs are immutable per `txid:vout`).
- **Address UTXO *sets* are deliberately NOT cached** (they change on spend; a stale set could underfund a tx). That path already has 4-provider fallback (mempool/blockstream/blockchain/blockcypher).

## Safety
- Only **immutable** data is cached (raw tx hex, tx outputs — both committed to by the txid). No spent/confirmed status is cached.
- Transient all-providers-down returns `null`, which is **not** cached (no cache poisoning).
- Public method signatures unchanged; existing UTXO unit + integration tests preserved.

## Tests
`tests/unit/esploraFetch.test.ts` — provider ordering, short-circuit on primary success, fallback on non-OK / throw / malformed payload, all-fail → null. (6 tests pass.)

## Follow-up (not in this PR)
QuickNode integration code (`QuicknodeUTXOService`, `QuickNodeFeeProvider`) is now fully dead (env unset + cancelled) — a separate cleanup PR can remove it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)