### PR TITLE
feat(seo): FAQPage on /faq + HowTo schema on 8 guides (GEO)

### DIFF
--- a/routes/faq/index.tsx
+++ b/routes/faq/index.tsx
@@ -1,13 +1,40 @@
 /* ===== FAQ PAGE ===== */
+import { Head } from "$fresh/runtime.ts";
 import { FaqAccordion } from "$content";
 import { FaqHeader } from "$header";
 import { body, containerBackground, containerGap, FAQ_CONTENT } from "$layout";
 import { subtitleGrey, text, titleGreyLD } from "$text";
 
+/* ===== JSON-LD STRUCTURED DATA (derived from the same FAQ_CONTENT the page renders) ===== */
+const flattenAnswer = (content: string | string[]): string =>
+  Array.isArray(content) ? content.join("\n") : content;
+
+const faqPageLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": FAQ_CONTENT.flatMap((section) =>
+    section.items.map((item) => ({
+      "@type": "Question",
+      "name": item.title,
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": flattenAnswer(item.content),
+      },
+    }))
+  ),
+};
+
 /* ===== PAGE COMPONENT ===== */
 export default function FaqPage() {
   return (
     <div class={`${body} ${containerGap}`}>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(faqPageLd) }}
+        />
+      </Head>
+
       {/* ===== HEADER SECTION ===== */}
       <FaqHeader />
 

--- a/routes/howto/deploytoken/index.tsx
+++ b/routes/howto/deploytoken/index.tsx
@@ -1,4 +1,5 @@
 /* ===== DEPLOY TOKEN HOW-TO PAGE ===== */
+import { Head } from "$fresh/runtime.ts";
 import {
   Article,
   AuthorSection,
@@ -7,6 +8,26 @@ import {
   List,
   StepList,
 } from "$section";
+
+/* ===== JSON-LD STRUCTURED DATA (steps derived from the shared DEPLOY_STEPS constant) ===== */
+const SUBTITLE = "DEPLOY YOUR OWN TOKEN";
+
+const flattenText = (description: string | string[]): string =>
+  Array.isArray(description) ? description.join("\n") : description;
+
+const howToLd = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": `How to ${SUBTITLE.toLowerCase()}`,
+  "description":
+    `A step-by-step guide to ${SUBTITLE.toLowerCase()} on stampchain.io.`,
+  "step": DEPLOY_STEPS.map((step) => ({
+    "@type": "HowToStep",
+    "name": step.title,
+    "text": flattenText(step.description),
+    "image": step.image,
+  })),
+};
 
 /* ===== INTRODUCTION COMPONENT ===== */
 function IntroSection() {
@@ -59,14 +80,22 @@ function DeploySteps() {
 /* ===== MAIN PAGE COMPONENT ===== */
 export default function DeployToken() {
   return (
-    <Article
-      title="HOW-TO"
-      subtitle="DEPLOY YOUR OWN TOKEN"
-      headerImage="/img/how-tos/deploy/00.png"
-      importantNotes={DEPLOY_IMPORTANT_NOTES}
-    >
-      <IntroSection />
-      <DeploySteps />
-    </Article>
+    <>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }}
+        />
+      </Head>
+      <Article
+        title="HOW-TO"
+        subtitle={SUBTITLE}
+        headerImage="/img/how-tos/deploy/00.png"
+        importantNotes={DEPLOY_IMPORTANT_NOTES}
+      >
+        <IntroSection />
+        <DeploySteps />
+      </Article>
+    </>
   );
 }

--- a/routes/howto/leatherconnect/index.tsx
+++ b/routes/howto/leatherconnect/index.tsx
@@ -1,4 +1,5 @@
 /* ===== LEATHER CONNECT HOW-TO PAGE ===== */
