### PR TITLE
fix(tx): stampattach fee double-count → trust CP outputs (#959)

### DIFF
--- a/lib/utils/bitcoin/psbt/serviceFeeOutputs.ts
+++ b/lib/utils/bitcoin/psbt/serviceFeeOutputs.ts
@@ -1,0 +1,146 @@
+/**
+ * Shared helper for assembling the output set of a Counterparty-composed
+ * transaction that we reconstruct into a PSBT (attach, and — as this is
+ * consolidated — send/detach/mint).
+ *
+ * Core principle (matches `routes/api/v2/create/send.ts`, #1137): **trust
+ * Counterparty's composed outputs.** CP has already deducted its network fee
+ * and computed the change back to the source address, so we do NOT re-derive a
+ * network fee or add a second change output. The previous stampattach code did
+ * exactly that, double-counting the fee (`change = cpFee − ourFee`) and
+ * producing a constant ~279-sat deficit on every wallet (#959).
+ *
+ * The only thing we optionally add on top of CP's outputs is an **operator
+ * service fee**, funded by reducing CP's change output (an optional "service"
+ * layer the operator enables via env vars). This module is pure and codec-
+ * injected so it can be unit-tested without bitcoinjs/network coupling.
+ */
+
+export interface TxOutput {
+  /** raw scriptPubKey */
+  script: Uint8Array;
+  /** value in satoshis */
+  value: bigint;
+}
+
+export interface ServiceFeeOutputsParams {
+  /** Counterparty's composed outputs, in order (includes CP's change). */
+  cpOutputs: TxOutput[];
+  /** Sum of the user's inputs the PSBT spends. */
+  sumOfUserInputs: bigint;
+  /** Source/change address (CP sends change back here). */
+  sourceAddress: string;
+  /** Operator service fee in sats (0 disables the service-fee output). */
+  serviceFeeSats: bigint;
+  /** Destination for the service fee; required when serviceFeeSats > 0. */
+  serviceFeeAddress?: string | undefined;
+  /** Dust threshold; a change output below this is dropped (rolls into fee). */
+  dustSize: bigint;
+  /** Decode a scriptPubKey to an address, or undefined if not address-like. */
+  decodeAddress: (script: Uint8Array) => string | undefined;
+  /** Encode an address to a scriptPubKey. */
+  encodeAddress: (address: string) => Uint8Array;
+}
+
+export interface ServiceFeeOutputsResult {
+  /** Final outputs to add to the PSBT, in order. */
+  outputs: TxOutput[];
+  /** CP's implicit miner fee: sumOfUserInputs − Σ(cpOutputs). */
+  cpNetworkFee: bigint;
+  /** Service fee actually added (0 if none). */
+  serviceFeeAdded: bigint;
+  /**
+   * Total cost to the user beyond the attach itself: the on-chain miner fee
+   * (inputs − final outputs) plus the service fee. Suitable for `estimatedFee`.
+   */
+  totalFee: bigint;
+}
+
+/**
+ * Reconstruct the final output set, optionally splicing an operator service fee
+ * out of Counterparty's change output.
+ *
+ * @throws Error (message contains "insufficient funds") when a service fee is
+ * requested but there is no change output, or the change cannot cover it.
+ */
+export function buildServiceFeeOutputs(
+  params: ServiceFeeOutputsParams,
+): ServiceFeeOutputsResult {
+  const {
+    cpOutputs,
+    sumOfUserInputs,
+    sourceAddress,
+    serviceFeeSats,
+    serviceFeeAddress,
+    dustSize,
+    decodeAddress,
+    encodeAddress,
+  } = params;
+
+  const cpOutputsTotal = cpOutputs.reduce((sum, o) => sum + o.value, 0n);
+  const cpNetworkFee = sumOfUserInputs - cpOutputsTotal;
+  if (cpNetworkFee < 0n) {
+    // CP's own composition is internally consistent (inputs ≥ outputs); a
+    // negative here means we mis-summed the inputs — fail loud rather than emit
+    // a transaction that can't be mined.
+    throw new Error(
+      `insufficient funds: inputs ${sumOfUserInputs} do not cover Counterparty outputs ${cpOutputsTotal}`,
+    );
+  }
+
+  // Default path (service fee disabled): trust CP's outputs verbatim.
+  const outputs: TxOutput[] = cpOutputs.map((o) => ({
+    script: o.script,
+    value: o.value,
+  }));
+  let serviceFeeAdded = 0n;
+
+  if (serviceFeeSats > 0n && serviceFeeAddress) {
+    // Find CP's change output: the last output paying back to the source.
+    let changeIndex = -1;
+    for (let i = outputs.length - 1; i >= 0; i--) {
+      const addr = decodeAddress(outputs[i].script);
+      if (addr === sourceAddress) {
+        changeIndex = i;
+        break;
+      }
+    }
+    if (changeIndex === -1) {
+      throw new Error(
+        "insufficient funds: no change output available to fund the service fee",
+      );
+    }
+
+    const reducedChange = outputs[changeIndex].value - serviceFeeSats;
+    if (reducedChange < 0n) {
+      throw new Error(
+        `insufficient funds: change ${
+          outputs[changeIndex].value
+        } cannot cover service fee ${serviceFeeSats}`,
+      );
+    }
+
+    if (reducedChange < dustSize) {
+      // Reduced change would be dust — drop it (its value rolls into the miner
+      // fee) rather than create an unspendable output.
+      outputs.splice(changeIndex, 1);
+    } else {
+      outputs[changeIndex] = {
+        script: outputs[changeIndex].script,
+        value: reducedChange,
+      };
+    }
+
+    outputs.push({
+      script: encodeAddress(serviceFeeAddress),
+      value: serviceFeeSats,
+    });
+    serviceFeeAdded = serviceFeeSats;
+  }
+
+  const finalOutputsTotal = outputs.reduce((sum, o) => sum + o.value, 0n);
+  const minerFee = sumOfUserInputs - finalOutputsTotal;
+  const totalFee = minerFee + serviceFeeAdded;
+
+  return { outputs, cpNetworkFee, serviceFeeAdded, totalFee };
+}

--- a/routes/api/v2/trx/stampattach.ts
+++ b/routes/api/v2/trx/stampattach.ts
@@ -1,18 +1,12 @@
 import { TX_CONSTANTS } from "$constants";
 import { Handlers } from "$fresh/server.ts";
-import type {
-  InputTypeForSizeEstimation,
-  OutputTypeForSizeEstimation,
-  ScriptTypeInfo,
-} from "$lib/types/transaction.d.ts";
 import { ApiResponseUtil } from "$lib/utils/api/responses/apiResponseUtil.ts";
 import { logger } from "$lib/utils/logger.ts";
-import { estimateMintingTransactionSize } from "$lib/utils/bitcoin/minting/transactionSizes.ts";
-import { getScriptTypeInfo } from "$lib/utils/bitcoin/scripts/scriptTypeUtils.ts";
 import {
   buildCpPsbtInput,
   buildCpPsbtInputsFromRawTx,
 } from "$lib/utils/bitcoin/psbt/cpRawTxInputs.ts";
+import { buildServiceFeeOutputs } from "$lib/utils/bitcoin/psbt/serviceFeeOutputs.ts";
 import { serverConfig } from "$server/config/config.ts"; // Import serverConfig
 import { StampController } from "$server/controller/stampController.ts";
 import {
@@ -164,176 +158,63 @@ export const handler: Handlers = {
         inputsToSign.push(...cpInputsToSign);
       }
 
-      let cpOutputsTotalValue = BigInt(0);
-      const essentialCpOutputs: { script: Buffer; value: bigint }[] = [];
-      for (const output of cpTx.outs) {
-        try {
-          bjsAddress.fromOutputScript(
-            output.script,
-            network,
-          );
-        } catch (_e: any) { /* Not a simple address output, _e is now used */ }
-        essentialCpOutputs.push({
-          script: Buffer.from(output.script),
-          value: BigInt(output.value),
-        });
-        cpOutputsTotalValue += BigInt(output.value);
-      }
-      essentialCpOutputs.forEach((out) => psbt.addOutput(out));
+      // Trust Counterparty's composed outputs: CP has already deducted its
+      // network fee and computed the change back to the source. We add them
+      // as-is (same approach as create/send, #1137) and only optionally splice
+      // an operator service fee out of CP's change via the shared helper. The
+      // prior code copied CP's change AND re-derived its own network fee + a
+      // second change output, double-counting the fee (change = cpFee - ourFee
+      // -> a constant ~279 sat deficit on every wallet, #959).
+      const cpOutputs = cpTx.outs.map((output) => ({
+        script: new Uint8Array(output.script),
+        value: BigInt(output.value),
+      }));
 
-      let totalValueToOutputsExcludingChange = cpOutputsTotalValue;
       const feeService = body.service_fee ?? options?.service_fee ??
         parseInt(serverConfig.MINTING_SERVICE_FEE_FIXED_SATS, 10);
       const feeServiceAddress = body.service_fee_address ??
         options?.service_fee_address ??
         serverConfig.MINTING_SERVICE_FEE_ADDRESS;
-      let actualServiceFeeAdded = BigInt(0);
 
-      if (feeService > 0 && feeServiceAddress) {
-        psbt.addOutput({
-          address: feeServiceAddress,
-          value: BigInt(feeService),
-        });
-        totalValueToOutputsExcludingChange += BigInt(feeService);
-        actualServiceFeeAdded = BigInt(feeService);
-        logger.info("api", {
-          message: "Added service fee output",
-          fee: feeService,
-          to: feeServiceAddress,
-        });
-      }
-
-      // Estimate size and calculate final network fee and change
-      const tempPsbtForSize = psbt.clone();
-      tempPsbtForSize.addOutput({
-        address: address,
-        value: BigInt(TX_CONSTANTS.DUST_SIZE),
-      });
-
-      const inputsForSizeEst: InputTypeForSizeEstimation[] = psbt.data.inputs
-        .map((input, idx) => {
-          let scriptHex = "";
-          if (input.witnessUtxo?.script) {
-            scriptHex = input.witnessUtxo.script.toString();
-          } else if (input.nonWitnessUtxo) {
+      const { outputs: finalOutputs, cpNetworkFee, serviceFeeAdded, totalFee } =
+        buildServiceFeeOutputs({
+          cpOutputs,
+          sumOfUserInputs,
+          sourceAddress: address,
+          serviceFeeSats: BigInt(feeService > 0 ? feeService : 0),
+          serviceFeeAddress: feeServiceAddress,
+          dustSize: BigInt(TX_CONSTANTS.DUST_SIZE),
+          decodeAddress: (script) => {
             try {
-              scriptHex = Buffer.from(
-                Transaction.fromBuffer(input.nonWitnessUtxo)
-                  .outs[psbt.txInputs[idx].index].script,
-              ).toString("hex");
-            } catch (e: any) {
-              logger.warn("api", {
-                message:
-                  `Error parsing nonWitnessUtxo for size est input ${idx}: ${e.message}`,
-              });
+              return bjsAddress.fromOutputScript(Buffer.from(script), network);
+            } catch {
+              return undefined;
             }
-          }
-          const scriptInfo: ScriptTypeInfo = getScriptTypeInfo(scriptHex || "");
-
-          const estInput: InputTypeForSizeEstimation = {
-            type: scriptInfo.type,
-            isWitness: scriptInfo.isWitness,
-          };
-          if (scriptInfo.redeemScriptType?.type !== undefined) {
-            estInput.redeemScriptType = scriptInfo.redeemScriptType.type;
-          }
-          return estInput;
+          },
+          encodeAddress: (addr) =>
+            new Uint8Array(bjsAddress.toOutputScript(addr, network)),
         });
 
-      const outputsForSizeEst: OutputTypeForSizeEstimation[] = tempPsbtForSize
-        .txOutputs.map((out) => {
-          const scriptInfo: ScriptTypeInfo = getScriptTypeInfo(
-            Buffer.from(out.script).toString("hex"),
-          );
-          return { type: scriptInfo.type };
-        });
+      for (const out of finalOutputs) {
+        psbt.addOutput({ script: Buffer.from(out.script), value: out.value });
+      }
 
-      const estimatedVsize = estimateMintingTransactionSize({
-        inputs: inputsForSizeEst,
-        outputs: outputsForSizeEst,
-        includeChangeOutput: false,
+      logger.info("api", {
+        message: "Assembled stampattach outputs (trust-CP + service fee)",
+        cpNetworkFee: cpNetworkFee.toString(),
+        serviceFeeAdded: serviceFeeAdded.toString(),
+        totalFee: totalFee.toString(),
+        outputCount: finalOutputs.length,
       });
-      const networkFee = BigInt(
-        Math.ceil(estimatedVsize * normalizedFees.normalizedSatsPerVB),
-      );
-      const finalUserChangeConst = sumOfUserInputs -
-        totalValueToOutputsExcludingChange - networkFee;
-      const finalUserChangeValue = finalUserChangeConst;
 
-      if (actualServiceFeeAdded > BigInt(0)) {
-        let cpChangeOutputIndex = -1;
-        for (let i = psbt.txOutputs.length - 1; i >= 0; i--) {
-          let outputAddr;
-          try {
-            outputAddr = bjsAddress.fromOutputScript(
-              psbt.txOutputs[i].script,
-              network,
-            );
-          } catch (_e: any) { // Intentionally empty
-          }
-          if (outputAddr === address && outputAddr !== feeServiceAddress) {
-            cpChangeOutputIndex = i;
-            break;
-          }
-        }
-        if (
-          cpChangeOutputIndex !== -1 &&
-          psbt.txOutputs[cpChangeOutputIndex].value !== actualServiceFeeAdded
-        ) {
-          logger.info("api", {
-            message:
-              `Removing potential CP change output at index ${cpChangeOutputIndex} before adding new change.`,
-          });
-          psbt.txOutputs.splice(cpChangeOutputIndex, 1);
-          if (psbt.data.globalMap.unsignedTx) {
-            (psbt.data.globalMap.unsignedTx as any).outs.splice(
-              cpChangeOutputIndex,
-              1,
-            );
-          }
-        } else {
-          while (psbt.txOutputs.length > 0) psbt.txOutputs.pop();
-          if (psbt.data.globalMap.unsignedTx) {
-            (psbt.data.globalMap.unsignedTx as any).outs = [];
-          }
-          essentialCpOutputs.forEach((out) => psbt.addOutput(out));
-          if (feeService > 0 && feeServiceAddress) {
-            psbt.addOutput({
-              address: feeServiceAddress,
-              value: BigInt(feeService),
-            });
-          }
-        }
-      }
-      if (finalUserChangeValue >= BigInt(TX_CONSTANTS.DUST_SIZE)) {
-        psbt.addOutput({ address: address, value: finalUserChangeValue });
-      } else if (
-        finalUserChangeValue > BigInt(0) &&
-        finalUserChangeValue < BigInt(TX_CONSTANTS.DUST_SIZE)
-      ) {
-        logger.info("api", {
-          message: "Change is dust, adding to fee for stampattach",
-          change: finalUserChangeValue.toString(),
-        });
-      } else if (finalUserChangeValue < BigInt(0)) {
-        throw new Error(
-          `Insufficient funds after all calculations for attach. Deficit: ${-finalUserChangeValue}`,
-        );
-      }
       // Return unsigned PSBT for the wallet to sign (do NOT finalize —
-      // finalizeAllInputs() requires signatures which the wallet provides)
+      // finalizeAllInputs() requires signatures which the wallet provides).
       const finalPsbtHex = psbt.toHex();
       return ApiResponseUtil.success({
         psbtHex: finalPsbtHex,
         inputsToSign,
-        estimatedFee: Number(
-          networkFee +
-            (finalUserChangeValue < BigInt(TX_CONSTANTS.DUST_SIZE) &&
-                finalUserChangeValue > 0
-              ? finalUserChangeValue
-              : BigInt(0)),
-        ),
-        estimatedVsize: Number(estimatedVsize),
+        estimatedFee: Number(totalFee),
+        estimatedVsize: cpTx.virtualSize(),
       }, { forceNoCache: true });
     } catch (error: unknown) {
       const errorMessage = error instanceof Error

--- a/tests/unit/serviceFeeOutputs.test.ts
+++ b/tests/unit/serviceFeeOutputs.test.ts
@@ -1,0 +1,168 @@
+import { assertEquals, assertThrows } from "@std/assert";
+import {
+  buildServiceFeeOutputs,
+  type TxOutput,
+} from "$lib/utils/bitcoin/psbt/serviceFeeOutputs.ts";
+
+// Simple in-memory address codec for testing (no bitcoinjs needed): an
+// "address" output script is the bytes of `ADDR:<addr>`; anything else (e.g. an
+// OP_RETURN data output) decodes to undefined.
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+function encodeAddress(addr: string): Uint8Array {
+  return enc.encode(`ADDR:${addr}`);
+}
+function decodeAddress(script: Uint8Array): string | undefined {
+  const s = dec.decode(script);
+  return s.startsWith("ADDR:") ? s.slice(5) : undefined;
+}
+const DATA_SCRIPT = enc.encode("OP_RETURN_DATA"); // non-address output
+
+const DUST = 546n;
+
+function sum(outs: TxOutput[]): bigint {
+  return outs.reduce((acc, o) => acc + o.value, 0n);
+}
+
+Deno.test("service_fee=0: trusts CP outputs verbatim, no deficit (#959 repro)", () => {
+  // CP composed: data output + attach output + change back to source.
+  const cpOutputs: TxOutput[] = [
+    { script: DATA_SCRIPT, value: 0n },
+    { script: DATA_SCRIPT, value: 330n }, // attach/destination
+    { script: encodeAddress("src"), value: 9000n }, // CP change
+  ];
+  const r = buildServiceFeeOutputs({
+    cpOutputs,
+    sumOfUserInputs: 10000n,
+    sourceAddress: "src",
+    serviceFeeSats: 0n,
+    dustSize: DUST,
+    decodeAddress,
+    encodeAddress,
+  });
+
+  // Outputs unchanged; fee is exactly CP's implicit fee; NO negative change.
+  assertEquals(r.outputs, cpOutputs);
+  assertEquals(r.cpNetworkFee, 670n); // 10000 - 9330
+  assertEquals(r.serviceFeeAdded, 0n);
+  assertEquals(r.totalFee, 670n);
+  // Invariant: inputs >= outputs (no deficit — the old code produced one here).
+  assertEquals(10000n - sum(r.outputs) >= 0n, true);
+});
+
+Deno.test("service_fee>0: funded from change, totals balance", () => {
+  const cpOutputs: TxOutput[] = [
+    { script: DATA_SCRIPT, value: 330n },
+    { script: encodeAddress("src"), value: 9000n },
+  ];
+  const r = buildServiceFeeOutputs({
+    cpOutputs,
+    sumOfUserInputs: 10000n,
+    sourceAddress: "src",
+    serviceFeeSats: 500n,
+    serviceFeeAddress: "svc",
+    dustSize: DUST,
+    decodeAddress,
+    encodeAddress,
+  });
+
+  // change reduced by 500, service-fee output appended
+  assertEquals(r.outputs.length, 3);
+  assertEquals(r.outputs[1].value, 8500n); // reduced change
+  assertEquals(decodeAddress(r.outputs[2].script), "svc");
+  assertEquals(r.outputs[2].value, 500n);
+  assertEquals(r.serviceFeeAdded, 500n);
+  assertEquals(r.cpNetworkFee, 670n);
+  // miner fee unchanged (670), total cost = miner + service
+  assertEquals(10000n - sum(r.outputs), 670n);
+  assertEquals(r.totalFee, 1170n);
+});
+
+Deno.test("service_fee>0: dust change is dropped (rolls into miner fee)", () => {
+  const cpOutputs: TxOutput[] = [
+    { script: DATA_SCRIPT, value: 330n },
+    { script: encodeAddress("src"), value: 600n },
+  ];
+  const r = buildServiceFeeOutputs({
+    cpOutputs,
+    sumOfUserInputs: 1000n,
+    sourceAddress: "src",
+    serviceFeeSats: 100n,
+    serviceFeeAddress: "svc",
+    dustSize: DUST,
+    decodeAddress,
+    encodeAddress,
+  });
+
+  // 600 - 100 = 500 < dust(546) -> change dropped, only attach + service remain
+  assertEquals(r.outputs.length, 2);
+  assertEquals(decodeAddress(r.outputs[1].script), "svc");
+  assertEquals(r.outputs[1].value, 100n);
+  assertEquals(r.serviceFeeAdded, 100n);
+  // dropped 500 sat change rolls into miner fee: 70 (cp) + 500 = 570
+  assertEquals(1000n - sum(r.outputs), 570n);
+  assertEquals(r.totalFee, 670n); // 570 miner + 100 service
+});
+
+Deno.test("service_fee>0: throws insufficient funds when change can't cover it", () => {
+  const cpOutputs: TxOutput[] = [
+    { script: DATA_SCRIPT, value: 330n },
+    { script: encodeAddress("src"), value: 400n },
+  ];
+  assertThrows(
+    () =>
+      buildServiceFeeOutputs({
+        cpOutputs,
+        sumOfUserInputs: 1000n,
+        sourceAddress: "src",
+        serviceFeeSats: 500n, // > 400 change
+        serviceFeeAddress: "svc",
+        dustSize: DUST,
+        decodeAddress,
+        encodeAddress,
+      }),
+    Error,
+    "insufficient funds",
+  );
+});
+
+Deno.test("service_fee>0: throws when there is no change output to fund it", () => {
+  const cpOutputs: TxOutput[] = [
+    { script: DATA_SCRIPT, value: 330n }, // only a data/destination output
+  ];
+  assertThrows(
+    () =>
+      buildServiceFeeOutputs({
+        cpOutputs,
+        sumOfUserInputs: 1000n,
+        sourceAddress: "src",
+        serviceFeeSats: 100n,
+        serviceFeeAddress: "svc",
+        dustSize: DUST,
+        decodeAddress,
+        encodeAddress,
+      }),
+    Error,
+    "no change output",
+  );
+});
+
+Deno.test("throws when inputs do not cover CP outputs (mis-summed inputs)", () => {
+  const cpOutputs: TxOutput[] = [
+    { script: encodeAddress("src"), value: 5000n },
+  ];
+  assertThrows(
+    () =>
+      buildServiceFeeOutputs({
+        cpOutputs,
+        sumOfUserInputs: 4000n, // < outputs
+        sourceAddress: "src",
+        serviceFeeSats: 0n,
+        dustSize: DUST,
+        decodeAddress,
+        encodeAddress,
+      }),
+    Error,
+    "insufficient funds",
+  );
+});


### PR DESCRIPTION
## Problem
`/api/v2/trx/stampattach` fails for **every** wallet with a constant **~279 sat deficit** (`Insufficient funds after all calculations for attach. Deficit: …`), regardless of balance — the endpoint is effectively 100% broken in prod.

**Root cause** (`stampattach.ts`): it copied Counterparty's composed outputs — which already include CP's change (CP's fee deducted) — **and then** re-derived its own network fee + a **second** change output. The change formula collapsed to `change = cpFee − ourFee` → negative whenever `ourFee > cpFee`. The variable `totalValueToOutputsExcludingChange` was misnamed: it **included** CP's change.

## Fix — trust CP's outputs (same as create/send #1137)
CP already deducted its network fee and computed change. We add CP's outputs verbatim; the only thing layered on top is an **optional operator service fee**, funded by reducing CP's change output (the env-configurable "service" layer).

- **New `lib/utils/bitcoin/psbt/serviceFeeOutputs.ts`** — pure, codec-injected `buildServiceFeeOutputs()`: trust-CP + splice-service-fee-from-change. Seeds the planned **shared service-fee layer** for send/mint/detach/attach.
- **`stampattach.ts`** — removed the entire `networkFee`/`finalUserChange` recalculation + duplicate change output; now calls the helper. `estimatedFee` = CP miner fee + service fee; `estimatedVsize` = `cpTx.virtualSize()`. Dropped now-unused size-estimation imports.

## Tests
`tests/unit/serviceFeeOutputs.test.ts` (6, all green): **service_fee=0 → no deficit (#959 repro)**, service-fee-from-change balance, dust-change drop, insufficient-funds + no-change-output throws, inputs<outputs guard. Type-checks clean. Newman suite covers stampattach end-to-end (Attach Stamp - Dev/Prod).

## ⚠️ Verification gate before prod
The pure fee/change math is unit-proven, but **before releasing to main I'll compose against the funded test wallet on prod and inspect the returned PSBT** (inputs − outputs = sane fee, no deficit, change correct) — no broadcast. The endpoint is already 100% broken, so there is no working behavior to regress.

## Follow-up
Consolidate send/mint/detach onto the shared `buildServiceFeeOutputs` helper (separate issue).

Fixes #959

🤖 Generated with [Claude Code](https://claude.com/claude-code)