### PR TITLE
fix(readme): remove broken codecov badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # BITCOIN STAMPS EXPLORER AND API
 
-[![codecov](https://codecov.io/gh/stampchain-io/stampchain.io/graph/badge.svg?token=4AEWJ1OMM2)](https://codecov.io/gh/stampchain-io/stampchain.io)
 [![Code Quality](https://github.com/stampchain-io/stampchain.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/stampchain-io/stampchain.io/actions/workflows/deploy.yml)
 [![Unit Tests](https://github.com/stampchain-io/stampchain.io/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/stampchain-io/stampchain.io/actions/workflows/unit-tests.yml)
 [![Integration Tests](https://github.com/stampchain-io/stampchain.io/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/stampchain-io/stampchain.io/actions/workflows/integration-tests.yml)


### PR DESCRIPTION
The codecov badge rendered as a broken/dead image — it pointed at codecov.io's `graph/badge.svg` (`Cache-Control: no-store`), which GitHub's image proxy can't cache.

This repo has **no codecov integration** (no coverage upload, inactive on codecov), so the badge could only ever be dead/unknown. Removed it. The deploy / unit-test / integration / type-check / newman badges remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)