### PR TITLE
feat(howto): /howto/buy guide + FAQPage/HowTo JSON-LD (GEO loop #1)

### DIFF
--- a/components/section/howto/data.ts
+++ b/components/section/howto/data.ts
@@ -8,6 +8,7 @@ export interface ArticleLinks {
 }
 
 export const ARTICLE_LINKS: ArticleLinks[] = [
+  { title: "HOW TO BUY", href: "/howto/buy" },
   { title: "CREATE A WALLET", href: "/howto/leathercreate" },
   { title: "CONNECT YOUR LEATHER WALLET", href: "/howto/leatherconnect" },
   { title: "DEPLOY YOUR OWN TOKEN", href: "/howto/deploytoken" },
@@ -468,6 +469,59 @@ export const TEMPLATE_SETUP_STEPS = [
 export const TEMPLATE_IMPORTANT_NOTES = [
   "First important note about the process",
   "Second important note about the process",
+];
+
+/* ===== BUY BITCOIN STAMPS & SRC-20 GUIDE ===== */
+export interface BuyFaqItem {
+  question: string;
+  answer: string;
+}
+
+// Section A — buying a Bitcoin Stamp via a dispenser (text-only, ordered)
+export const BUY_STAMP_STEPS: string[] = [
+  "Connect your Bitcoin wallet (for example, Leather) to stampchain.io.",
+  "Find a stamp with an open dispenser — browse the stamp explorer or open a specific stamp's page. Open dispensers show the price in BTC and the remaining quantity.",
+  "Review the dispenser price and the available supply before you buy.",
+  "Send the exact BTC amount to the dispenser address. The dispenser automatically sends the stamp to your wallet.",
+  "Confirm the stamp has arrived in your wallet or on the stamp's page.",
+];
+
+export const BUY_STAMP_IMPORTANT_NOTE =
+  "Only buy from dispensers shown on the stamp's own page, and verify the stamp ID and price before sending BTC. Dispenser purchases settle on-chain and are final.";
+
+// Section B — buying an SRC-20 token on a third-party marketplace (text-only, ordered)
+export const BUY_SRC20_STEPS: string[] = [
+  "Look up the token on stampchain.io's SRC-20 explorer to confirm its ticker, supply, and mint status.",
+  "Go to a marketplace that lists SRC-20 tokens: OpenStamp (SRC-20 marketplace and listings), StampScan (SRC-20 market data and listings), or BitMart (a centralized exchange that lists select SRC-20 tokens such as KEVIN).",
+  "Follow that venue's buy flow — connect your wallet or fund your exchange account, then place the order.",
+  "Before buying, confirm the token ticker exactly matches the one shown on stampchain.io, because SRC-20 tickers can be duplicated.",
+];
+
+export const BUY_SRC20_IMPORTANT_NOTE =
+  "stampchain.io is a neutral explorer and does not endorse any marketplace. A decentralized exchange on stampchain is a potential future development, pending community SIPs.";
+
+// FAQ — drives both the visible FAQ and the FAQPage JSON-LD (single source of truth)
+export const BUY_FAQ: BuyFaqItem[] = [
+  {
+    question: "Can I buy SRC-20 tokens on stampchain.io?",
+    answer:
+      "No. stampchain.io is the reference explorer for Bitcoin Stamps and SRC-20 data, but it does not currently operate a fungible-token exchange. SRC-20 tokens such as KEVIN are traded on third-party venues including OpenStamp, StampScan, and BitMart. A decentralized exchange on stampchain is a potential future development pending community SIPs.",
+  },
+  {
+    question: "How do I buy a Bitcoin Stamp?",
+    answer:
+      "Bitcoin Stamps are bought on stampchain.io through dispensers — automated on-chain sell orders. Connect a Bitcoin wallet, find a stamp with an open dispenser, and send the listed BTC amount; the dispenser sends the stamp to your wallet.",
+  },
+  {
+    question: "What is a dispenser?",
+    answer:
+      "A dispenser is an automated, on-chain sell order that dispenses a Bitcoin Stamp to any buyer who sends the specified amount of BTC to its address.",
+  },
+  {
+    question: "Where can I buy KEVIN?",
+    answer:
+      "KEVIN and other SRC-20 tokens trade on third-party marketplaces including OpenStamp, StampScan, and BitMart. Confirm the ticker on stampchain.io's SRC-20 explorer before buying.",
+  },
 ];
 
 /* ===== DESCRIPTION FORMATTING DOCUMENTATION ===== */

--- a/fresh.gen.ts
+++ b/fresh.gen.ts
@@ -123,6 +123,7 @@ import * as $handlers_sharedBlockWithStampsHandler from "./routes/handlers/share
 import * as $handlers_sharedCollectionHandler from "./routes/handlers/sharedCollectionHandler.ts";
 import * as $handlers_sharedContentHandler from "./routes/handlers/sharedContentHandler.ts";
 import * as $handlers_sharedStampHandler from "./routes/handlers/sharedStampHandler.ts";
+import * as $howto_buy_index from "./routes/howto/buy/index.tsx";
 import * as $howto_deploytoken_index from "./routes/howto/deploytoken/index.tsx";
 import * as $howto_index from "./routes/howto/index.tsx";
 import * as $howto_leatherconnect_index from "./routes/howto/leatherconnect/index.tsx";
@@ -476,6 +477,7 @@ const manifest = {
       $handlers_sharedCollectionHandler,
     "./routes/handlers/sharedContentHandler.ts": $handlers_sharedContentHandler,
     "./routes/handlers/sharedStampHandler.ts": $handlers_sharedStampHandler,
+    "./routes/howto/buy/index.tsx": $howto_buy_index,
     "./routes/howto/deploytoken/index.tsx": $howto_deploytoken_index,
     "./routes/howto/index.tsx": $howto_index,
     "./routes/howto/leatherconnect/index.tsx": $howto_leatherconnect_index,

--- a/routes/howto/buy/index.tsx
+++ b/routes/howto/buy/index.tsx
@@ -1,0 +1,185 @@
+/* ===== HOW TO BUY BITCOIN STAMPS & SRC-20 TOKENS PAGE ===== */
+import { Head } from "$fresh/runtime.ts";
+import {
+  Article,
+  BUY_FAQ,
+  BUY_SRC20_IMPORTANT_NOTE,
+  BUY_SRC20_STEPS,
+  BUY_STAMP_IMPORTANT_NOTE,
+  BUY_STAMP_STEPS,
+} from "$section";
+import { headingGrey, text } from "$text";
+
+/* ===== VERBATIM COPY (single source of truth for visible text + JSON-LD) ===== */
+const LEAD =
+  "There are two different kinds of Bitcoin Stamps assets, and you buy them in different places. Bitcoin Stamps — individual stamp artwork — are bought directly on stampchain.io through dispensers, which are automated on-chain sell orders. SRC-20 tokens — fungible tokens such as KEVIN — are traded on third-party marketplaces including OpenStamp, StampScan, and BitMart. stampchain.io is the Bitcoin Stamps ecosystem's reference explorer; it does not currently operate a fungible-token exchange.";
+
+const SECTION_A_HEADING = "How to buy a Bitcoin Stamp (via a dispenser)";
+const SECTION_A_INTRO =
+  "A dispenser is an automated, on-chain sell order that dispenses a Bitcoin Stamp to anyone who sends the listed amount of BTC to its address. Here is how to buy a stamp from an open dispenser on stampchain.io:";
+
+const SECTION_B_HEADING = "How to buy an SRC-20 token (for example, KEVIN)";
+const SECTION_B_INTRO =
+  "SRC-20 fungible tokens are not sold directly on stampchain.io. Use stampchain.io to verify a token, then buy it on a third-party marketplace:";
+
+/* ===== JSON-LD STRUCTURED DATA ===== */
+const howToBuyStampLd = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": SECTION_A_HEADING,
+  "description": SECTION_A_INTRO,
+  "step": BUY_STAMP_STEPS.map((step) => ({
+    "@type": "HowToStep",
+    "name": step,
+    "text": step,
+  })),
+};
+
+const howToBuySrc20Ld = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": SECTION_B_HEADING,
+  "description": SECTION_B_INTRO,
+  "step": BUY_SRC20_STEPS.map((step) => ({
+    "@type": "HowToStep",
+    "name": step,
+    "text": step,
+  })),
+};
+
+const faqPageLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": BUY_FAQ.map((item) => ({
+    "@type": "Question",
+    "name": item.question,
+    "acceptedAnswer": {
+      "@type": "Answer",
+      "text": item.answer,
+    },
+  })),
+};
+
+/* ===== ORDERED STEP LIST (text-only — the List component requires step images) ===== */
+function OrderedSteps({ steps }: { steps: string[] }) {
+  return (
+    <ol class={`${text} list-decimal list-outside pl-5 flex flex-col gap-2`}>
+      {steps.map((step, index) => <li key={index}>{step}</li>)}
+    </ol>
+  );
+}
+
+/* ===== IMPORTANT NOTE BLOCK ===== */
+function ImportantNote({ note }: { note: string }) {
+  return (
+    <div class="mt-3">
+      <p class={`${headingGrey} !text-color-grey-light mb-0`}>IMPORTANT</p>
+      <p class={text}>{note}</p>
+    </div>
+  );
+}
+
+/* ===== MAIN PAGE COMPONENT ===== */
+export default function HowToBuy() {
+  return (
+    <>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(howToBuyStampLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(howToBuySrc20Ld) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageLd) }}
+        />
+      </Head>
+
+      <Article
+        title="HOW TO BUY BITCOIN STAMPS & SRC-20 TOKENS"
+        subtitle="TWO ASSETS, TWO PLACES TO BUY"
+        headerImage="/img/how-tos/stamping/00.png"
+      >
+        {/* ===== INTRO (extractable answer) ===== */}
+        <p>
+          <b>{LEAD}</b>
+        </p>
+
+        {/* ===== SECTION A — BUY A BITCOIN STAMP VIA A DISPENSER ===== */}
+        <section class="flex flex-col gap-3 mt-6">
+          <h2 class={headingGrey}>{SECTION_A_HEADING}</h2>
+          <p class={text}>{SECTION_A_INTRO}</p>
+          <OrderedSteps steps={BUY_STAMP_STEPS} />
+          <p class={text}>
+            Browse the{" "}
+            <a
+              href="/stamp"
+              f-partial="/stamp"
+              class="animated-underline"
+            >
+              stamp explorer
+            </a>{" "}
+            to find a stamp with an open dispenser.
+          </p>
+          <ImportantNote note={BUY_STAMP_IMPORTANT_NOTE} />
+        </section>
+
+        {/* ===== SECTION B — BUY AN SRC-20 TOKEN ===== */}
+        <section class="flex flex-col gap-3 mt-6">
+          <h2 class={headingGrey}>{SECTION_B_HEADING}</h2>
+          <p class={text}>{SECTION_B_INTRO}</p>
+          <OrderedSteps steps={BUY_SRC20_STEPS} />
+          <p class={text}>
+            Verify a token on the{" "}
+            <a
+              href="/src20"
+              f-partial="/src20"
+              class="animated-underline"
+            >
+              SRC-20 explorer
+            </a>, then buy it on{" "}
+            <a
+              href="https://openstamp.io"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="animated-underline"
+            >
+              OpenStamp
+            </a>,{" "}
+            <a
+              href="https://stampscan.xyz"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="animated-underline"
+            >
+              StampScan
+            </a>, or{" "}
+            <a
+              href="https://www.bitmart.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="animated-underline"
+            >
+              BitMart
+            </a>.
+          </p>
+          <ImportantNote note={BUY_SRC20_IMPORTANT_NOTE} />
+        </section>
+
+        {/* ===== FAQ (visible text drives the FAQPage JSON-LD above) ===== */}
+        <section class="flex flex-col gap-4 mt-6">
+          <h2 class={headingGrey}>FREQUENTLY ASKED QUESTIONS</h2>
+          {BUY_FAQ.map((item, index) => (
+            <div key={index} class="flex flex-col gap-1">
+              <h3 class={headingGrey}>{item.question}</h3>
+              <p class={text}>{item.answer}</p>
+            </div>
+          ))}
+        </section>
+      </Article>
+    </>
+  );
+}

