### PR TITLE
fix(tx): stampattach — structured 400 when fee rate is missing

### DIFF
--- a/routes/api/v2/trx/stampattach.ts
+++ b/routes/api/v2/trx/stampattach.ts
@@ -65,7 +65,17 @@ export const handler: Handlers = {
       if (options?.satsPerVB !== undefined) {
         feeArgs.satsPerVB = options.satsPerVB;
       }
-      const normalizedFees = normalizeFeeRate(feeArgs);
+      // normalizeFeeRate throws when no fee was supplied (empty options) or the
+      // rate is non-positive — map both to a structured 400 instead of letting
+      // the throw escape to the outer catch as an opaque 500 (#1155 class).
+      let normalizedFees;
+      try {
+        normalizedFees = normalizeFeeRate(feeArgs);
+      } catch (_feeErr) {
+        return ApiResponseUtil.badRequest(
+          "Invalid or missing fee rate. Provide options.satsPerVB or options.fee_per_kb.",
+        );
+      }
 
       if (!normalizedFees || normalizedFees.normalizedSatsPerVB <= 0) {
         return ApiResponseUtil.badRequest("Invalid fee rate.");


### PR DESCRIPTION
Follow-up to #1168. Live verification showed the optional-chaining fix stopped the raw `Cannot read properties of undefined` TypeError, but omitting a fee then made `normalizeFeeRate({})` throw ("Either satsPerKB or satsPerVB must be provided"), which escaped to the outer catch as a **second** opaque 500 (`Failed to process stamp attach request`). The existing `if (!normalizedFees…)` 400-guard was dead because the throw fires first.

Wrap `normalizeFeeRate` in try/catch → `ApiResponseUtil.badRequest`. Fully closes the #1155-class opaque-500 on the no-fee path. Happy path (options.satsPerVB present) unchanged — verified live: HTTP 200 + psbtHex.

`deno check` + `deno fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)