### PR TITLE
chore: reconcile main into dev (post-#1182 squash-promotion)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,39 @@ Follow the established directory structure:
 └── tests/            # Test files
 ```
 
+## Branch Model & Deployment
+
+stampchain.io uses a **staging → production** branch model. There are two
+long-lived branches, each mapped to an environment:
+
+| Branch | Role | Default | Deploys to | Protection |
+|--------|------|---------|-----------|------------|
+| `dev`  | Integration / staging — where all work lands first | ✅ yes | Preview / staging (Deno preview deploys on PRs) | PR + linear history; no force-push or deletion |
+| `main` | **Production** — the live site | no | **Production** — `production-deploy.yml` deploys on every push | PR + **1 approving review** + linear history; no force-push or deletion |
+
+### Day-to-day (contributors)
+
+1. Branch off **`dev`**: `git checkout dev && git pull && git checkout -b feature/description`
+2. Open your PR against **`dev`** (the default base). CI and a preview deploy run on the PR.
+3. Once it's approved and green, squash-merge into `dev`. Your change is now on staging.
+
+### Promotion to production (maintainers)
+
+Production is released **only** by landing `dev` → `main`:
+
+1. Open a PR **`dev` → `main`**, e.g. `release: promote dev to production (YYYY-MM-DD)`.
+2. Review the diff — it is exactly what will go live.
+3. Merge. The push to `main` triggers `production-deploy.yml`, which deploys to
+   production and runs post-deploy validation.
+
+There are no version tags — this is **continuous deployment**. `main` always
+reflects what is currently live; `dev` is everything staged for the next
+promotion.
+
+> ⚠️ **`main` is the production branch.** Never push to it directly (the branch
+> ruleset blocks it) — every production change goes through a reviewed
+> `dev → main` promotion PR.
+
 ## Submitting Changes
 
 ### Pull Request Process

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # BITCOIN STAMPS EXPLORER AND API
 
-[![codecov](https://codecov.io/gh/stampchain-io/stampchain.io/graph/badge.svg?token=4AEWJ1OMM2)](https://codecov.io/gh/stampchain-io/stampchain.io)
 [![Code Quality](https://github.com/stampchain-io/stampchain.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/stampchain-io/stampchain.io/actions/workflows/deploy.yml)
 [![Unit Tests](https://github.com/stampchain-io/stampchain.io/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/stampchain-io/stampchain.io/actions/workflows/unit-tests.yml)
 [![Integration Tests](https://github.com/stampchain-io/stampchain.io/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/stampchain-io/stampchain.io/actions/workflows/integration-tests.yml)

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:api:trends:analyze": "node -e \"console.log('Trends analysis would run here - see daily-regression-tests.yml for implementation')\"",
     "test:api:version:detect": "node scripts/detect-api-version-changes.cjs",
     "test:api:schema-contract": "NEWMAN_COLLECTION=tests/postman/collections/schema-contract-tests.json docker-compose -f docker-compose.test.yml run --rm newman",
-    "prepare": "husky"
+    "prepare": "husky || true"
   },
   "dependencies": {
     "bitcoinjs-lib": "7.0.1",


### PR DESCRIPTION
## Why

Production promotion #1182 (\`a0da7ea1\`) was **squash-merged** \`dev → main\` because the \`main\` ruleset requires linear history. Squashing creates a commit on \`main\` that is not in \`dev\`'s ancestry, so the two histories diverge and every future \`dev → main\` PR would show phantom conflicts / an inflated diff until a manual reconciliation is run.

Content-wise \`main\` and \`dev\` are already identical (same tree \`5356180d\`); this PR only re-links the graph so \`main\` is fully contained in \`dev\` again.

## What

Merge commit bringing \`main\` (\`a0da7ea1\`) into \`dev\`'s ancestry — the repo's established reconciliation pattern (cf. \`aad0c029\`). No file changes.

After merge: \`git log dev..main\` is empty (dev contains everything on main), so the next promotion starts clean.

This is the **last** manual reconciliation that should be needed — see the accompanying ruleset change (allow merge commits on \`main\`) and the updated CONTRIBUTING.md that eliminate squash-induced divergence going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)