--- a/routes/howto/index.tsx
+++ b/routes/howto/index.tsx
@@ -27,6 +27,38 @@ export default function HowToPage() {
         </p>
       </section>
 
+      {/* ===== HOW TO BUY GUIDE ===== */}
+      <section class={containerBackground}>
+        <div
+          class={`grid grid-cols-1 tablet:grid-cols-2 desktop:grid-cols-3 ${containerGap}`}
+        >
+          <img
+            src="/img/how-tos/stamping/00.png"
+            width="100%"
+            alt="How to buy Bitcoin Stamps and SRC-20 tokens such as KEVIN"
+            class="rounded-2xl"
+          />
+          <div class="flex flex-col desktop:col-span-2 gap-2">
+            <h2 class={`${headingGrey} mb-2`}>HOW TO BUY</h2>
+            <p class={text}>
+              There are two different kinds of Bitcoin Stamps assets, and you
+              buy them in different places. Bitcoin Stamps are bought directly
+              on stampchain.io through dispensers, while SRC-20 tokens such as
+              KEVIN are traded on third-party marketplaces.
+            </p>
+            <p class={text}>
+              <a
+                href="/howto/buy"
+                f-partial="/howto/buy"
+                class="animated-underline mb-1.5"
+              >
+                Learn how to buy Bitcoin Stamps and SRC-20 tokens
+              </a>
+            </p>
+          </div>
+        </div>
+      </section>
+
       {/* ===== LEATHER WALLET CREATION GUIDE ===== */}
       <section class={containerBackground}>
         <div


### PR DESCRIPTION
## What
Adds a new `/howto/buy` guide and the site's first **FAQPage + HowTo JSON-LD** structured data.

## Why (data-grounded)
stampchain ranks well on Google for high-intent queries but is **not cited by answer engines** (Perplexity) for them:

| Query | GSC impr | Google pos | Perplexity cited |
|---|---|---|---|
| how to mint bitcoin stamp | 22 | #3 | ❌ |
| how to buy bitcoin stamps | 21 | #7 | ❌ |
| buy bitcoin stamp | 20 | #14 | ❌ |

This is a GEO gap: strong classic SEO, weak generative-engine citation. Structured, extractable content + schema is the lever. Baseline: stampchain cited **4/8** probed queries.

## Domain accuracy (important)
Two **distinct** buy journeys, kept accurate:
- **Bitcoin Stamps (art)** → bought on-site via **dispensers** (drives on-site sales).
- **SRC-20 (fungible, e.g. KEVIN)** → **NOT sold on stampchain**; guide points to external venues **OpenStamp / StampScan / BitMart**. A decentralized exchange on stampchain is a future possibility pending community SIPs.

The copy never implies stampchain sells SRC-20.

## Changes
- New `routes/howto/buy/index.tsx` (2 sections + FAQ; steps as semantic ordered lists).
- `components/section/howto/data.ts`: `BUY_*` constants + `ARTICLE_LINKS` entry (FAQ visible text and FAQPage schema derive from the **same** constant → cannot drift).
- `routes/howto/index.tsx`: "HOW TO BUY" card.
- JSON-LD: 2× HowTo + 1× FAQPage in page `<Head>`.

## Verification
- `deno task check` (repo pre-commit) passed across 595 files; import validation 99.7% (0 critical).
- Internal links point to real routes (`/stamp`, `/src20`); external links `rel="noopener noreferrer"`.

## Measurement (case study)
After deploy, weekly Perplexity re-probe + GSC position tracking; target 4/8 → 6–7/8 cited. Full report: `.paos/research/content-opportunity-stampchain-2026-07-08.md`.

> Merging to `dev` → release to `main` triggers the CI deploy. Recommend validating the 3 JSON-LD blocks in Google's Rich Results Test post-deploy.