### PR TITLE
fix(ci): guard husky prepare script against production installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:api:trends:analyze": "node -e \"console.log('Trends analysis would run here - see daily-regression-tests.yml for implementation')\"",
     "test:api:version:detect": "node scripts/detect-api-version-changes.cjs",
     "test:api:schema-contract": "NEWMAN_COLLECTION=tests/postman/collections/schema-contract-tests.json docker-compose -f docker-compose.test.yml run --rm newman",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "dependencies": {
     "bitcoinjs-lib": "7.0.1",


### PR DESCRIPTION
## Problem

The scheduled **Daily Regression Testing** workflow has failed every day for 8+ consecutive days. The failure is in the **Install dependencies** step:

```
sh: 1: husky: not found
npm error code 127
npm error command sh -c husky
##[error]Process completed with exit code 127.
```

## Root cause

`daily-regression-tests.yml` sets `env: NODE_ENV: production`. Under `NODE_ENV=production`, `npm install` skips **devDependencies** — and `husky` is a devDependency. But `npm install` still runs the `prepare` lifecycle script (`"prepare": "husky"`), so it invokes a `husky` binary that was never installed, exiting 127 and aborting the job **before any API regression test runs**.

This is deterministic (not flaky/external): it is the only workflow that combines `NODE_ENV=production` with `npm install`, which is why it alone fails while other CI installs husky normally.

## Fix

Guard the prepare step: `"prepare": "husky || true"` — husky's recommended pattern for production/CI. When husky is present (local dev) it installs git hooks as before; when it is absent (production/CI) the missing binary becomes a harmless no-op instead of a hard failure.

One-line, low-risk change; no workflow/infra changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)