### PR TITLE
fix(tx): empty-wallet UTXO selection → 400 not opaque 500 (#1155)

### DIFF
--- a/server/services/transaction/bitcoinUtxoManager.ts
+++ b/server/services/transaction/bitcoinUtxoManager.ts
@@ -134,7 +134,12 @@ export class BitcoinUtxoManager {
 
     if (!basicUtxos || basicUtxos.length === 0) {
       logger.warn("transaction-utxo-service", { message: "No basic UTXOs available for transaction after fetching/filtering", address, optionsReceived: options });
-      throw new Error("No UTXOs available for transaction after filtering (selectUTXOsForTransaction entry)");
+      // Phrase the message so every create/* route's error classifier (which
+      // matches the lowercase substring "insufficient funds", some case-
+      // sensitively) maps an empty/unfunded wallet to HTTP 400 instead of an
+      // opaque 500 — an empty wallet is a client condition, not a server bug
+      // (#1155).
+      throw new Error("No spendable UTXOs available for this address (insufficient funds)");
     }
 
     return this.selectUTXOsLogic(basicUtxos, vouts, feeRate, !!options.includeAncestors);

--- a/tests/unit/bitcoinUtxoManager.branch-coverage.test.ts
+++ b/tests/unit/bitcoinUtxoManager.branch-coverage.test.ts
@@ -267,7 +267,7 @@ class MockUTXOService {
 
     if (!basicUtxos || basicUtxos.length === 0) {
       throw new Error(
-        "No UTXOs available for transaction after filtering (selectUTXOsForTransaction entry)",
+        "No spendable UTXOs available for this address (insufficient funds)",
       );
     }
 
@@ -579,7 +579,7 @@ Deno.test("UTXOService - Comprehensive Branch Coverage", async (t) => {
     await assertRejects(
       () => service.selectUTXOsForTransaction("empty_address", vouts, 10),
       Error,
-      "No UTXOs available for transaction after filtering",
+      "No spendable UTXOs available for this address (insufficient funds)",
     );
   });
 


### PR DESCRIPTION
## Problem
`POST /api/v2/olga/mint` (and other tx-building routes) returned an opaque **500** when the source wallet had no spendable UTXOs. Root cause: `BitcoinUtxoManager.selectUTXOsForTransaction` (`bitcoinUtxoManager.ts:137`) threw `"No UTXOs available for transaction after filtering"`, which matched **none** of the routes' error classifiers (they key on `"insufficient funds"` / `"UTXO selection failed"`), so it fell through to `internalError` → 500. Surfaced by the nightly Newman `Mint Stamp` test (unfunded `test_address`).

Confirmed on prod: unfunded wallet → 500 `{"error":"Internal server error",...}`; the real thrown message (from CloudWatch) was `"No UTXOs available for transaction after filtering (selectUTXOsForTransaction entry)"`.

## Fix (at the source — all consumers benefit)
Reword the thrown message to **`"No spendable UTXOs available for this address (insufficient funds)"`**. The lowercase `insufficient funds` substring is recognised by the existing classifiers in **all six** tx-building routes (olga/mint, create/send, trx/stampattach, trx/stampdetach — which matches case-sensitively, src20/create, src101/create), so an empty wallet now returns a structured **400** with a clear message instead of a 500. An empty wallet is a client condition, not a server bug.

No per-route changes needed. Also drops the leaky `(selectUTXOsForTransaction entry)` internal detail.

## Tests
Updated the two assertions in `bitcoinUtxoManager.branch-coverage.test.ts` that pinned the old string. Branch-coverage test green; source type-checks.

## Verify (post-deploy)
`POST /api/v2/olga/mint` with an unfunded wallet → **400** (was 500); funded wallet still → 200 + PSBT.

Fixes #1155

🤖 Generated with [Claude Code](https://claude.com/claude-code)