+import { Head } from "$fresh/runtime.ts";
 import {
   Article,
   AuthorSection,
@@ -9,6 +10,26 @@ import {
   List,
   StepList,
 } from "$section";
+
+/* ===== JSON-LD STRUCTURED DATA (steps derived from the shared LEATHER_CONNECT_STEPS constant) ===== */
+const SUBTITLE = "CONNECT YOUR LEATHER WALLET";
+
+const flattenText = (description: string | string[]): string =>
+  Array.isArray(description) ? description.join("\n") : description;
+
+const howToLd = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": `How to ${SUBTITLE.toLowerCase()}`,
+  "description":
+    `A step-by-step guide to ${SUBTITLE.toLowerCase()} on stampchain.io.`,
+  "step": LEATHER_CONNECT_STEPS.map((step) => ({
+    "@type": "HowToStep",
+    "name": step.title,
+    "text": flattenText(step.description),
+    "image": step.image,
+  })),
+};
 
 /* ===== INTRODUCTION COMPONENT ===== */
 function IntroSection() {
@@ -73,14 +94,22 @@ function ConnectSteps() {
 /* ===== MAIN PAGE COMPONENT ===== */
 export default function LeatherConnect() {
   return (
-    <Article
-      title="HOW-TO"
-      subtitle="CONNECT YOUR LEATHER WALLET"
-      headerImage="/img/how-tos/connectleatherwallet/00.png"
-      importantNotes={LEATHER_CONNECT_IMPORTANT_NOTES}
-    >
-      <IntroSection />
-      <ConnectSteps />
-    </Article>
+    <>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }}
+        />
+      </Head>
+      <Article
+        title="HOW-TO"
+        subtitle={SUBTITLE}
+        headerImage="/img/how-tos/connectleatherwallet/00.png"
+        importantNotes={LEATHER_CONNECT_IMPORTANT_NOTES}
+      >
+        <IntroSection />
+        <ConnectSteps />
+      </Article>
+    </>
   );
 }

--- a/routes/howto/leathercreate/index.tsx
+++ b/routes/howto/leathercreate/index.tsx
@@ -1,4 +1,5 @@
 /* ===== LEATHER CREATE HOW-TO PAGE ===== */
+import { Head } from "$fresh/runtime.ts";
 import {
   Article,
   AuthorSection,
@@ -9,6 +10,26 @@ import {
   List,
   StepList,
 } from "$section";
+
+/* ===== JSON-LD STRUCTURED DATA (steps derived from the shared LEATHER_CREATE_WALLET_STEPS constant) ===== */
+const SUBTITLE = "CREATE A LEATHER WALLET";
+
+const flattenText = (description: string | string[]): string =>
+  Array.isArray(description) ? description.join("\n") : description;
+
+const howToLd = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": `How to ${SUBTITLE.toLowerCase()}`,
+  "description":
+    `A step-by-step guide to ${SUBTITLE.toLowerCase()} on stampchain.io.`,
+  "step": LEATHER_CREATE_WALLET_STEPS.map((step) => ({
+    "@type": "HowToStep",
+    "name": step.title,
+    "text": flattenText(step.description),
+    "image": step.image,
+  })),
+};
 
 /* ===== INTRODUCTION COMPONENT ===== */
 function IntroSection() {
@@ -59,14 +80,22 @@ function WalletSteps() {
 /* ===== MAIN PAGE COMPONENT ===== */
 export default function LeatherCreate() {
   return (
-    <Article
-      title="HOW-TO"
-      subtitle="CREATE A LEATHER WALLET"
-      headerImage="/img/how-tos/createleatherwallet/00.png"
-      importantNotes={LEATHER_CREATE_IMPORTANT_NOTES}
-    >
-      <IntroSection />
-      <WalletSteps />
-    </Article>
+    <>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }}
+        />
+      </Head>
+      <Article
+        title="HOW-TO"
+        subtitle={SUBTITLE}
+        headerImage="/img/how-tos/createleatherwallet/00.png"
+        importantNotes={LEATHER_CREATE_IMPORTANT_NOTES}
+      >
+        <IntroSection />
+        <WalletSteps />
+      </Article>
+    </>
   );
 }

--- a/routes/howto/minttoken/index.tsx
+++ b/routes/howto/minttoken/index.tsx
@@ -1,4 +1,5 @@
 /* ===== MINT TOKEN HOW-TO PAGE ===== */
