### PR TITLE
fix(tx): stampattach — guard optional options to avoid opaque 500

### DIFF
--- a/routes/api/v2/trx/stampattach.ts
+++ b/routes/api/v2/trx/stampattach.ts
@@ -59,10 +59,10 @@ export const handler: Handlers = {
 
       // Prepare args for normalizeFeeRate carefully due to exactOptionalPropertyTypes
       const feeArgs: { satsPerKB?: number; satsPerVB?: number } = {};
-      if (options.fee_per_kb !== undefined) {
+      if (options?.fee_per_kb !== undefined) {
         feeArgs.satsPerKB = options.fee_per_kb;
       }
-      if (options.satsPerVB !== undefined) {
+      if (options?.satsPerVB !== undefined) {
         feeArgs.satsPerVB = options.satsPerVB;
       }
       const normalizedFees = normalizeFeeRate(feeArgs);


### PR DESCRIPTION
## Bug
`POST /api/v2/trx/stampattach` with the `options` field omitted returns an opaque **HTTP 500** (`Cannot read properties of undefined (reading 'fee_per_kb')`, empty `details:{}`) — same class as #1155. `options` is destructured with no default (`:57`) then read bare at `:62`/`:65`, while the rest of the handler already defends undefined options (`...(options || {})`, `options?.`).

## Fix
Optional chaining on the fee-arg parse (`options?.fee_per_kb` / `options?.satsPerVB`). With `options` omitted, `feeArgs` stays empty → `normalizeFeeRate` returns null → the existing structured **400 "Invalid fee rate"** fires instead of a 500. The options-present path is byte-identical (`options?.x` === `options.x` when defined) → zero regression for funded compose.

## Verification
- Prod baseline (pre-fix): no-options body → `HTTP 500` "Cannot read properties of undefined (reading 'fee_per_kb')".
- Post-deploy I'll confirm: no-options → clean **400**; funded-wallet + valid options + owned stamp `A303012015459266100` → unsigned PSBT composes (no broadcast).

`deno check` + `deno fmt` clean. 2-line change in a tx route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)