+import { Head } from "$fresh/runtime.ts";
 import {
   Article,
   AuthorSection,
@@ -7,6 +8,26 @@ import {
   MINT_STEPS,
   StepList,
 } from "$section";
+
+/* ===== JSON-LD STRUCTURED DATA (steps derived from the shared MINT_STEPS constant) ===== */
+const SUBTITLE = "MINT A SRC-20 TOKEN";
+
+const flattenText = (description: string | string[]): string =>
+  Array.isArray(description) ? description.join("\n") : description;
+
+const howToLd = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": `How to ${SUBTITLE.toLowerCase()}`,
+  "description":
+    `A step-by-step guide to ${SUBTITLE.toLowerCase()} on stampchain.io.`,
+  "step": MINT_STEPS.map((step) => ({
+    "@type": "HowToStep",
+    "name": step.title,
+    "text": flattenText(step.description),
+    "image": step.image,
+  })),
+};
 
 /* ===== INTRODUCTION COMPONENT ===== */
 function IntroSection() {
@@ -52,14 +73,22 @@ function MintSteps() {
 /* ===== MAIN PAGE COMPONENT ===== */
 export default function MintToken() {
   return (
-    <Article
-      title="HOW-TO"
-      subtitle="MINT A SRC-20 TOKEN"
-      headerImage="/img/how-tos/mintsrc20/00.png"
-      importantNotes={MINT_IMPORTANT_NOTES}
-    >
-      <IntroSection />
-      <MintSteps />
-    </Article>
+    <>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }}
+        />
+      </Head>
+      <Article
+        title="HOW-TO"
+        subtitle={SUBTITLE}
+        headerImage="/img/how-tos/mintsrc20/00.png"
+        importantNotes={MINT_IMPORTANT_NOTES}
+      >
+        <IntroSection />
+        <MintSteps />
+      </Article>
+    </>
   );
 }

--- a/routes/howto/sendstamp/index.tsx
+++ b/routes/howto/sendstamp/index.tsx
@@ -1,4 +1,5 @@
 /* ===== SEND STAMP HOW-TO PAGE ===== */
+import { Head } from "$fresh/runtime.ts";
 import {
   Article,
   AuthorSection,
@@ -7,6 +8,26 @@ import {
   SEND_STAMP_STEPS,
   StepList,
 } from "$section";
+
+/* ===== JSON-LD STRUCTURED DATA (steps derived from the shared SEND_STAMP_STEPS constant) ===== */
+const SUBTITLE = "SEND A STAMP";
+
+const flattenText = (description: string | string[]): string =>
+  Array.isArray(description) ? description.join("\n") : description;
+
+const howToLd = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": `How to ${SUBTITLE.toLowerCase()}`,
+  "description":
+    `A step-by-step guide to ${SUBTITLE.toLowerCase()} on stampchain.io.`,
+  "step": SEND_STAMP_STEPS.map((step) => ({
+    "@type": "HowToStep",
+    "name": step.title,
+    "text": flattenText(step.description),
+    "image": step.image,
+  })),
+};
 
 /* ===== INTRODUCTION COMPONENT ===== */
 function IntroSection() {
@@ -50,14 +71,22 @@ function SendSteps() {
 /* ===== MAIN PAGE COMPONENT ===== */
 export default function SendStamp() {
   return (
-    <Article
-      title="HOW-TO"
-      subtitle="SEND A STAMP"
-      headerImage="/img/how-tos/sendstamp/00.png"
-      importantNotes={SEND_STAMP_IMPORTANT_NOTES}
-    >
-      <IntroSection />
-      <SendSteps />
-    </Article>
+    <>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }}
+        />
+      </Head>
+      <Article
+        title="HOW-TO"
+        subtitle={SUBTITLE}
+        headerImage="/img/how-tos/sendstamp/00.png"
+        importantNotes={SEND_STAMP_IMPORTANT_NOTES}
+      >
+        <IntroSection />
+        <SendSteps />
+      </Article>
+    </>
   );
 }

--- a/routes/howto/stamp/index.tsx
+++ b/routes/howto/stamp/index.tsx
@@ -1,4 +1,5 @@
 /* ===== STAMPING GUIDE HOW-TO PAGE ===== */
+import { Head } from "$fresh/runtime.ts";
 import {
   Article,
   AuthorSection,
@@ -7,6 +8,26 @@ import {
   STAMP_STEPS,
   StepList,
 } from "$section";
+
+/* ===== JSON-LD STRUCTURED DATA (steps derived from the shared STAMP_STEPS constant) ===== */
+const SUBTITLE = "STAMP YOUR ART";
+
+const flattenText = (description: string | string[]): string =>
+  Array.isArray(description) ? description.join("\n") : description;
+
+const howToLd = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": `How to ${SUBTITLE.toLowerCase()}`,
+  "description":
+    `A step-by-step guide to ${SUBTITLE.toLowerCase()} on stampchain.io.`,
+  "step": STAMP_STEPS.map((step) => ({
+    "@type": "HowToStep",
+    "name": step.title,
+    "text": flattenText(step.description),
+    "image": step.image,
+  })),
+};
 
 /* ===== INTRODUCTION COMPONENT ===== */
 function IntroSection() {
@@ -50,14 +71,22 @@ function StampSteps() {
 /* ===== MAIN PAGE COMPONENT ===== */
 export default function StampingGuide() {
   return (
-    <Article
-      title="HOW-TO"
-      subtitle="STAMP YOUR ART"
-      headerImage="/img/how-tos/stamping/00.png"
-      importantNotes={STAMP_IMPORTANT_NOTES}
-    >
-      <IntroSection />
-      <StampSteps />
-    </Article>
+    <>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }}
+        />
+      </Head>
+      <Article
+        title="HOW-TO"
+        subtitle={SUBTITLE}
+        headerImage="/img/how-tos/stamping/00.png"
+        importantNotes={STAMP_IMPORTANT_NOTES}
+      >
+        <IntroSection />
+        <StampSteps />
+      </Article>
+    </>
   );
 }

--- a/routes/howto/transferbitname/index.tsx
+++ b/routes/howto/transferbitname/index.tsx
@@ -1,4 +1,5 @@
 /* ===== TRANSFER BITNAME HOW-TO PAGE ===== */
+import { Head } from "$fresh/runtime.ts";
 import {
   Article,
   AuthorSection,
@@ -7,6 +8,26 @@ import {
   TRANSFER_BITNAME_IMPORTANT_NOTES,
   TRANSFER_BITNAME_STEPS,
 } from "$section";
+
+/* ===== JSON-LD STRUCTURED DATA (steps derived from the shared TRANSFER_BITNAME_STEPS constant) ===== */
+const SUBTITLE = "TRANSFER BITNAME";
+
+const flattenText = (description: string | string[]): string =>
+  Array.isArray(description) ? description.join("\n") : description;
+
+const howToLd = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": `How to ${SUBTITLE.toLowerCase()}`,
+  "description":
+    `A step-by-step guide to ${SUBTITLE.toLowerCase()} on stampchain.io.`,
+  "step": TRANSFER_BITNAME_STEPS.map((step) => ({
+    "@type": "HowToStep",
+    "name": step.title,
+    "text": flattenText(step.description),
+    "image": step.image,
+  })),
+};
 
 /* ===== INTRODUCTION COMPONENT ===== */
 function IntroSection() {
@@ -50,14 +71,22 @@ function TransferSteps() {
 /* ===== MAIN PAGE COMPONENT ===== */
 export default function TransferBitname() {
   return (
-    <Article
-      title="HOW-TO"
-      subtitle="TRANSFER BITNAME"
-      headerImage="/img/how-tos/stamping/00.png"
-      importantNotes={TRANSFER_BITNAME_IMPORTANT_NOTES}
-    >
-      <IntroSection />
-      <TransferSteps />
-    </Article>
+    <>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }}
+        />
+      </Head>
+      <Article
+        title="HOW-TO"
+        subtitle={SUBTITLE}
+        headerImage="/img/how-tos/stamping/00.png"
+        importantNotes={TRANSFER_BITNAME_IMPORTANT_NOTES}
+      >
+        <IntroSection />
+        <TransferSteps />
+      </Article>
+    </>
   );
 }

--- a/routes/howto/transfertoken/index.tsx
+++ b/routes/howto/transfertoken/index.tsx
@@ -1,4 +1,5 @@
 /* ===== TRANSFER TOKEN HOW-TO PAGE ===== */
+import { Head } from "$fresh/runtime.ts";
 import {
   Article,
   AuthorSection,
@@ -7,6 +8,26 @@ import {
   TRANSFER_TOKEN_IMPORTANT_NOTES,
   TRANSFER_TOKEN_STEPS,
 } from "$section";
+
+/* ===== JSON-LD STRUCTURED DATA (steps derived from the shared TRANSFER_TOKEN_STEPS constant) ===== */
+const SUBTITLE = "TRANSFER TOKENS";
+
+const flattenText = (description: string | string[]): string =>
+  Array.isArray(description) ? description.join("\n") : description;
+
+const howToLd = {
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": `How to ${SUBTITLE.toLowerCase()}`,
+  "description":
+    `A step-by-step guide to ${SUBTITLE.toLowerCase()} on stampchain.io.`,
+  "step": TRANSFER_TOKEN_STEPS.map((step) => ({
+    "@type": "HowToStep",
+    "name": step.title,
+    "text": flattenText(step.description),
+    "image": step.image,
+  })),
+};
 
 /* ===== INTRODUCTION COMPONENT ===== */
 function IntroSection() {
@@ -50,14 +71,22 @@ function TransferSteps() {
 /* ===== MAIN PAGE COMPONENT ===== */
 export default function TransferToken() {
   return (
-    <Article
-      title="HOW-TO"
-      subtitle="TRANSFER TOKENS"
-      headerImage="/img/how-tos/stamping/00.png"
-      importantNotes={TRANSFER_TOKEN_IMPORTANT_NOTES}
-    >
-      <IntroSection />
-      <TransferSteps />
-    </Article>
+    <>
+      <Head>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(howToLd) }}
+        />
+      </Head>
+      <Article
+        title="HOW-TO"
+        subtitle={SUBTITLE}
+        headerImage="/img/how-tos/stamping/00.png"
+        importantNotes={TRANSFER_TOKEN_IMPORTANT_NOTES}
+      >
+        <IntroSection />
+        <TransferSteps />
+      </Article>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Extends the GEO / structured-data pattern established in `routes/howto/buy/index.tsx` (already merged) to the FAQ page and the 8 existing how-to guides. All JSON-LD is emitted via `<Head>` from `$fresh/runtime.ts` using `<script type="application/ld+json" ...>`, mirroring the `/howto/buy` template exactly.

## What changed

**`/faq` — `FAQPage` JSON-LD**
- Built by flattening the same `FAQ_CONTENT` constant (`components/layout/data.ts`) the visible page renders: `sections -> items` into `mainEntity[]` of `Question`/`acceptedAnswer:Answer` nodes (22 Q&A entries across 5 sections).
- Multi-paragraph answers (`string[]`) flattened by joining with `\n`.

**8 how-to guides — `HowTo` JSON-LD** (steps derived from each guide's typed `*_STEPS` constant in `components/section/howto/data.ts` -> `HowToStep{name:title, text:description, image}`):
- `routes/howto/minttoken` -> `MINT_STEPS`
- `routes/howto/deploytoken` -> `DEPLOY_STEPS`
- `routes/howto/transfertoken` -> `TRANSFER_TOKEN_STEPS`
- `routes/howto/stamp` -> `STAMP_STEPS`
- `routes/howto/sendstamp` -> `SEND_STAMP_STEPS`
- `routes/howto/transferbitname` -> `TRANSFER_BITNAME_STEPS`
- `routes/howto/leatherconnect` -> `LEATHER_CONNECT_STEPS`
- `routes/howto/leathercreate` -> `LEATHER_CREATE_WALLET_STEPS`

## Drift-proof

Every schema field derives from the existing content constants that already drive the visible pages — no second copy of any step or Q&A text. Guide `name`/`description` derive from a `SUBTITLE` const that is also used for the visible `<Article subtitle>` (identical rendered value), so there is a single source of truth.

## Additive only

No visible page content changed. Each guide's `subtitle` literal was extracted into a `SUBTITLE` const with an identical rendered value; the only new output is the non-visible `<script type="application/ld+json">` block in `<Head>`. All `@context` = `https://schema.org`.

## Pages touched (9)

`routes/faq/index.tsx` + the 8 guide routes above.

## Verification

- `deno check` green on all 9 touched files (plus the two `data.ts` sources).
- `deno lint --quiet` and `deno fmt` green on touched files.
- Pre-commit `deno task check` (595 files) passed.

Do not merge yet.